### PR TITLE
fix(canvasui): run_status 卡从 args 解析 runId，修加载窗口空指针

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -138,11 +138,21 @@ window.__ModuleLoader__.load({
         .join("");
     }
 
-    // canvas_run_workflow 结果 JSON 里的 runId（execute 返回 {started:true,runId} 字符串）
+    // canvas_run_workflow 结果 JSON 里的 runId（execute 返回 {started:true,runId} 字符串）；
+    // canvas_run_status 的结果没有 runId，从 args 里取（组件用 props.toolName 区分）。
     function runIdFromText(text) {
       if (!text) return null;
       try {
         var v = JSON.parse(text);
+        return v && typeof v === "object" && typeof v.runId === "string" ? v.runId : null;
+      } catch (e) {
+        return null;
+      }
+    }
+    function runIdFromArgs(argsRaw) {
+      if (!argsRaw) return null;
+      try {
+        var v = typeof argsRaw === "string" ? JSON.parse(argsRaw) : argsRaw;
         return v && typeof v === "object" && typeof v.runId === "string" ? v.runId : null;
       } catch (e) {
         return null;
@@ -260,9 +270,12 @@ window.__ModuleLoader__.load({
     function WorkflowRunCard(props) {
       var block = props.block || {};
       var text = toolText(block);
+      // runId 双源：canvas_run_workflow 从结果 JSON 解析；canvas_run_status 结果没有
+      // runId，从调用 args 取（running/settled 两个阶段都带）。
+      var argsRaw = (block.call && block.call.argsRaw) || block.argsRaw;
       var runId = react.useMemo(
-        function () { return runIdFromText(text); },
-        [text],
+        function () { return runIdFromText(text) || runIdFromArgs(argsRaw); },
+        [text, argsRaw],
       );
       var sessionId = currentDshSessionId(null);
       var [run, setRun] = react.useState(null);
@@ -308,6 +321,17 @@ window.__ModuleLoader__.load({
           dotState: "pending",
           stateText: "已归档",
           meta: "运行 " + runId.slice(0, 8) + "… 记录不在当前工作区",
+          thumbnail: null,
+        });
+      }
+      if (!run) {
+        // runId 已解析、首次详情未返回的窗口（真实环境 <2s）：渲染加载态，
+        // 不读 run.status（此前这里直接空指针）
+        return workflowCardShell({
+          title: "工作流运行",
+          dotState: "running",
+          stateText: "加载中",
+          meta: "运行 " + runId.slice(0, 8) + "…",
           thumbnail: null,
         });
       }
@@ -729,6 +753,7 @@ window.__ModuleLoader__.load({
       subscribeSidebarService: subscribeSidebarService,
       toolText: toolText,
       runIdFromText: runIdFromText,
+      runIdFromArgs: runIdFromArgs,
       runDotState: runDotState,
       WorkflowRunCard: WorkflowRunCard,
       GraphPatchCard: GraphPatchCard,

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -197,11 +197,14 @@ assert.equal(
 assert.equal(client.__test.toolText({ kind: "tool-result", content: [{ type: "image", text: "x" }] }), "");
 assert.equal(client.__test.toolText({ name: "x" }), null); // running block 无 kind/content
 
-// runId 解析：canvas_run_workflow 结果 JSON
+// runId 解析：canvas_run_workflow 结果 JSON；canvas_run_status 从 args 取
 assert.equal(client.__test.runIdFromText('{"started":true,"runId":"run_123"}'), "run_123");
 assert.equal(client.__test.runIdFromText("画布尚未打开或未上报图。"), null);
 assert.equal(client.__test.runIdFromText(null), null);
 assert.equal(client.__test.runIdFromText('{"ok":true}'), null);
+assert.equal(client.__test.runIdFromArgs('{"runId":"run_456"}'), "run_456");
+assert.equal(client.__test.runIdFromArgs({ runId: "run_789" }), "run_789");
+assert.equal(client.__test.runIdFromArgs(null), null);
 
 // 运行状态 → 卡片状态点
 assert.equal(client.__test.runDotState({ status: "success" }), "success");
@@ -307,6 +310,26 @@ cardClient.__test.WorkflowRunCard({
 {
   const dot = cardCalls.findLast((c) => c.props && c.props.className === "wf1-card-dot");
   assert.equal(dot.props["data-s"], "pending");
+}
+
+// WorkflowRunCard：canvas_run_status 形状（结果无 runId，args 携带）→ 从 args 解析，
+// 不再落入降级态（此前整段 JSON 塞进 meta 的 bug 回归）
+cardCalls.length = 0;
+cardClient.__test.WorkflowRunCard({
+  toolName: "canvas_run_status",
+  block: {
+    kind: "tool-result",
+    isError: false,
+    call: { name: "canvas_run_status", argsRaw: JSON.stringify({ runId: "run_status_case" }) },
+    content: [{ type: "text", text: '{"status":"success","nodeStates":{}}' }],
+  },
+});
+{
+  // useEffect 不跑（shim），轮询未启动——但 runId 已解析成功，卡片不应再走
+  // 「就绪 + JSON 塞 meta」的降级分支（title 会带 run 详情态而非“就绪”状态章）
+  const meta = cardCalls.findLast((c) => c.props && c.props.className === "wf1-card-meta");
+  const metaText = meta.children && meta.children[0];
+  assert.ok(!String(metaText).startsWith("{"), "run_status 卡不应把结果 JSON 塞进 meta");
 }
 
 console.log("canvasui client tests: passed");


### PR DESCRIPTION
## 背景

节点密度实测（API 构造 20/50/100 节点受控运行 + 真实对话让 AI 调 canvas_run_status 查询）暴露 #4 遗留的两个 bug。

## 修复

1. **run_status 卡降级态 bug**：`canvas_run_status` 的结果 JSON 顶层没有 `runId`（形状是 `{status, nodeStates, outputs}`），原 `runIdFromText` 只认 `{started,runId}` → 解析失败落入降级态：状态章「就绪」+ 整段 JSON 塞进 meta。修法：runId 双源——结果解析不到时从调用 args 取（`args.runId` 必带，running/settled 都在）
2. **加载窗口空指针**：runId 解析成功但首次详情未返回的窗口（<2s）直读 `run.status` 崩溃——真实环境被快速 fetch 遮住，测试 shim（useEffect 不跑）暴露。修法：补「加载中」渲染态

## 验证

- ✅ 密度实测：20/50/100 节点链式图（脚本节点，零 LLM）三档运行全部 success；修复前 run_status 卡三张全部错误落入降级态（截图存档）
- ✅ 单测：runIdFromArgs 三例 + run_status 形状回归 + 加载态分支；全量 npm test 绿
- ✅ bundle --check 一致

## 密度结论（本次实测附带）

缩略图在 300×88 viewBox 内按 bounds 等比缩放，>24 节点自动缩点（4.5→3px）。链式拓扑在 100 节点时能看出行列结构，状态色仍可辨；卡片头部的 x/y 完成度计数不受密度影响（这才是密集图的主要信息通道）。缩略图在密集图下的定位是「趋势感」，精确状态看头部计数与画布。