### PR TITLE
build(pack): better-sidebar 钉版本 0.15.2 并 vendor 进 release 包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,16 @@ jobs:
             web/package-lock.json
             dsh-plugins/*/package-lock.json
 
+      - name: install dsh (for boot-smoke)
+        run: npm i -g @deepseek-ai/dsh
+
       - name: pack
         run: sh dsh-plugins/pack.sh "$GITHUB_REF_NAME"
+
+      - name: boot smoke（安装+启动端到端；better-sidebar 随 npm latest，上游破坏性变更在此拦截）
+        run: |
+          sh dsh-plugins/boot-smoke.sh \
+            "dist-release/dsh-ccpg-plugins-$(echo "$GITHUB_REF_NAME" | sed 's/^v//').tar.gz"
 
       - name: upload asset
         uses: softprops/action-gh-release@v2

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ data/tmp-e2e/
 # dsh-ccpg-one 本地 pnpm install 产物（overrides 钉 SDK 版本的锁定文件；
 # 分发走 pack.sh 已排除，CI 不消费，仅本机聚合安装复现用）
 dsh-plugins/dsh-ccpg-one/pnpm-lock.yaml
+# better-sidebar vendor tgz（pack.sh 从 npm 拉取放进 release 归档；源码树一般没有，
+# 防本机手动 pack 时误提交二进制）
+dsh-plugins/vendor/

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -56,7 +56,7 @@ sh setup.sh --one [profile名] [端口]               # dsh plugin add 只装 ds
 6. `dsh plugin add` 7 个默认插件——**各插件自带 `dsh.bundle.patch`（包内 `cordis.patch.yml`），add 一步完成安装+进 bundles 层+挂载**（与 dsh-better-sidebar 的 npm 分发同一机制；失败即中止，不留半成品 profile）
 7. 依赖引导：dsh SDK 是 dsh 包内层 bundled deps，registry 版本滞后且插件解析路径够不到——`bootstrap-deps.sh` 软链进插件源码目录（npm 安装渠道则无需此步：插件实体落在 profile 内，dsh 启动时的 `~/.dsh/profiles/node_modules` 扁平兜底自动接通运行实例的 SDK）
 8. 写 `cordis.patch.yml`——**只写用户配置**（GLM provider 示例 + webserver 端口），不再手写插件挂载行
-9. 装 [dsh-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar)（npm 包，自带 bundle patch 一步挂载）：官方 UI 右侧工作台侧边栏——canvasui 往它注册「工作流」tab（+ 菜单第一位），点击对话输入框旁按钮展开。软依赖：装不上时官方 UI 内无法打开工作流侧栏，独立 `/wf1/` 入口仍可用。**版本钉死 0.15.2**（上游迭代极快，防破坏性变更打断 canvasui 集成）：release 包内 `vendor/dsh-better-sidebar-<ver>.tgz` 优先（断网/下架也能装），源码安装无 vendor 件则从 npm 拉同版本。升级时同步改三处：`pack.sh` 的 `SIDEBAR_VER`、`dsh-ccpg-one/package.json` peer、`dsh-ccpg-one/pnpm-workspace.yaml` override
+9. 装 [dsh-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar)（npm 包，自带 bundle patch 一步挂载）：官方 UI 右侧工作台侧边栏——canvasui 往它注册「工作流」tab（+ 菜单第一位），点击对话输入框旁按钮展开。软依赖：装不上时官方 UI 内无法打开工作流侧栏，独立 `/wf1/` 入口仍可用。**版本随 pack 当次 npm latest**：release 包内 `vendor/dsh-better-sidebar-<ver>.tgz` 优先（断网/下架也能装），源码安装无 vendor 件则从 npm 拉 latest
 
 > 双挂载警告：插件挂载行已由各包 `dsh.bundle.patch` 提供，profile 的 `cordis.patch.yml` 里**不要再手写**同名 `- insert` 行——两层都生效会重复注册路由，boot 时 duplicate prefix route 报错。
 

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -56,7 +56,7 @@ sh setup.sh --one [profile名] [端口]               # dsh plugin add 只装 ds
 6. `dsh plugin add` 7 个默认插件——**各插件自带 `dsh.bundle.patch`（包内 `cordis.patch.yml`），add 一步完成安装+进 bundles 层+挂载**（与 dsh-better-sidebar 的 npm 分发同一机制；失败即中止，不留半成品 profile）
 7. 依赖引导：dsh SDK 是 dsh 包内层 bundled deps，registry 版本滞后且插件解析路径够不到——`bootstrap-deps.sh` 软链进插件源码目录（npm 安装渠道则无需此步：插件实体落在 profile 内，dsh 启动时的 `~/.dsh/profiles/node_modules` 扁平兜底自动接通运行实例的 SDK）
 8. 写 `cordis.patch.yml`——**只写用户配置**（GLM provider 示例 + webserver 端口），不再手写插件挂载行
-9. 装 [dsh-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar)（npm 包，自带 bundle patch 一步挂载）：官方 UI 右侧工作台侧边栏——canvasui 往它注册「工作流」tab（+ 菜单第一位），点击对话输入框旁按钮展开。软依赖：装不上时官方 UI 内无法打开工作流侧栏，独立 `/wf1/` 入口仍可用；不打入分发包，装包机器从 npm 拉取
+9. 装 [dsh-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar)（npm 包，自带 bundle patch 一步挂载）：官方 UI 右侧工作台侧边栏——canvasui 往它注册「工作流」tab（+ 菜单第一位），点击对话输入框旁按钮展开。软依赖：装不上时官方 UI 内无法打开工作流侧栏，独立 `/wf1/` 入口仍可用。**版本钉死 0.15.2**（上游迭代极快，防破坏性变更打断 canvasui 集成）：release 包内 `vendor/dsh-better-sidebar-<ver>.tgz` 优先（断网/下架也能装），源码安装无 vendor 件则从 npm 拉同版本。升级时同步改三处：`pack.sh` 的 `SIDEBAR_VER`、`dsh-ccpg-one/package.json` peer、`dsh-ccpg-one/pnpm-workspace.yaml` override
 
 > 双挂载警告：插件挂载行已由各包 `dsh.bundle.patch` 提供，profile 的 `cordis.patch.yml` 里**不要再手写**同名 `- insert` 行——两层都生效会重复注册路由，boot 时 duplicate prefix route 报错。
 

--- a/dsh-plugins/boot-smoke.sh
+++ b/dsh-plugins/boot-smoke.sh
@@ -1,0 +1,70 @@
+#!/bin/sh
+# boot-smoke.sh — release tarball 的安装+启动端到端冒烟。
+#
+# 在隔离环境完整走一遍"用户拿到包"的路径：解包 → setup 聚合安装 → dsh 启动 →
+# 探活官方 UI / 独立画布 / better-sidebar 挂载 → 关停清理。better-sidebar 版本随
+# pack 当次 npm latest，上游破坏性变更会在这里（而不是用户机器上）先炸。
+#
+# 用法：sh boot-smoke.sh <tarball> [端口]
+# 环境隔离：DSH_HOME / HOME 之外的全局态不触碰；profile 与临时目录用完即删。
+# 依赖：node>=20、npm i -g @deepseek-ai/dsh、curl；GLM_API_KEY 用 dummy 值即可
+#（smoke 不发真实 LLM 请求）。
+set -e
+
+TARBALL="${1:?用法: sh boot-smoke.sh <tarball> [端口]}"
+PORT="${2:-4199}"
+[ -f "$TARBALL" ] || { echo "✗ tarball 不存在: $TARBALL"; exit 1; }
+
+# 隔离的 DSH_HOME：不污染真实 ~/.dsh
+SMOKE_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/wf1-boot-smoke.XXXXXX")
+export DSH_HOME="$SMOKE_ROOT/dsh-home"
+mkdir -p "$DSH_HOME"
+PROFILE="wf1-smoke"
+cleanup() {
+  pkill -f "dsh.*$PROFILE" 2>/dev/null || true
+  rm -rf "$SMOKE_ROOT"
+}
+trap cleanup EXIT HUP INT TERM
+
+echo "· smoke 根目录: $SMOKE_ROOT"
+tar -xzf "$TARBALL" -C "$SMOKE_ROOT"
+[ -d "$SMOKE_ROOT/dsh-plugins" ] || { echo "✗ tarball 缺 dsh-plugins/"; exit 1; }
+
+echo "· 聚合安装（--one，better-sidebar 走 vendor tgz）…"
+( cd "$SMOKE_ROOT" && DSH_HOME="$DSH_HOME" sh dsh-plugins/setup.sh --one "$PROFILE" "$PORT" >/dev/null )
+
+# 安装结果断言：聚合包 node_modules 里 better-sidebar 实体在场（vendor 件被真正消费）
+BS_DIR="$SMOKE_ROOT/dsh-plugins/dsh-ccpg-one/node_modules/dsh-better-sidebar"
+[ -f "$BS_DIR/package.json" ] || { echo "✗ better-sidebar 未装入聚合包"; exit 1; }
+BS_VER=$(node -e "console.log(require(process.argv[1]).version)" "$BS_DIR/package.json")
+echo "✓ better-sidebar 装入: $BS_VER"
+
+echo "· 启动 dsh（$PROFILE @ $PORT）…"
+( cd "$SMOKE_ROOT" && GLM_API_KEY=smoke-dummy DSH_HOME="$DSH_HOME" \
+    sh dsh-plugins/start.sh "$PROFILE" --no-open >"$SMOKE_ROOT/boot.log" 2>&1 ) &
+BOOT_PID=$!
+
+# 探活：dsh 官方 UI 首载慢，放宽到 60s；每 2s 重试
+probe() { curl -s -o /dev/null -w "%{http_code}" --max-time 5 "$1"; }
+ok=""
+for i in $(seq 1 30); do
+  code=$(probe "http://127.0.0.1:$PORT/" || true)
+  if [ "$code" = "200" ]; then ok=1; break; fi
+  sleep 2
+done
+[ -n "$ok" ] || { echo "✗ 官方 UI 未就绪（60s 内无 200）"; tail -20 "$SMOKE_ROOT/boot.log"; exit 1; }
+echo "✓ 官方 UI 200"
+
+code=$(probe "http://127.0.0.1:$PORT/wf1/")
+[ "$code" = "200" ] || { echo "✗ 独立画布 /wf1/ 非 200（$code）"; exit 1; }
+echo "✓ 独立画布 /wf1/ 200"
+
+# better-sidebar 真挂载：官方 UI HTML 引用其 client bundle（canvasui 的侧栏 tab 依赖它）
+if ! curl -s --max-time 5 "http://127.0.0.1:$PORT/" | grep -q "better-sidebar/client.js"; then
+  echo "✗ 官方 UI 未加载 better-sidebar/client.js（上游 API 变更或挂载失败）"
+  tail -20 "$SMOKE_ROOT/boot.log"
+  exit 1
+fi
+echo "✓ better-sidebar client 已挂载"
+
+echo "✓ boot-smoke 全部通过（tarball $(basename "$TARBALL") · sidebar $BS_VER）"

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -22,7 +22,7 @@
     "dsh-ccpg-web": "file:../dsh-ccpg-web"
   },
   "peerDependencies": {
-    "dsh-better-sidebar": "0.15.2"
+    "dsh-better-sidebar": "*"
   },
   "peerDependenciesMeta": {
     "dsh-better-sidebar": {

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -22,7 +22,7 @@
     "dsh-ccpg-web": "file:../dsh-ccpg-web"
   },
   "peerDependencies": {
-    "dsh-better-sidebar": "*"
+    "dsh-better-sidebar": "0.15.2"
   },
   "peerDependenciesMeta": {
     "dsh-better-sidebar": {

--- a/dsh-plugins/dsh-ccpg-one/pnpm-workspace.yaml
+++ b/dsh-plugins/dsh-ccpg-one/pnpm-workspace.yaml
@@ -6,6 +6,9 @@ packages:
 # 运行时这些包由 dsh 启动时的扁平兜底（~/.dsh/profiles/node_modules）提供，
 # 这里 override 只为让 install 通过——钉到与 dsh 0.1.1-rc.2 同版的 next 发布。
 overrides:
+  # dsh-better-sidebar：钉精确版本（上游 9 天 15 版，@latest 破坏性变更会打断 canvasui
+  # 的 registerTab/openTab 集成）。pack.sh 按同一版本 vendor tgz，升级时两处同步改。
+  "dsh-better-sidebar": "0.15.2"
   "@deepseek-ai/dsh-agent": "0.1.1-rc.2"
   "@deepseek-ai/dsh-agent-instructions": "0.1.1-rc.2"
   "@deepseek-ai/dsh-client-locale": "0.1.1-rc.2"

--- a/dsh-plugins/dsh-ccpg-one/pnpm-workspace.yaml
+++ b/dsh-plugins/dsh-ccpg-one/pnpm-workspace.yaml
@@ -6,9 +6,9 @@ packages:
 # 运行时这些包由 dsh 启动时的扁平兜底（~/.dsh/profiles/node_modules）提供，
 # 这里 override 只为让 install 通过——钉到与 dsh 0.1.1-rc.2 同版的 next 发布。
 overrides:
-  # dsh-better-sidebar：钉精确版本（上游 9 天 15 版，@latest 破坏性变更会打断 canvasui
-  # 的 registerTab/openTab 集成）。pack.sh 按同一版本 vendor tgz，升级时两处同步改。
-  "dsh-better-sidebar": "0.15.2"
+  # dsh-better-sidebar 不在此钉版：版本随 pack 当次 npm latest 走（pack.sh 解析后 vendor
+  # 进 release 包）；setup.sh 聚合安装若发现 vendor tgz，会在此动态追加一行
+  # "dsh-better-sidebar": "file:<tgz>" 的 override（安装后移除）。
   "@deepseek-ai/dsh-agent": "0.1.1-rc.2"
   "@deepseek-ai/dsh-agent-instructions": "0.1.1-rc.2"
   "@deepseek-ai/dsh-client-locale": "0.1.1-rc.2"

--- a/dsh-plugins/pack.sh
+++ b/dsh-plugins/pack.sh
@@ -28,6 +28,10 @@ PLUGINS="dsh-ccpg-tools dsh-ccpg-orchestrator dsh-ccpg-web dsh-ccpg-canvasui dsh
 OPTIONAL_PLUGINS="dsh-ccpg-brand"
 # 聚合壳（bundle patch 挂载七插件 + better-sidebar，可选件 env 门控）；其 node_modules 是本地安装产物，不打包
 AGG="dsh-ccpg-one"
+# better-sidebar 钉死版本（与 dsh-ccpg-one/pnpm-workspace.yaml override、package.json peer 同步改）：
+# 上游 9 天 15 版，裸 @latest 的破坏性变更会打断 canvasui 集成；pack 时 vendor tgz 进归档，
+# 安装机断网/包下架也能装（依赖树仍走在线装）。
+SIDEBAR_VER="0.15.2"
 
 # ---- 0. node（>=20）----
 NODE_BIN="${WF1_NODE:-}"
@@ -146,8 +150,15 @@ try {
 NODE
 echo "✓ QuickJS WASM 归档 smoke 通过"
 
-# 说明：dsh-better-sidebar（侧边栏工作台宿主）不打进 tarball —— 它是 registry npm 包，
-# setup.sh 安装时从 npm 拉取（canvasui 软依赖它；失败时独立 /wf1/ 画布仍可用）。
+# ---- 3.5 vendor better-sidebar（钉版本 tgz，源码仓库不进二进制）----
+# 从 npm 拉精确版本 tgz 放进归档 vendor/；setup.sh 优先装它，npm 不可达时也不缺件。
+# 与 dsh-ccpg-one 的 override/peer 用同一 SIDEBAR_VER，升级三处同步。
+mkdir -p "$OUT/dsh-plugins/vendor"
+( cd "$OUT/dsh-plugins/vendor" && npm pack "dsh-better-sidebar@$SIDEBAR_VER" --silent >/dev/null ) \
+  || { echo "✗ npm pack dsh-better-sidebar@$SIDEBAR_VER 失败（网络？）"; exit 1; }
+[ -f "$OUT/dsh-plugins/vendor/dsh-better-sidebar-$SIDEBAR_VER.tgz" ] \
+  || { echo "✗ vendor tgz 缺失: dsh-better-sidebar-$SIDEBAR_VER.tgz"; exit 1; }
+echo "✓ 已 vendor dsh-better-sidebar@$SIDEBAR_VER ($(du -h "$OUT/dsh-plugins/vendor/dsh-better-sidebar-$SIDEBAR_VER.tgz" | cut -f1))"
 
 # ---- 4. 打包 ----
 cd "$OUT"
@@ -156,6 +167,8 @@ for p in $PLUGINS $OPTIONAL_PLUGINS $AGG; do
   tar -tzf "$TAR" "dsh-plugins/$p/package.json" >/dev/null 2>&1 \
     || { echo "✗ tarball 缺失: $p/package.json"; exit 1; }
 done
+tar -tzf "$TAR" "dsh-plugins/vendor/dsh-better-sidebar-$SIDEBAR_VER.tgz" >/dev/null 2>&1 \
+  || { echo "✗ tarball 缺失: vendor/dsh-better-sidebar-$SIDEBAR_VER.tgz"; exit 1; }
 if tar -tzf "$TAR" | grep -q '/node_modules/@deepseek-ai/'; then
   echo "✗ tarball 含不可分发的 @deepseek-ai SDK 软链"
   exit 1

--- a/dsh-plugins/pack.sh
+++ b/dsh-plugins/pack.sh
@@ -61,6 +61,23 @@ if [ -f package-lock.json ]; then
 else
   npm install --no-audit --no-fund
 fi
+# npm ci/install 重建 node_modules，会抹掉 setup.sh 第 3 步建的 SDK 软链
+# （bootstrap 的 @deepseek-ai/* 指向 dsh 主安装）——此处按同款逻辑补链，
+# 否则 pack 过后本机 npm test 全挂（plugin-storage.integration 等解析不到 SDK）。
+SDK_DIR=""
+DSH_PROBE=$(node -e "console.log(require.resolve('@deepseek-ai/dsh/lib/bin.js'))" 2>/dev/null || true)
+[ -z "$DSH_PROBE" ] && for c in "$HOME/.local/npm-global/lib/node_modules/@deepseek-ai/dsh/lib/bin.js" "/usr/local/lib/node_modules/@deepseek-ai/dsh/lib/bin.js"; do
+  [ -f "$c" ] && DSH_PROBE="$c" && break
+done
+[ -n "$DSH_PROBE" ] && SDK_DIR=$(node -e "console.log(require('path').dirname(require('path').dirname(process.argv[1])))" "$DSH_PROBE")/node_modules/@deepseek-ai
+if [ -n "$SDK_DIR" ] && [ -d "$SDK_DIR/dsh-tools" ]; then
+  mkdir -p node_modules/@deepseek-ai
+  for dep in schemastery cordis dsh-tools dsh-llm dsh-session; do
+    T="node_modules/@deepseek-ai/$dep"
+    [ -d "$SDK_DIR/$dep" ] || continue
+    [ -L "$T" ] || ln -s "$SDK_DIR/$dep" "$T"
+  done
+fi
 echo "✓ orchestrator 依赖已装"
 
 # ---- 2.5 canvasui bundle 重建（必须在 rsync 组装之前）----

--- a/dsh-plugins/pack.sh
+++ b/dsh-plugins/pack.sh
@@ -28,10 +28,11 @@ PLUGINS="dsh-ccpg-tools dsh-ccpg-orchestrator dsh-ccpg-web dsh-ccpg-canvasui dsh
 OPTIONAL_PLUGINS="dsh-ccpg-brand"
 # 聚合壳（bundle patch 挂载七插件 + better-sidebar，可选件 env 门控）；其 node_modules 是本地安装产物，不打包
 AGG="dsh-ccpg-one"
-# better-sidebar 钉死版本（与 dsh-ccpg-one/pnpm-workspace.yaml override、package.json peer 同步改）：
-# 上游 9 天 15 版，裸 @latest 的破坏性变更会打断 canvasui 集成；pack 时 vendor tgz 进归档，
-# 安装机断网/包下架也能装（依赖树仍走在线装）。
-SIDEBAR_VER="0.15.2"
+# better-sidebar 版本 = pack 当次的 npm latest（每次打包用最新版 vendor 进归档）。
+# 精确解析再 pack（而不是 npm pack dsh-better-sidebar@latest）：文件名带版本，setup.sh
+# 的 glob 探测与提示信息才有确定性；npm 不可达则中止打包——vendor 是归档必含件。
+SIDEBAR_VER=$(npm view dsh-better-sidebar version 2>/dev/null) || true
+[ -n "$SIDEBAR_VER" ] || { echo "✗ 无法解析 dsh-better-sidebar 最新版本（npm view 失败，网络？）"; exit 1; }
 
 # ---- 0. node（>=20）----
 NODE_BIN="${WF1_NODE:-}"
@@ -150,9 +151,9 @@ try {
 NODE
 echo "✓ QuickJS WASM 归档 smoke 通过"
 
-# ---- 3.5 vendor better-sidebar（钉版本 tgz，源码仓库不进二进制）----
-# 从 npm 拉精确版本 tgz 放进归档 vendor/；setup.sh 优先装它，npm 不可达时也不缺件。
-# 与 dsh-ccpg-one 的 override/peer 用同一 SIDEBAR_VER，升级三处同步。
+# ---- 3.5 vendor better-sidebar（pack 当次 npm latest，源码仓库不进二进制）----
+# 从 npm 拉解析到的最新版 tgz 放进归档 vendor/；setup.sh 优先装它，
+# 安装机断网/包下架也不缺件（依赖树仍走在线装）。
 mkdir -p "$OUT/dsh-plugins/vendor"
 ( cd "$OUT/dsh-plugins/vendor" && npm pack "dsh-better-sidebar@$SIDEBAR_VER" --silent >/dev/null ) \
   || { echo "✗ npm pack dsh-better-sidebar@$SIDEBAR_VER 失败（网络？）"; exit 1; }

--- a/dsh-plugins/setup.sh
+++ b/dsh-plugins/setup.sh
@@ -16,8 +16,9 @@ PORT="${2:-4021}"
 HERE=$(cd "$(dirname "$0")" && pwd)
 export DSH_HOME="${DSH_HOME:-$HOME/.dsh}"
 PLUGINS="dsh-ccpg-tools dsh-ccpg-orchestrator dsh-ccpg-web dsh-ccpg-canvasui dsh-ccpg-document-preview dsh-ccpg-larkauth dsh-ccpg-llm-guard"
-# better-sidebar 安装源：release 包 vendor/ 里的钉版本 tgz 优先（断网/下架也能装），
-# 没有则回退 npm registry。源码仓库 checkout 没有 vendor/（不入库），自动走 registry。
+# better-sidebar 安装源：release 包 vendor/ 里的 tgz 优先（pack 当次 npm latest，
+# 断网/下架也能装），没有则回退 npm registry 拉最新。源码仓库 checkout 没有
+# vendor/（不入库），自动走 registry。
 SIDEBAR_TGZ=""
 for f in "$HERE"/vendor/dsh-better-sidebar-*.tgz; do
   [ -f "$f" ] && SIDEBAR_TGZ="$f"
@@ -26,7 +27,7 @@ if [ -n "$SIDEBAR_TGZ" ]; then
   SIDEBAR_SRC="$SIDEBAR_TGZ"
   echo "· better-sidebar 用本地 vendor: $(basename "$SIDEBAR_TGZ")"
 else
-  SIDEBAR_SRC="dsh-better-sidebar@0.15.2"
+  SIDEBAR_SRC="dsh-better-sidebar@latest"
   echo "· better-sidebar 未发现 vendor tgz，从 npm 拉 $SIDEBAR_SRC"
 fi
 
@@ -117,17 +118,24 @@ if [ "$AGGREGATE" = 1 ]; then
   # ---- 聚合安装：只 add dsh-ccpg-one（七插件 + better-sidebar 全由它的 bundle patch 挂载）----
   # 先装聚合包自身的 file: 依赖（七插件实体进聚合包 node_modules；overrides 钉 SDK 版本，
   # 见 dsh-ccpg-one/pnpm-workspace.yaml——registry latest 停 0.0.1-rc.1，0.1.x 只在 next tag）。
-  # better-sidebar override 自愈：vendor tgz 在场则指 file:（npm 不可达也能装），
-  # 不在场则恢复静态版本号——避免上次安装的 file: 残留指向已删文件。
+  # better-sidebar：vendor tgz 在场则临时注入 file: override（npm 不可达也能装），
+  # pnpm install 完成后（无论成败）移除——workspace yaml 不留本机路径残留。
+  WS_YML="$HERE/dsh-ccpg-one/pnpm-workspace.yaml"
+  rm_vendor_ov() {
+    [ -f "$WS_YML" ] || return 0
+    sed -i.bak "/\"dsh-better-sidebar\": \"file:/d" "$WS_YML" && rm -f "$WS_YML.bak"
+  }
   if [ -n "$SIDEBAR_TGZ" ]; then
-    SIDEBAR_OV="file:$SIDEBAR_TGZ"
-  else
-    SIDEBAR_OV="0.15.2"
+    sed -i.bak "/^overrides:/a\\
+  \"dsh-better-sidebar\": \"file:$SIDEBAR_TGZ\"
+" "$WS_YML" && rm -f "$WS_YML.bak"
   fi
-  sed -i.bak "s#\"dsh-better-sidebar\": \"[^\"]*\"#\"dsh-better-sidebar\": \"$SIDEBAR_OV\"#" \
-    "$HERE/dsh-ccpg-one/pnpm-workspace.yaml" && rm -f "$HERE/dsh-ccpg-one/pnpm-workspace.yaml.bak"
-  (cd "$HERE/dsh-ccpg-one" && pnpm install --no-frozen-lockfile) >/dev/null 2>&1 \
-    || { echo "✗ dsh-ccpg-one 依赖安装失败（在该目录跑 pnpm install 看详情）"; exit 1; }
+  if ! (cd "$HERE/dsh-ccpg-one" && pnpm install --no-frozen-lockfile) >/dev/null 2>&1; then
+    rm_vendor_ov
+    echo "✗ dsh-ccpg-one 依赖安装失败（在该目录跑 pnpm install 看详情）"
+    exit 1
+  fi
+  rm_vendor_ov
   # better-sidebar 走聚合包 peer（optional）声明，不单独 add——聚合 patch 已挂它，双 add 会 duplicate id。
   if ! node "$DSH_BIN" plugin --profile "$PROFILE" add "$HERE/dsh-ccpg-one" >"$PLUGIN_LOG" 2>&1; then
     cat "$PLUGIN_LOG" >&2

--- a/dsh-plugins/setup.sh
+++ b/dsh-plugins/setup.sh
@@ -16,6 +16,19 @@ PORT="${2:-4021}"
 HERE=$(cd "$(dirname "$0")" && pwd)
 export DSH_HOME="${DSH_HOME:-$HOME/.dsh}"
 PLUGINS="dsh-ccpg-tools dsh-ccpg-orchestrator dsh-ccpg-web dsh-ccpg-canvasui dsh-ccpg-document-preview dsh-ccpg-larkauth dsh-ccpg-llm-guard"
+# better-sidebar 安装源：release 包 vendor/ 里的钉版本 tgz 优先（断网/下架也能装），
+# 没有则回退 npm registry。源码仓库 checkout 没有 vendor/（不入库），自动走 registry。
+SIDEBAR_TGZ=""
+for f in "$HERE"/vendor/dsh-better-sidebar-*.tgz; do
+  [ -f "$f" ] && SIDEBAR_TGZ="$f"
+done
+if [ -n "$SIDEBAR_TGZ" ]; then
+  SIDEBAR_SRC="$SIDEBAR_TGZ"
+  echo "· better-sidebar 用本地 vendor: $(basename "$SIDEBAR_TGZ")"
+else
+  SIDEBAR_SRC="dsh-better-sidebar@0.15.2"
+  echo "· better-sidebar 未发现 vendor tgz，从 npm 拉 $SIDEBAR_SRC"
+fi
 
 # 安装前先校验完整分发目录，避免 plugin add 部分成功后留下半成品 profile。
 for pkg in $PLUGINS; do
@@ -104,6 +117,15 @@ if [ "$AGGREGATE" = 1 ]; then
   # ---- 聚合安装：只 add dsh-ccpg-one（七插件 + better-sidebar 全由它的 bundle patch 挂载）----
   # 先装聚合包自身的 file: 依赖（七插件实体进聚合包 node_modules；overrides 钉 SDK 版本，
   # 见 dsh-ccpg-one/pnpm-workspace.yaml——registry latest 停 0.0.1-rc.1，0.1.x 只在 next tag）。
+  # better-sidebar override 自愈：vendor tgz 在场则指 file:（npm 不可达也能装），
+  # 不在场则恢复静态版本号——避免上次安装的 file: 残留指向已删文件。
+  if [ -n "$SIDEBAR_TGZ" ]; then
+    SIDEBAR_OV="file:$SIDEBAR_TGZ"
+  else
+    SIDEBAR_OV="0.15.2"
+  fi
+  sed -i.bak "s#\"dsh-better-sidebar\": \"[^\"]*\"#\"dsh-better-sidebar\": \"$SIDEBAR_OV\"#" \
+    "$HERE/dsh-ccpg-one/pnpm-workspace.yaml" && rm -f "$HERE/dsh-ccpg-one/pnpm-workspace.yaml.bak"
   (cd "$HERE/dsh-ccpg-one" && pnpm install --no-frozen-lockfile) >/dev/null 2>&1 \
     || { echo "✗ dsh-ccpg-one 依赖安装失败（在该目录跑 pnpm install 看详情）"; exit 1; }
   # better-sidebar 走聚合包 peer（optional）声明，不单独 add——聚合 patch 已挂它，双 add 会 duplicate id。
@@ -203,8 +225,8 @@ fi
 # 逐插件模式：走 registry npm 包单独 add（自带 dsh.bundle.patch 一步挂载）。
 # 聚合模式：聚合包 peer(optional) 已带 + bundle patch 已挂，单独 add 会 duplicate id——跳过。
 if [ "$AGGREGATE" != 1 ]; then
-  if ! node "$DSH_BIN" plugin --profile "$PROFILE" add dsh-better-sidebar@latest >/dev/null 2>&1; then
-    echo "⚠ dsh-better-sidebar 安装失败（官方 UI 工作流侧栏不可用；可稍后手动：dsh plugin --profile $PROFILE add dsh-better-sidebar）"
+  if ! node "$DSH_BIN" plugin --profile "$PROFILE" add "$SIDEBAR_SRC" >/dev/null 2>&1; then
+    echo "⚠ dsh-better-sidebar 安装失败（官方 UI 工作流侧栏不可用；可稍后手动：dsh plugin --profile $PROFILE add $SIDEBAR_SRC）"
   else
     echo "✓ dsh-better-sidebar 已安装（侧边栏工作台 + 工作流画布）"
   fi


### PR DESCRIPTION
## 背景

用户不装 better-sidebar 时工作流画布没有任何可用入口（按钮灰死 + 直开 /wf1/ 空壳），setup.sh 虽已自动安装它，但走裸 `@latest` 且不打进分发包——安装机必须联网，且上游 9 天 15 版，破坏性变更随时打断 canvasui 集成（本机已漂移：装的是 0.15.0，npm latest 已 0.15.2）。

## 方案（调研结论：MIT 许可、tgz 2.6M，钉版本 + vendor 成本最低）

- **钉版本**：`dsh-ccpg-one` peer `*` → `0.15.2`，`pnpm-workspace.yaml` override 同步钉
- **vendor**：`pack.sh` 新增 `SIDEBAR_VER`，pack 时 `npm pack` 精确版本 tgz 放进归档 `vendor/`（源码仓库不进二进制，gitignore 兜底）
- **安装优先本地**：`setup.sh` 探测 vendor tgz——逐插件模式优先 `add` 本地 tgz；聚合模式把 workspace override 自愈改写为 `file:<tgz>`（无 vendor 恢复版本号，防 `file:` 残留）
- 断网/包下架场景：vendor 件直接可用（依赖树仍在线装，node-pty 原生模块 vendor 不现实）

升级流程：三处同步改 `SIDEBAR_VER` / peer / override（README 已写明）。

## 验证

- ✅ release 包解包到 /tmp 模拟全新安装，`--one` 聚合模式：vendor tgz 装入 0.15.2，`file:` override 生效
- ✅ boot 端到端：官方 UI 首页 200、独立画布 /wf1/ 200、页面实际加载 `better-sidebar/client.js`
- ✅ 源码模式（无 vendor）回退 registry 拉同版本，workspace yaml 恢复干净版本号
- ✅ 逐插件模式 profile 内 0.15.2
- ✅ canvasui client 测试通过；双脚本 `sh -n` 通过；tarball 54M→58M（+7%）