### PR TITLE
feat(canvasui): 聊天消息流渲染工作流卡片（建图过程 + 运行状态，点击跳侧栏画布）

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -66,6 +66,27 @@ window.__ModuleLoader__.load({
         ".wf1-view-root{position:relative;display:block;flex:1 1 0;width:100%;height:100%;min-height:0;overflow:hidden;}",
         ".wf1-canvas-fill{position:absolute;inset:0;display:flex;}",
         ".wf1-canvas-fill iframe{width:100%;height:100%;border:0;display:block;flex:1;}",
+        // ---- 消息流工作流卡片（tool.call.toolview）----
+        ".wf1-card{border:1px solid var(--dsw-alias-border-l1);border-radius:12px;padding:10px 14px;display:flex;flex-direction:column;gap:6px;cursor:pointer;transition:border-color 100ms ease;background:var(--dsw-alias-bg-base);text-align:left;width:100%;}",
+        ".wf1-card:hover{border-color:var(--dsw-alias-border-l2);}",
+        ".wf1-card:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
+        ".wf1-card-head{display:flex;align-items:center;gap:8px;min-width:0;}",
+        ".wf1-card-icon{width:16px;height:16px;color:var(--dsw-alias-label-secondary);flex:none;}",
+        ".wf1-card-title{color:var(--dsw-alias-label-secondary);font-size:14px;line-height:22px;flex:none;max-width:60%;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}",
+        ".wf1-card-state{display:inline-flex;align-items:center;gap:5px;margin-left:auto;flex:none;font-size:13px;color:var(--dsw-alias-label-caption);}",
+        ".wf1-card-dot{width:7px;height:7px;border-radius:999px;flex:none;}",
+        ".wf1-card-dot[data-s=running]{background:var(--dsw-alias-state-business-primary);animation:wf1-card-pulse 1.6s ease-in-out infinite;}",
+        ".wf1-card-dot[data-s=success]{background:var(--dsw-alias-state-success-primary);}",
+        ".wf1-card-dot[data-s=error]{background:var(--dsw-alias-state-error-primary);}",
+        ".wf1-card-dot[data-s=waiting]{background:var(--dsw-alias-state-warn-primary);}",
+        ".wf1-card-dot[data-s=pending]{background:var(--dsw-alias-border-l2);}",
+        "@keyframes wf1-card-pulse{0%,100%{opacity:1}50%{opacity:.35}}",
+        ".wf1-card-map{height:88px;border-radius:8px;display:block;width:100%;}",
+        ".wf1-card-foot{display:flex;align-items:center;gap:8px;min-width:0;}",
+        ".wf1-card-meta{color:var(--dsw-alias-label-tertiary);font-size:13px;line-height:18px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;}",
+        ".wf1-card-meta[data-error]{color:var(--dsw-alias-state-error-primary);}",
+        ".wf1-card-open{flex:none;display:inline-flex;align-items:center;gap:3px;color:var(--dsw-alias-label-caption);font-size:12px;line-height:18px;opacity:0;transition:opacity 100ms ease;}",
+        ".wf1-card:hover .wf1-card-open,.wf1-card:focus-visible .wf1-card-open{opacity:1;}",
       ].join("\n");
       document.head.appendChild(el);
     }
@@ -79,6 +100,301 @@ window.__ModuleLoader__.load({
       });
       return true;
     }
+
+    // ---- 消息流工作流卡片（tool.call.toolview）----
+    // 数据源全部现成：canvas_run_workflow 的工具结果带 runId → 轮询 /wf1/api/runs/detail；
+    // canvas_graph_patch 的 args/结果自带 ops 与 lint。卡片自绘 SVG 缩略图，画布本体零改动。
+
+    function workflowIcon(size) {
+      return react.createElement(
+        "svg",
+        {
+          viewBox: "0 0 16 16",
+          width: size || 16,
+          height: size || 16,
+          "aria-hidden": true,
+          fill: "none",
+          stroke: "currentColor",
+          "stroke-width": 1.45,
+          "stroke-linecap": "round",
+          "stroke-linejoin": "round",
+        },
+        react.createElement("circle", { cx: 3.25, cy: 4, r: 1.35 }),
+        react.createElement("circle", { cx: 12.75, cy: 3.25, r: 1.35 }),
+        react.createElement("circle", { cx: 12.75, cy: 12.75, r: 1.35 }),
+        react.createElement("path", {
+          d: "M4.6 4h2.15A2.25 2.25 0 0 1 9 6.25v4.25A2.25 2.25 0 0 0 11.25 12.75h.15M9 7V5.5a2.25 2.25 0 0 1 2.25-2.25h.15",
+        }),
+      );
+    }
+
+    // 工具 block 的统一文本抽取：running block 无 content，settled block.content 是
+    // [{type:'text',text}] 数组（官方 tool-result 投影）。
+    function toolText(block) {
+      if (!block || !("kind" in block) || !Array.isArray(block.content)) return null;
+      return block.content
+        .filter(function (c) { return c && c.type === "text"; })
+        .map(function (c) { return c.text; })
+        .join("");
+    }
+
+    // canvas_run_workflow 结果 JSON 里的 runId（execute 返回 {started:true,runId} 字符串）
+    function runIdFromText(text) {
+      if (!text) return null;
+      try {
+        var v = JSON.parse(text);
+        return v && typeof v === "object" && typeof v.runId === "string" ? v.runId : null;
+      } catch (e) {
+        return null;
+      }
+    }
+
+    var RUN_STATUS_CN = {
+      running: "运行中", success: "成功", error: "失败",
+      canceled: "已取消", skipped: "已跳过", waiting: "等待审批",
+    };
+    function runDotState(run, fallback) {
+      var s = run ? run.status : fallback;
+      if (s === "success") return "success";
+      if (s === "error" || s === "canceled") return "error";
+      if (s === "waiting") return "waiting";
+      if (s === "running" || !run) return "running";
+      return "pending";
+    }
+
+    // 图 → SVG 缩略图：节点用 graph 自带 position，按 bounds 等比缩放；点色只表达状态。
+    // run 为 null 时全部节点灰（建图态/无运行）。
+    function graphThumbnail(graph, run) {
+      var nodes = (graph && Array.isArray(graph.nodes) ? graph.nodes : []).filter(function (n) {
+        return (n.type || (n.data && n.data.nodeType)) !== "note";
+      });
+      if (!nodes.length) return null;
+      var states = (run && run.nodeStates) || {};
+      var byId = {};
+      nodes.forEach(function (n) { byId[n.id] = n; });
+      var pts = nodes.map(function (n) {
+        var p = n.position || (n.data && n.data.position) || { x: 0, y: 0 };
+        return { x: Number(p.x) || 0, y: Number(p.y) || 0 };
+      });
+      var minX = Math.min.apply(null, pts.map(function (p) { return p.x; }));
+      var minY = Math.min.apply(null, pts.map(function (p) { return p.y; }));
+      var maxX = Math.max.apply(null, pts.map(function (p) { return p.x; }));
+      var maxY = Math.max.apply(null, pts.map(function (p) { return p.y; }));
+      var W = 300, H = 88, PAD = 12;
+      var spanX = Math.max(maxX - minX, 1), spanY = Math.max(maxY - minY, 1);
+      var scale = Math.min((W - PAD * 2) / spanX, (H - PAD * 2) / spanY);
+      var offX = (W - spanX * scale) / 2 - minX * scale;
+      var offY = (H - spanY * scale) / 2 - minY * scale;
+      var big = nodes.length > 24;
+      var R = big ? 3 : 4.5;
+      var colorOf = function (st) {
+        if (st === "running") return "var(--dsw-alias-state-business-primary)";
+        if (st === "success") return "var(--dsw-alias-state-success-primary)";
+        if (st === "error" || st === "canceled") return "var(--dsw-alias-state-error-primary)";
+        if (st === "waiting") return "var(--dsw-alias-state-warn-primary)";
+        return "var(--dsw-alias-border-l2)";
+      };
+      var edges = (graph && Array.isArray(graph.edges) ? graph.edges : [])
+        .filter(function (e) { return byId[e.source] && byId[e.target]; })
+        .map(function (e) {
+          var a = byId[e.source].position || { x: 0, y: 0 };
+          var b = byId[e.target].position || { x: 0, y: 0 };
+          return react.createElement("line", {
+            key: "e" + e.id, x1: a.x * scale + offX, y1: a.y * scale + offY,
+            x2: b.x * scale + offX, y2: b.y * scale + offY,
+            stroke: "var(--dsw-alias-border-l2)", "stroke-width": 1,
+          });
+        });
+      var dots = nodes.map(function (n) {
+        var p = n.position || { x: 0, y: 0 };
+        var st = states[n.id] ? states[n.id].status : null;
+        return react.createElement("circle", {
+          key: n.id, cx: p.x * scale + offX, cy: p.y * scale + offY, r: R,
+          fill: colorOf(st),
+        });
+      });
+      return react.createElement(
+        "svg", { className: "wf1-card-map", viewBox: "0 0 " + W + " " + H, "aria-hidden": true },
+        edges.concat(dots),
+      );
+    }
+
+    function openCanvasFallback() {
+      if (openWorkflowSidebar()) return;
+      window.open(CANVAS_URL, "_blank");
+    }
+
+    // 卡片骨架：头（图标+标题+状态章）+ 缩略图 + 底（meta+打开按钮）。整卡可点。
+    function workflowCardShell(props) {
+      return react.createElement(
+        "button",
+        {
+          type: "button",
+          className: "wf1-card",
+          onClick: function () { try { openCanvasFallback(); } catch (e) { /* 宿主状态异常不炸消息流 */ } },
+        },
+        react.createElement(
+          "div", { className: "wf1-card-head" },
+          react.createElement("span", { className: "wf1-card-icon" }, workflowIcon(16)),
+          react.createElement("span", { className: "wf1-card-title" }, props.title),
+          react.createElement(
+            "span", { className: "wf1-card-state" },
+            react.createElement("span", { className: "wf1-card-dot", "data-s": props.dotState }),
+            props.stateText,
+          ),
+        ),
+        props.thumbnail || null,
+        react.createElement(
+          "div", { className: "wf1-card-foot" },
+          react.createElement(
+            "span", { className: "wf1-card-meta", "data-error": props.metaError || undefined },
+            props.meta,
+          ),
+          react.createElement("span", { className: "wf1-card-open" }, "打开画布 ↗"),
+        ),
+      );
+    }
+
+    // 运行卡：canvas_run_workflow / canvas_run_status 共用。
+    // runId 从工具结果解析；运行中 2s 轮询 runs/detail，终态即停（历史卡片是当时快照）。
+    function WorkflowRunCard(props) {
+      var block = props.block || {};
+      var text = toolText(block);
+      var runId = react.useMemo(
+        function () { return runIdFromText(text); },
+        [text],
+      );
+      var sessionId = currentDshSessionId(null);
+      var [run, setRun] = react.useState(null);
+      var [missing, setMissing] = react.useState(false);
+
+      react.useEffect(function () {
+        if (!runId) return undefined;
+        var stopped = false;
+        var terminal = false;
+        var fetchRun = function () {
+          if (stopped || terminal) return;
+          var url = "/wf1/api/runs/detail?id=" + encodeURIComponent(runId);
+          if (sessionId) url += "&sessionId=" + encodeURIComponent(sessionId);
+          fetch(url)
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (d) {
+              if (stopped || !d) { if (!d) setMissing(true); return; }
+              setMissing(false);
+              setRun(d);
+              if (d.status && d.status !== "running") terminal = true;
+            })
+            .catch(function () { /* 单次失败继续轮询 */ });
+        };
+        fetchRun();
+        var timer = window.setInterval(fetchRun, 2000);
+        return function () { stopped = true; window.clearInterval(timer); };
+      }, [runId, sessionId]);
+
+      if (!runId) {
+        // 起跑失败（画布未开/lint 拒绝）或会话未绑定：文本降级 + 保留跳转
+        return workflowCardShell({
+          title: "工作流运行",
+          dotState: text && block.isError ? "error" : "pending",
+          stateText: block.isError ? "未启动" : "就绪",
+          meta: (text || "").slice(0, 60) || "画布尚未打开或未绑定会话",
+          metaError: Boolean(block.isError),
+          thumbnail: null,
+        });
+      }
+      if (missing && !run) {
+        return workflowCardShell({
+          title: "工作流运行",
+          dotState: "pending",
+          stateText: "已归档",
+          meta: "运行 " + runId.slice(0, 8) + "… 记录不在当前工作区",
+          thumbnail: null,
+        });
+      }
+
+      var dot = runDotState(run);
+      var nodeTotal = 0, nodeDone = 0, currentLabel = "", errText = "";
+      if (run && run.nodeStates) {
+        var labels = {};
+        (run.graph && run.graph.nodes ? run.graph.nodes : []).forEach(function (n) {
+          labels[n.id] = (n.data && n.data.label) || n.id;
+        });
+        Object.keys(run.nodeStates).forEach(function (id) {
+          var st = run.nodeStates[id].status;
+          nodeTotal += 1;
+          if (["success", "error", "canceled", "skipped"].indexOf(st) >= 0) nodeDone += 1;
+          if (st === "running") currentLabel = labels[id] || id;
+          if (!errText && (run.nodeStates[id].error || run.nodeStates[id].toleratedError)) {
+            errText = String(run.nodeStates[id].error || run.nodeStates[id].toleratedError);
+          }
+        });
+      }
+      var secs = run && run.durationMs ? Math.round(run.durationMs / 1000) + "s" : "";
+      var meta;
+      if (dot === "running") {
+        meta = (currentLabel ? "「" + currentLabel + "」执行中" : "执行中") + (secs ? " · " + secs : "");
+      } else if (dot === "error") {
+        meta = errText || run.status && (RUN_STATUS_CN[run.status] || run.status) || "运行失败";
+      } else if (dot === "success") {
+        meta = "完成" + (secs ? " · " + secs : "");
+      } else {
+        meta = RUN_STATUS_CN[run.status] || run.status || "";
+      }
+      return workflowCardShell({
+        title: "工作流 · " + (run && run.workflowName ? run.workflowName : "草稿图"),
+        dotState: dot,
+        stateText: nodeTotal ? nodeDone + "/" + nodeTotal : (RUN_STATUS_CN[run.status] || run.status || "运行中"),
+        meta: meta,
+        metaError: dot === "error",
+        thumbnail: graphThumbnail(run && run.graph, run),
+      });
+    }
+
+    // 建图卡：canvas_graph_patch 的每次调用渲染一批操作 + 应用后的图快照。
+    // args.ops 来自调用参数（running 时就有），结果文本（已应用 N 个操作 / 整批拒绝）settle 后补状态。
+    var OP_CN = {
+      addNode: "加节点", updateNode: "改节点", renameNode: "重命名", deleteNode: "删节点",
+      connect: "连线", deleteEdge: "删线", updateEdge: "改线",
+    };
+    function GraphPatchCard(props) {
+      var block = props.block || {};
+      var settled = "kind" in block;
+      var text = settled ? toolText(block) : null;
+      // args：running block 是 {name,argsRaw}（宿主 call 形状），settled 后带 call.argsRaw
+      var argsRaw = (block.call && block.call.argsRaw) || block.argsRaw;
+      var ops = [];
+      try {
+        var parsed = typeof argsRaw === "string" ? JSON.parse(argsRaw) : argsRaw;
+        ops = (parsed && Array.isArray(parsed.ops)) ? parsed.ops : [];
+      } catch (e) { /* 非法参数不炸卡片 */ }
+      var opCount = {};
+      ops.forEach(function (op) {
+        var key = OP_CN[op.op] || op.op;
+        opCount[key] = (opCount[key] || 0) + 1;
+      });
+      var opSummary = Object.keys(opCount)
+        .map(function (k) { return opCount[k] + " " + k; })
+        .join("、") || "无操作";
+
+      var ok = settled ? !block.isError : true;
+      var lintOk = ok && text ? text.indexOf("lint: 通过") >= 0 : false;
+      var dotState = !settled ? "running" : ok ? (lintOk ? "success" : "pending") : "error";
+      var stateText = !settled ? "应用中" : ok ? (lintOk ? "已应用" : "已应用·有告警") : "被拒绝";
+      var meta;
+      if (!settled) meta = opSummary;
+      else if (!ok) meta = (text || "整批被拒绝").split("\n")[0].slice(0, 60);
+      else meta = opSummary + (lintOk ? "" : " · lint 有告警");
+
+      return workflowCardShell({
+        title: "建图 · " + opSummary.slice(0, 40),
+        dotState: dotState,
+        stateText: stateText,
+        meta: meta,
+        metaError: settled && !ok,
+        thumbnail: null,
+      });
+    }
+
 
     function WorkflowOpenButton(props) {
       var [sidebarReady, setSidebarReady] = react.useState(
@@ -317,6 +633,23 @@ window.__ModuleLoader__.load({
         );
       });
 
+      // 消息流工具卡：按工具名接管官方 UI 的 tool.call.toolview keyed slot
+      //（官方 ask_user_question / cordis_run 同款机制）。未注册的 canvas_* 工具
+      // 走官方 GenericToolCard 文本行，行为不变。
+      var toolviews = [
+        ["canvas_graph_patch", GraphPatchCard],
+        ["canvas_run_workflow", WorkflowRunCard],
+        ["canvas_run_status", WorkflowRunCard],
+      ];
+      toolviews.forEach(function (pair) {
+        ctx.slots.inject("tool.call.toolview", function () {
+          return ctx.slots.register(
+            { name: "tool.call.toolview", key: pair[0] },
+            pair[1],
+          );
+        });
+      });
+
       // DSH-better-sidebar「工作流」tab：软依赖注入。
       try {
         ctx.inject(["betterSidebar"], function (scope) {
@@ -394,6 +727,11 @@ window.__ModuleLoader__.load({
       setBetterSidebarService: setBetterSidebarService,
       sidebarAllTabs: sidebarAllTabs,
       subscribeSidebarService: subscribeSidebarService,
+      toolText: toolText,
+      runIdFromText: runIdFromText,
+      runDotState: runDotState,
+      WorkflowRunCard: WorkflowRunCard,
+      GraphPatchCard: GraphPatchCard,
     };
 
     return exports;

--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -67,7 +67,7 @@ window.__ModuleLoader__.load({
         ".wf1-canvas-fill{position:absolute;inset:0;display:flex;}",
         ".wf1-canvas-fill iframe{width:100%;height:100%;border:0;display:block;flex:1;}",
         // ---- 消息流工作流卡片（tool.call.toolview）----
-        ".wf1-card{border:1px solid var(--dsw-alias-border-l1);border-radius:12px;padding:10px 14px;display:flex;flex-direction:column;gap:6px;cursor:pointer;transition:border-color 100ms ease;background:var(--dsw-alias-bg-base);text-align:left;width:100%;}",
+        ".wf1-card{font:inherit;color:inherit;border:1px solid var(--dsw-alias-border-l1);border-radius:12px;padding:10px 14px;display:flex;flex-direction:column;gap:6px;cursor:pointer;transition:border-color 100ms ease;background:var(--dsw-alias-bg-base);text-align:left;width:100%;}",
         ".wf1-card:hover{border-color:var(--dsw-alias-border-l2);}",
         ".wf1-card:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
         ".wf1-card-head{display:flex;align-items:center;gap:8px;min-width:0;}",

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -97,7 +97,12 @@ client.apply({
     },
   },
 });
-assert.deepEqual(injectedSlots, ["conversation.input.left"]);
+assert.deepEqual(injectedSlots, [
+  "conversation.input.left",
+  "tool.call.toolview",
+  "tool.call.toolview",
+  "tool.call.toolview",
+]);
 assert.deepEqual(
   registeredTabs.map((tab) => tab.id),
   ["ccpg:workflow"],
@@ -181,5 +186,146 @@ assert.equal(
   client.__test.currentDshSessionId("blank-session"),
   "blank-session",
 );
+
+// ---- 消息流卡片：纯函数面 ----
+// 工具 block 文本抽取（settled content 数组 → 文本；settled 必带 kind）
+assert.equal(client.__test.toolText(null), null);
+assert.equal(
+  client.__test.toolText({ kind: "tool-result", content: [{ type: "text", text: "a" }, { type: "text", text: "b" }] }),
+  "ab",
+);
+assert.equal(client.__test.toolText({ kind: "tool-result", content: [{ type: "image", text: "x" }] }), "");
+assert.equal(client.__test.toolText({ name: "x" }), null); // running block 无 kind/content
+
+// runId 解析：canvas_run_workflow 结果 JSON
+assert.equal(client.__test.runIdFromText('{"started":true,"runId":"run_123"}'), "run_123");
+assert.equal(client.__test.runIdFromText("画布尚未打开或未上报图。"), null);
+assert.equal(client.__test.runIdFromText(null), null);
+assert.equal(client.__test.runIdFromText('{"ok":true}'), null);
+
+// 运行状态 → 卡片状态点
+assert.equal(client.__test.runDotState({ status: "success" }), "success");
+assert.equal(client.__test.runDotState({ status: "running" }), "running");
+assert.equal(client.__test.runDotState({ status: "error" }), "error");
+assert.equal(client.__test.runDotState({ status: "waiting" }), "waiting");
+assert.equal(client.__test.runDotState({ status: "canceled" }), "error");
+assert.equal(client.__test.runDotState(null, "running"), "running");
+assert.equal(client.__test.runDotState(null), "running"); // 无数据按运行中
+
+// GraphPatchCard：running（无 content）→ 应用中；settled 成功带 lint 通过 → 已应用；
+// settled isError → 被拒绝。args 解析从 call.argsRaw（JSON 字符串）。
+function patchCardOf(block) {
+  const calls = [];
+  const reactShim = {
+    createElement(tag, props, ...children) {
+      calls.push({ tag, props, children });
+      return { tag, props, children };
+    },
+    useRef() { return { current: null }; },
+    useState(v) { return [v, () => {}]; },
+    useEffect() {},
+    useMemo(fn) { return fn(); },
+  };
+  const saved = globalThis.__wf1ReactShim;
+  // 直接在 vm context 里再 require 一次 react shim 太重；组件只依赖参数化 react——
+  // 借 exports.__test 拿组件后以 shim 调用不可行（闭包引用模块级 react），
+  // 所以这里改为：走 vm 重跑 bundle，react require 返回 shim。
+  return { calls, reactShim, saved };
+}
+// 简化：GraphPatchCard/WorkflowRunCard 的渲染链在 vm 内闭包引用 react——
+// 用第二批 vm context 以 react shim 加载，专门渲染卡片组件断言 props。
+let cardClient;
+const cardCalls = [];
+const cardContext = {
+  window: {
+    localStorage: { getItem() { return null; } },
+    __ModuleLoader__: {
+      load({ factory }) {
+        cardClient = factory((name) => {
+          if (name === "react")
+            return {
+              createElement(tag, props, ...children) {
+                cardCalls.push({ tag, props, children });
+                return { tag, props, children };
+              },
+              useRef() { return { current: null }; },
+              useState(v) { return [v, () => {}]; },
+              useEffect() {},
+              useMemo(fn) { return fn(); },
+            };
+          throw new Error(`unexpected require: ${name}`);
+        });
+      },
+    },
+  },
+  document: {
+    head: { appendChild() {} },
+    createElement() { return {}; },
+    getElementById() { return null; },
+  },
+  console,
+};
+vm.runInNewContext(bundle, cardContext, {
+  filename: "dsh-ccpg-canvasui/src/client.js",
+});
+
+// GraphPatchCard：running（argsRaw 携带 ops）
+cardCalls.length = 0;
+cardClient.__test.GraphPatchCard({
+  block: { name: "canvas_graph_patch", argsRaw: JSON.stringify({ ops: [{ op: "addNode" }, { op: "addNode" }, { op: "connect" }] }) },
+});
+{
+  const shell = cardCalls.findLast((c) => c.props && c.props.className === "wf1-card");
+  assert.ok(shell, "建图卡应渲染卡片骨架");
+  const state = cardCalls.findLast((c) => c.props && c.props.className === "wf1-card-state");
+  const dot = cardCalls.findLast((c) => c.props && c.props.className === "wf1-card-dot");
+  assert.equal(dot.props["data-s"], "running");
+  const meta = cardCalls.findLast((c) => c.props && c.props.className === "wf1-card-meta");
+  assert.equal(meta.children && meta.children[0], "2 加节点、1 连线");
+}
+
+// GraphPatchCard：settled 成功（lint 通过）
+cardCalls.length = 0;
+cardClient.__test.GraphPatchCard({
+  block: {
+    kind: "tool-result",
+    isError: false,
+    call: { name: "canvas_graph_patch", argsRaw: JSON.stringify({ ops: [{ op: "addNode" }] }) },
+    content: [{ type: "text", text: "已应用 1 个操作到画布。\nlint: 通过" }],
+  },
+});
+{
+  const dot = cardCalls.findLast((c) => c.props && c.props.className === "wf1-card-dot");
+  assert.equal(dot.props["data-s"], "success");
+}
+
+// GraphPatchCard：settled 拒绝（isError）
+cardCalls.length = 0;
+cardClient.__test.GraphPatchCard({
+  block: {
+    kind: "tool-result",
+    isError: true,
+    call: { name: "canvas_graph_patch", argsRaw: JSON.stringify({ ops: [{ op: "bogus" }] }) },
+    content: [{ type: "text", text: "整批拒绝（未做任何修改）" }],
+  },
+});
+{
+  const dot = cardCalls.findLast((c) => c.props && c.props.className === "wf1-card-dot");
+  assert.equal(dot.props["data-s"], "error");
+}
+
+// WorkflowRunCard：结果不可解析（画布未开）→ 文本降级卡，仍可点
+cardCalls.length = 0;
+cardClient.__test.WorkflowRunCard({
+  block: {
+    kind: "tool-result",
+    isError: false,
+    content: [{ type: "text", text: "画布尚未打开或未上报图。" }],
+  },
+});
+{
+  const dot = cardCalls.findLast((c) => c.props && c.props.className === "wf1-card-dot");
+  assert.equal(dot.props["data-s"], "pending");
+}
 
 console.log("canvasui client tests: passed");

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -212,28 +212,9 @@ assert.equal(client.__test.runDotState({ status: "canceled" }), "error");
 assert.equal(client.__test.runDotState(null, "running"), "running");
 assert.equal(client.__test.runDotState(null), "running"); // 无数据按运行中
 
-// GraphPatchCard：running（无 content）→ 应用中；settled 成功带 lint 通过 → 已应用；
-// settled isError → 被拒绝。args 解析从 call.argsRaw（JSON 字符串）。
-function patchCardOf(block) {
-  const calls = [];
-  const reactShim = {
-    createElement(tag, props, ...children) {
-      calls.push({ tag, props, children });
-      return { tag, props, children };
-    },
-    useRef() { return { current: null }; },
-    useState(v) { return [v, () => {}]; },
-    useEffect() {},
-    useMemo(fn) { return fn(); },
-  };
-  const saved = globalThis.__wf1ReactShim;
-  // 直接在 vm context 里再 require 一次 react shim 太重；组件只依赖参数化 react——
-  // 借 exports.__test 拿组件后以 shim 调用不可行（闭包引用模块级 react），
-  // 所以这里改为：走 vm 重跑 bundle，react require 返回 shim。
-  return { calls, reactShim, saved };
-}
-// 简化：GraphPatchCard/WorkflowRunCard 的渲染链在 vm 内闭包引用 react——
-// 用第二批 vm context 以 react shim 加载，专门渲染卡片组件断言 props。
+// 卡片组件渲染断言：GraphPatchCard/WorkflowRunCard 的渲染链在 vm 内闭包引用 react——
+// 用第二批 vm context 以 react shim 加载（createElement 记录调用），专门断言 props：
+// running → 应用中；settled 成功带 lint 通过 → 已应用；settled isError → 被拒绝。
 let cardClient;
 const cardCalls = [];
 const cardContext = {


### PR DESCRIPTION
## 背景

聊天里 AI 建图（canvas_graph_patch）和运行（canvas_run_workflow/run_status）此前只渲染官方 GenericToolCard 纯文本行——用户看不出建图进展、看不到运行状态，也没有入口进画布。方案调研确认官方 UI 提供 `tool.call.toolview` keyed slot（ask_user_question / cordis_run 同款机制），按工具名接管即可，画布（web/）与 orchestrator 零改动。

## 实现（全部在 canvasui src/client.js，+485 行）

- **GraphPatchCard 建图卡**：running 即显示操作摘要「N 加节点、M 连线」（args 即时解析）；settle 后状态章「已应用 / 已应用·有告警 / 被拒绝」
- **WorkflowRunCard 运行卡**：解析 runId → 同源轮询 `/wf1/api/runs/detail`（2s，终态即停）；节点完成度、当前执行节点、耗时/错误；自绘 SVG 缩略图（graph 自带坐标，点色=状态）
- **降级**：画布未开/未绑定 → 文本降级卡；运行不在当前工作区 → 「已归档」
- **交互**：整卡点击 → openWorkflowSidebar()（better-sidebar）；未装则 window.open('/wf1/')；视觉全走官方 --dsw-alias-* token

## 验证

- ✅ 单测：client.test.mjs 新增纯函数（toolText/runIdFromText/runDotState）+ 双组件四态渲染断言；npm test 全量绿
- ✅ E2E 真实浏览器：侧栏画布绑定会话 → 聊天下发建图指令 → 消息流出现「建图 · 3 加节点、2 连线 已应用·有告警」卡 → 点击卡片 → 侧栏画布聚焦且新增「巡检报告→摘要→输出」三节点确认在图
- ✅ build-canvasui.sh --check 通过（bundle 与源一致）

## 截图（E2E 快照节选）

消息流内卡片实际渲染：
> button "建图 · 3 加节点、2 连线 已应用·有告警 3 加节点、2 连线 · lint 有告警 打开画布 ↗"