### PR TITLE
fix(orchestrator): 产物预览 409/404 修复 + 断点续跑 + 成果面板关闭按钮

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
@@ -76,6 +76,7 @@ export class Orchestrator {
   async run(graph, {
     triggerInput = '', runId, workflowName, workflowId, canvasId, source, workspaceRoot,
     globalVariables = {}, workflowVariables = {}, runInputs = {},
+    resume = null,
   } = {}) {
     const id = runId || `run_${Date.now().toString(36)}_${++runSeq}`;
     const safeRunInputs = structuredClone(runInputs || {});
@@ -86,6 +87,7 @@ export class Orchestrator {
       schemaVersion: RUN_SCHEMA_VERSION,
       nodeStates: {}, outputs: {}, structuredOutputs: {}, nodeOrder: [],
       canceled: false,
+      ...(resume ? { resumedFrom: resume.runId || null } : {}),
     };
     const s = {
       run, graph,
@@ -137,6 +139,38 @@ export class Orchestrator {
       });
       this.runs.delete(id);
       return run;
+    }
+
+    // ---- 断点续跑：把上次运行中 success 节点的输出/结构化输出搬进本次运行 ----
+    // 图一致才可续跑（入口 startRun 已做 fingerprint 校验；这里只搬运）。
+    // 对每个 success 节点：写 outputs/nodeStates、释放直接下游依赖计数，
+    // 并按原判定回放分支跳过（与 _onNodeDone 同语义）。
+    if (resume?.nodeStates) {
+      const prior = resume;
+      for (const n of graph.nodes) {
+        const st = prior.nodeStates[n.id];
+        if (!st || st.status !== 'success') continue;
+        const restored = { ...st, resumed: true };
+        // startedAt/durationMs 保留原值：续跑报告的耗时语义是“这些节点没再花时间”
+        run.outputs[n.id] = prior.outputs?.[n.id] ?? '';
+        if (prior.structuredOutputs?.[n.id] !== undefined) {
+          run.structuredOutputs[n.id] = prior.structuredOutputs[n.id];
+        }
+        run.nodeStates[n.id] = restored;
+        run.nodeOrder.push(n.id);
+        this.emit('node-status', { runId: id, nodeId: n.id, status: 'success', resumed: true, ...(st.chars != null ? { chars: st.chars } : {}) });
+        for (const next of s.outgoing.get(n.id) || []) {
+          if (this._edgeTaken(s, n.id, next)) {
+            s.pendingDeps.set(next, s.pendingDeps.get(next) - 1);
+          } else if (s.run.nodeStates[next] === undefined) {
+            s.remaining -= 1;
+            s.run.nodeStates[next] = { status: 'skipped', error: '条件分支未命中' };
+            this.emit('node-status', { runId: id, nodeId: next, status: 'skipped', error: '条件分支未命中' });
+            this._propagateSkip(s, next);
+          }
+        }
+        s.remaining -= 1;
+      }
     }
 
     this.emit('run-start', {

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -28,6 +28,7 @@ import { describeNodeOutput, normalizeExecutionResult, RUN_SCHEMA_VERSION } from
 import { resolveInside, safeFileId, safeFilename } from './safe-path.js';
 import { runScript } from './script-runner.js';
 import {
+  artifactId as runArtifactId,
   createRunExport,
   createRunResults,
   isPreviewableMediaType,
@@ -609,7 +610,7 @@ export function apply(ctx, config) {
 
   const startRun = (graph, {
     triggerInput, workflowName, workflowId, canvasId, source,
-    globalVariables = {}, workflowVariables = {}, runInputs = {}, runId: providedRunId, replayOf,
+    globalVariables = {}, workflowVariables = {}, runInputs = {}, runId: providedRunId, replayOf, resume,
   } = {}) => {
     const store = currentStore();
     const runId = providedRunId || `run_${Date.now().toString(36)}_${++runIdSeq}`;
@@ -620,6 +621,7 @@ export function apply(ctx, config) {
         runId, status: 'running', startedAt: new Date().toISOString(),
         triggerInput: triggerInput ?? '', workflowName: workflowName || null, workflowId: workflowId || null,
         canvasId: canvasId || null, source: source || null, replayOf: replayOf || null,
+        ...(resume ? { resumedFrom: resume.runId || null } : {}),
         nodeStates: {}, outputs: {}, structuredOutputs: {}, issues: [],
         graph: graph ? { nodes: graph.nodes.map((n) => ({ id: n.id, type: n.type, position: n.position, data: n.data })), edges: graph.edges } : undefined,
         graphFingerprint: graph ? graphFingerprint(graph) : null,
@@ -629,6 +631,7 @@ export function apply(ctx, config) {
       triggerInput, workflowName, workflowId, canvasId, source, runId,
       workspaceRoot: store.workspaceRoot,
       globalVariables, workflowVariables, runInputs,
+      resume,
     })).then((run) => {
       if (replayOf) run.replayOf = replayOf;
       persistRun(run, graph, workflowName, workflowId);
@@ -1333,10 +1336,31 @@ export function apply(ctx, config) {
   // ---- 运行历史 ----
   register({ kind: 'exact', path: '/wf1/api/runs', handler(_req, res) {
     const live = [...orch.runs.values()].filter((entry) => entry.run.workspaceRoot === currentStore().workspaceRoot).map((entry) => entry.run.runId);
+    const runProgress = (r) => {
+      // 进度 = 终态节点数 / 图节点数。passThrough 注释节点通常不进 nodeStates，用图快照兜底总数。
+      const total = (r.graph?.nodes?.length ?? Object.keys(r.nodeStates || {}).length) || Object.keys(r.nodeStates || {}).length;
+      const done = Object.values(r.nodeStates || {}).filter((st) => ['success', 'error', 'canceled', 'skipped'].includes(st?.status)).length;
+      const succeeded = Object.values(r.nodeStates || {}).filter((st) => st?.status === 'success').length;
+      return { done, total, succeeded };
+    };
+    const resumable = (r, isLive) => !isLive
+      && ['error', 'canceled'].includes(r.status)
+      && Boolean(r.graph?.nodes?.length)
+      && Object.values(r.nodeStates || {}).some((st) => st?.status === 'success')
+      && Object.values(r.nodeStates || {}).some((st) => !['success', 'skipped'].includes(st?.status));
     json(res, 200, {
       runs: runHistory.slice(0, 20).map((r) => {
         const { structuredOutputs, graph, ...summary } = r;
-        return { ...summary, outputs: summarizeOutputs(summary.outputs, structuredOutputs), nodeStates: summarizeNodeStates(summary.nodeStates), structuredOutputSummary: summarizeStructuredOutputs(structuredOutputs), live: live.includes(r.runId) };
+        const isLive = live.includes(r.runId);
+        return {
+          ...summary,
+          outputs: summarizeOutputs(summary.outputs, structuredOutputs),
+          nodeStates: summarizeNodeStates(summary.nodeStates),
+          structuredOutputSummary: summarizeStructuredOutputs(structuredOutputs),
+          live: isLive,
+          progress: runProgress(r),
+          resumable: resumable(r, isLive),
+        };
       }),
     });
   } });
@@ -1501,6 +1525,45 @@ export function apply(ctx, config) {
       source: 'replay', replayOf: prev.runId,
     });
     json(res, 200, { started: true, runId, replayOf: prev.runId });
+  } });
+
+  // 断点续跑：从上次运行的 success 节点之后继续。图必须与上次一致（fingerprint），
+  // 否则产物/模板引用对不上——提示用户重新运行。
+  register({ kind: 'exact', path: '/wf1/api/runs/resume', async handler(req, res) {
+    if (req.method !== 'POST') return json(res, 405, { error: 'method' });
+    const body = await readBody(req);
+    const prev = readRun(body?.runId);
+    if (!prev) return json(res, 404, { error: '运行记录不存在' });
+    if (orch.runs.has(prev.runId)) return json(res, 409, { error: '该运行仍在进行中', code: 'run-live' });
+    if (!prev.graph || !Array.isArray(prev.graph.nodes)) return json(res, 400, { error: '该运行没有图快照，无法续跑' });
+    const succeeded = Object.values(prev.nodeStates || {}).filter((st) => st?.status === 'success');
+    if (!succeeded.length) return json(res, 400, { error: '该运行没有已完成的节点，无需续跑', code: 'nothing-to-resume' });
+    // 图来源：优先当前画布图（可能是保存后的同名图），须与上次 fingerprint 一致
+    let graph = body.graph || prev.graph;
+    if (body.graphFingerprint && body.graphFingerprint !== graphFingerprint(body.graph)) {
+      return json(res, 400, { error: '画布图与请求指纹不一致', code: 'graph-fingerprint-mismatch' });
+    }
+    if (graphFingerprint(graph) !== prev.graphFingerprint) {
+      return json(res, 409, {
+        error: '画布图已修改，与上次运行不一致；请重新运行或还原画布',
+        code: 'workflow-graph-mismatch',
+      });
+    }
+    // 沿用上次的触发输入与运行输入：续跑语义是“同样的输入，只补跑没跑完的节点”
+    const triggerInput = String(prev.triggerInput || '');
+    let runInputs; try { runInputs = assertSafeContextObject(prev.runInputs, 'runInputs'); } catch (error) { return routeError(res, error); }
+    let globals; try { globals = globalContext(); } catch (error) { return routeError(res, error); }
+    const persistedWorkflow = prev.workflowId ? readWf(prev.workflowId) : null;
+    const workflowVariables = variableDefinitionsToValues(persistedWorkflow?.variables || []);
+    const lint = lintGraph(graph);
+    if (!lint.ok) return json(res, 400, { error: lint.issues.find((i) => i.level === 'error').message, lint });
+    const { runId } = startRun(graph, {
+      triggerInput, workflowName: prev.workflowName || null, workflowId: prev.workflowId || null,
+      canvasId: body.canvasId || prev.canvasId || null,
+      globalVariables: globals.globalVariables, workflowVariables, runInputs,
+      source: 'resume', resume: prev,
+    });
+    json(res, 200, { started: true, runId, resumedFrom: prev.runId, resumedNodes: succeeded.length });
   } });
 
   // 工作流导出 / 导入（画布间分享：{ name, graph } 单文件）

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -1357,7 +1357,9 @@ export function apply(ctx, config) {
     if (!id) return json(res, 400, { error: '缺少 id' });
     const run = readRun(id);
     if (!run) return json(res, 404, { error: '运行记录不存在' });
-    return json(res, 200, createRunResults(run));
+    // 产物 URL 回传给前端后会被直接 fetch，必须继承本次请求的会话标识
+    const sessionId = url.searchParams.get('sessionId') || req.headers?.['x-wf1-session'] || '';
+    return json(res, 200, createRunResults(run, { sessionId }));
   } });
 
   const artifactLocationsForRun = (run) => ({

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -1861,12 +1861,47 @@ export function apply(ctx, config) {
     json(res, 405, { error: 'method' });
   } });
 
-  // ---- 产物下载/预览：?node=&file=&preview=1 读该节点工作区文件 ----
+  // ---- 产物下载/预览 ----
+  // 新格式 ?run=&node=<nodeId>&file=：运行文档 artifactIndex 命中则走快照目录，
+  // 未命中（运行中试运行尚未持久化）则直接解析该 run 的节点工作区。
+  // 旧格式 ?node=<label>&file= 读 legacy data/workspaces/<label>/，仅兼容旧数据。
   register({ kind: 'exact', path: '/wf1/api/artifact', async handler(req, res) {
     const url = new URL(req.url, 'http://x');
-    const nodeLabel = safeFileId(url.searchParams.get('node') || '', '');
+    const runId = url.searchParams.get('run') || '';
     const file = url.searchParams.get('file') || '';
-    if (!nodeLabel || !file) return json(res, 400, { error: '需要 node 和 file' });
+    const nodeParam = url.searchParams.get('node') || '';
+    if (!runId && !nodeParam) return json(res, 400, { error: '需要 node 和 file' });
+    if (!file) return json(res, 400, { error: '需要 node 和 file' });
+    if (runId) {
+      // node 参数是 nodeId；artifactId 生成规则与 snapshotRunArtifacts 一致（run-results.js）
+      const run = readRun(runId);
+      const artifactId = runArtifactId(nodeParam, file);
+      const resolved = run && resolveRunArtifact(artifactLocationsForRun(run), run, artifactId);
+      if (resolved) {
+        const mediaType = resolved.artifact.mediaType || mediaTypeFor(resolved.artifact.name);
+        const preview = url.searchParams.get('preview') === '1'
+          && resolved.artifact.previewable
+          && isPreviewableMediaType(mediaType);
+        return streamArtifactResponse(req, res, {
+          file: resolved.file, filename: resolved.artifact.name, mediaType, preview,
+        });
+      }
+      // 运行中/试运行：运行文档还没有快照，直接从节点工作区解析
+      const ws = resolveInside(STORAGE.workspaceForNode({
+        workflowId: run?.workflowId || 'draft', runId, nodeId: nodeParam,
+      }), file);
+      if (ws && existsSync(ws) && statSync(ws).isFile()) {
+        const realWsParent = realpathSync(dirname(ws));
+        const realWs = realpathSync(ws);
+        if (resolveInside(realWsParent, realWs) === realWs) {
+          const mediaType = mediaTypeFor(file);
+          const preview = url.searchParams.get('preview') === '1' && isPreviewableMediaType(mediaType);
+          return streamArtifactResponse(req, res, { file: realWs, filename: file, mediaType, preview });
+        }
+      }
+      return json(res, 404, { error: '产物不存在' });
+    }
+    const nodeLabel = safeFileId(nodeParam, '');
     const dir = resolveInside(STORAGE.legacy.workspaces, nodeLabel);
     const full = dir && resolveInside(dir, file);
     if (!dir || !full || !existsSync(full) || !statSync(full).isFile()) {

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/run-results.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/run-results.js
@@ -106,7 +106,7 @@ export function streamArtifactResponse(req, res, { file, filename, mediaType, pr
 
 const clone = (value) => value == null ? value : structuredClone(value);
 const nodeLabel = (run, nodeId) => (run.graph?.nodes || []).find((node) => node.id === nodeId)?.data?.label || nodeId;
-const artifactId = (nodeId, relativePath) => createHash('sha256').update(`${nodeId}\0${relativePath}`).digest('hex').slice(0, 24);
+export const artifactId = (nodeId, relativePath) => createHash('sha256').update(`${nodeId}\0${relativePath}`).digest('hex').slice(0, 24);
 const asIso = (value) => {
   if (!value) return null;
   const date = new Date(value);
@@ -326,7 +326,10 @@ function extractHttpLinks(text) {
   return [...new Set(matches)].map((url) => ({ type: 'output', url }));
 }
 
-export function createRunResults(value, { apiBase = '/wf1/api' } = {}) {
+// 产物 URL 必须带 sessionId：scoped 路由靠它定位会话工作目录，缺了会 409 workspace-session-required。
+// 默认 '' 保持 createRunExport 等无会话场景的 URL 形状不变。
+export function createRunResults(value, { apiBase = '/wf1/api', sessionId = '' } = {}) {
+  const sessionQuery = sessionId ? `&sessionId=${encodeURIComponent(sessionId)}` : '';
   const run = normalizeRunDocument(value);
   const rows = orderedGraphNodes(run).map((node) => resultRow(run, node));
   const configuredOutputs = rows.filter((row) => row.nodeType === 'output');
@@ -350,8 +353,8 @@ export function createRunResults(value, { apiBase = '/wf1/api' } = {}) {
     mediaType: artifact.mediaType,
     previewable: Boolean(artifact.previewable),
     sha256: artifact.sha256,
-    downloadUrl: `${apiBase}/run-artifact?run=${encodeURIComponent(run.runId)}&artifact=${encodeURIComponent(artifact.id)}`,
-    previewUrl: artifact.previewable ? `${apiBase}/run-artifact?run=${encodeURIComponent(run.runId)}&artifact=${encodeURIComponent(artifact.id)}&preview=1` : null,
+    downloadUrl: `${apiBase}/run-artifact?run=${encodeURIComponent(run.runId)}&artifact=${encodeURIComponent(artifact.id)}${sessionQuery}`,
+    previewUrl: artifact.previewable ? `${apiBase}/run-artifact?run=${encodeURIComponent(run.runId)}&artifact=${encodeURIComponent(artifact.id)}&preview=1${sessionQuery}` : null,
   }));
   const outputNodeIds = new Set(configuredOutputs.map((row) => row.nodeId));
   const outputArtifacts = artifacts.filter((artifact) => outputNodeIds.has(artifact.nodeId));

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/engine-resume.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/engine-resume.test.mjs
@@ -1,0 +1,146 @@
+// 断点续跑（resume 种子）引擎离线单测。
+// 用法：node test/engine-resume.test.mjs
+import assert from 'node:assert/strict';
+import { Orchestrator } from '../lib/engine.js';
+
+const renderTemplate = (tpl, ctx) => {
+  const upstream = ctx.incomingIds.length ? ctx.incomingIds.map((id) => `── 来自 [${ctx.labels.get(id) || id}] ──\n${ctx.outputs.get(id) || ''}`).join('\n\n') : '';
+  let text = String(tpl ?? '');
+  text = text.replaceAll('{{$upstream}}', upstream);
+  for (const id of ctx.incomingIds) {
+    const label = ctx.labels.get(id) || id;
+    text = text.replaceAll(`{{${label}}}`, ctx.outputs.get(id) || '');
+  }
+  return { text };
+};
+
+let passed = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ✓ ${name}`);
+  } catch (e) {
+    console.error(`  ✗ ${name}\n    ${e.message}`);
+    process.exitCode = 1;
+  }
+}
+
+const makeOrch = (runner) => {
+  const events = [];
+  const orch = new Orchestrator(null, { onEvent: (e, p) => events.push([e, p]), renderTemplate });
+  if (runner) orch.nodeRunner = runner;
+  return { orch, events };
+};
+
+// 三节点链：in(输入) → mid(agent) → out(输出)；in 成功、mid 失败的“半程”运行
+const chainGraph = () => ({
+  nodes: [
+    { id: 'in', type: 'input', data: { label: '输入', text: 'hello' } },
+    { id: 'mid', type: 'agent', data: { label: '中转' } },
+    { id: 'out', type: 'output', data: { label: '汇总' } },
+  ],
+  edges: [
+    { source: 'in', target: 'mid' },
+    { source: 'mid', target: 'out' },
+  ],
+});
+
+console.log('engine resume tests:');
+
+await test('续跑：success 节点免重跑，只执行未完成部分', async () => {
+  const calls = [];
+  const { orch: orch1 } = makeOrch(async (node) => {
+    calls.push(node.id);
+    if (node.id === 'mid') throw new Error('模拟中途失败');
+    return `out:${node.id}`;
+  });
+  const first = await orch1.run(chainGraph(), { runId: 'run_half' });
+  assert.equal(first.status, 'error');
+  assert.equal(first.nodeStates.in.status, 'success');
+  assert.equal(first.nodeStates.mid.status, 'error');
+  assert.equal(first.nodeStates.out.status, 'skipped');
+
+  // 续跑：mid 换成成功 runner；in 不应再执行
+  const calls2 = [];
+  const { orch: orch2, events } = makeOrch(async (node) => {
+    calls2.push(node.id);
+    return `out2:${node.id}`;
+  });
+  const resumed = await orch2.run(chainGraph(), {
+    runId: 'run_resume',
+    resume: {
+      runId: 'run_half',
+      nodeStates: first.nodeStates,
+      outputs: first.outputs,
+      structuredOutputs: first.structuredOutputs,
+    },
+  });
+  assert.equal(resumed.status, 'success');
+  assert.deepEqual(calls2, ['mid']); // in 未重跑（input/output 走内置执行器，runner 只拦 agent）
+  // in 的输出被搬进新运行，out 能引用（渲染上游）
+  assert.match(resumed.outputs.out, /out2:mid/);
+  assert.equal(resumed.nodeStates.in.resumed, true);
+  assert.equal(resumed.nodeStates.in.status, 'success');
+  assert.equal(resumed.resumedFrom, 'run_half');
+  // SSE：恢复节点发 success(resumed) 事件，前端能立即点亮
+  const restored = events.find(([e, p]) => e === 'node-status' && p.resumed);
+  assert.equal(restored[1].nodeId, 'in');
+});
+
+await test('续跑：条件分支跳过按原判定回放', async () => {
+  // in → cond(条件) → a(true 分支)/b(false 分支)
+  const graph = () => ({
+    nodes: [
+      { id: 'in', type: 'input', data: { label: '输入', text: '紧急报修' } },
+      { id: 'cond', type: 'condition', data: { label: '判定', include: '紧急' } },
+      { id: 'a', type: 'agent', data: { label: '加急' } },
+      { id: 'b', type: 'agent', data: { label: '普通' } },
+    ],
+    edges: [
+      { source: 'in', target: 'cond' },
+      { source: 'cond', target: 'a', branch: 'true' },
+      { source: 'cond', target: 'b', branch: 'false' },
+    ],
+  });
+  // 第一次：in/cond 成功，a 失败
+  const { orch: orch1 } = makeOrch(async (node) => {
+    if (node.id === 'a') throw new Error('a 挂了');
+    return `ok:${node.id}`;
+  });
+  const first = await orch1.run(graph(), { runId: 'run_branch' });
+  assert.equal(first.nodeStates.b.status, 'skipped');
+
+  // 续跑：cond 是 success，其 false 边依旧跳过 b；只重跑 a
+  const calls = [];
+  const { orch: orch2 } = makeOrch(async (node) => {
+    calls.push(node.id);
+    return `ok2:${node.id}`;
+  });
+  const resumed = await orch2.run(graph(), {
+    runId: 'run_branch_resume',
+    resume: {
+      runId: 'run_branch',
+      nodeStates: first.nodeStates,
+      outputs: first.outputs,
+      structuredOutputs: first.structuredOutputs,
+    },
+  });
+  assert.equal(resumed.status, 'success');
+  assert.deepEqual(calls, ['a']); // cond/b 都没重跑（b 维持 skipped）
+  assert.equal(resumed.nodeStates.b.status, 'skipped');
+});
+
+await test('续跑种子为空对象时行为等同全新运行', async () => {
+  const calls = [];
+  const { orch } = makeOrch(async (node) => {
+    calls.push(node.id);
+    return `ok:${node.id}`;
+  });
+  const run = await orch.run(chainGraph(), { runId: 'run_fresh' });
+  assert.equal(run.status, 'success');
+  assert.deepEqual(calls, ['mid']); // 全新运行：agent 节点照常执行
+  assert.equal(run.resumedFrom, undefined);
+});
+
+console.log(passed === 3 ? 'engine resume tests: ALL PASS' : 'engine resume tests: FAILED');

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { apply } from '../lib/index.js';
 
 function responseCapture() {
+  const listeners = new Map();
   return {
     status: 0,
     headers: {},
@@ -14,7 +15,10 @@ function responseCapture() {
     writeHead(status, headers = {}) { this.status = status; this.headers = headers; },
     write(chunk) { this.chunks.push(Buffer.from(chunk)); },
     end(chunk) { if (chunk) this.chunks.push(Buffer.from(chunk)); this.writableEnded = true; },
-    destroy(error) { throw error; },
+    on(event, callback) { listeners.set(event, callback); return this; },
+    once(event, callback) { const inner = listeners.get(event); listeners.set(event, () => { inner?.(); callback(); }); return this; },
+    emit(event) { listeners.get(event)?.(); return this; },
+    destroy(error) { if (error) throw error; },
     json() { return JSON.parse(Buffer.concat(this.chunks).toString('utf8') || '{}'); },
   };
 }
@@ -133,6 +137,57 @@ try {
   const missingSession = responseCapture();
   await route('/wf1/api/graph')(request('GET', '/wf1/api/graph'), missingSession);
   assert.equal(missingSession.status, 409);
+
+  // 产物预览链路：/run-results 回传的 URL 必须继承 sessionId，
+  // 前端原样 fetch 才不会撞 scoped 路由的 409 workspace-session-required。
+  const artifactRunRes = responseCapture();
+  await route('/wf1/api/run')(request('POST', withSession('/wf1/api/run', 'session-b'), {
+    graph: {
+      nodes: [
+        { id: 'input_src', type: 'input', position: { x: 0, y: 0 }, data: { label: '输入', text: 'hi' } },
+        { id: 'script_doc', type: 'script', position: { x: 0, y: 0 }, data: {
+          label: '写文件',
+          code: 'function main(input, workspace) { workspace.write("report.md", "# 成果"); return { ok: true }; }',
+          outputSchema: null,
+        } },
+      ],
+      edges: [{ source: 'input_src', target: 'script_doc' }],
+    },
+    triggerInput: '',
+  }), artifactRunRes);
+  assert.equal(artifactRunRes.status, 200);
+  const artifactRunId = artifactRunRes.json().runId;
+  let artifactRunDoc;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    artifactRunDoc = readdirSync(runsDirB)
+      .map((file) => JSON.parse(readFileSync(join(runsDirB, file), 'utf8')))
+      .find((run) => run.runId === artifactRunId);
+    if (artifactRunDoc && artifactRunDoc.status !== 'running') break;
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+  assert.equal(artifactRunDoc?.status, 'success');
+  assert.ok(artifactRunDoc.artifactIndex.length >= 1);
+
+  const resultsRes = responseCapture();
+  await route('/wf1/api/run-results')(request('GET', withSession(`/wf1/api/run-results?id=${artifactRunId}`, 'session-b')), resultsRes);
+  assert.equal(resultsRes.status, 200);
+  const artifactRow = resultsRes.json().artifacts.find((row) => row.name === 'report.md');
+  assert.ok(artifactRow, 'report.md 应在产物清单中');
+  assert.match(artifactRow.downloadUrl, /[?&]sessionId=session-b$/);
+  assert.match(artifactRow.previewUrl, /[?&]sessionId=session-b$/);
+
+  // 前端拿响应 URL 直接请求（相对路径挂在服务根上）：命中 scoped 会话应 200 而非 409
+  const previewPath = artifactRow.previewUrl.replace(/^https?:\/\/[^/]+/, '');
+  const previewRes = responseCapture();
+  await new Promise((resolve, reject) => {
+    previewRes.on('error', reject);
+    const origEnd = previewRes.end.bind(previewRes);
+    previewRes.end = (chunk) => { origEnd(chunk); resolve(); };
+    route('/wf1/api/run-artifact')(request('GET', previewPath), previewRes);
+  });
+  assert.equal(previewRes.status, 200);
+  assert.equal(previewRes.headers['Content-Type'], 'text/markdown; charset=utf-8');
+
   console.log('plugin storage integration tests: ALL PASS');
 } finally {
   if (original === undefined) delete process.env.DSH_HOME;

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/run-results.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/run-results.test.mjs
@@ -103,6 +103,23 @@ await test('run results use output nodes as final results and include every runt
   assert.equal(result.links[0].url, 'https://example.test/doc');
 });
 
+await test('artifact URLs inherit sessionId so scoped routes can resolve the workspace', () => {
+  const run = normalizeRunDocument({
+    ...baseRun(),
+    artifactIndex: [
+      { id: 'a2', nodeId: 'output', nodeLabel: '最终成果', name: 'final.pdf', relativePath: 'final.pdf', previewable: true },
+    ],
+  });
+  const withSession = createRunResults(run, { sessionId: 'sess/单 元' });
+  assert.equal(withSession.artifacts[0].downloadUrl,
+    '/wf1/api/run-artifact?run=run_test_1&artifact=a2&sessionId=sess%2F%E5%8D%95%20%E5%85%83');
+  assert.equal(withSession.artifacts[0].previewUrl,
+    '/wf1/api/run-artifact?run=run_test_1&artifact=a2&preview=1&sessionId=sess%2F%E5%8D%95%20%E5%85%83');
+  const withoutSession = createRunResults(run);
+  assert.equal(withoutSession.artifacts[0].downloadUrl, '/wf1/api/run-artifact?run=run_test_1&artifact=a2');
+  assert.equal(withoutSession.artifacts[0].previewUrl, '/wf1/api/run-artifact?run=run_test_1&artifact=a2&preview=1');
+});
+
 await test('non-technical generated artifacts become final when output nodes have no files', () => {
   const run = normalizeRunDocument({
     ...baseRun(),

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -256,7 +256,7 @@ export default function App() {
           if (p.outputPreview != null) data.runOutput = p.outputPreview;
           if (p.hasTrace) data.hasTrace = true;
           if (p.model) data.runtimeModel = p.model;
-          if (p.artifacts) data.artifacts = p.artifacts;
+          if (p.artifacts) { data.artifacts = p.artifacts; data.artifactsRunId = p.runId || null; }
           if (p.sessionId) data.sessionId = p.sessionId;
           return { ...n, data };
         })
@@ -396,7 +396,7 @@ export default function App() {
           if (st.error) data.runError = st.error;
           if (st.durationMs != null) data.durationMs = st.durationMs;
           if (st.model) data.runtimeModel = st.model;
-          if (st.artifacts) data.artifacts = st.artifacts;
+          if (st.artifacts) { data.artifacts = st.artifacts; data.artifactsRunId = p.runId || null; }
           if (st.sessionId) data.sessionId = st.sessionId;
           const out = (p.outputs || {})[nodeId];
           if (out != null) data.runOutput = String(out).slice(0, 4000);

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -78,6 +78,8 @@ export default function App() {
   const [focusLark, setFocusLark] = useState(false); // 从 ⋯ 打开设置时聚焦授权区
   const [testNode, setTestNode] = useState(null); // 试运行弹窗目标节点
   const [nodeDetail, setNodeDetail] = useState(null); // 日志行点击 → { runId, nodeId }
+  // 断点续跑选择弹窗：待启动的图 + 可续跑的上次运行
+  const [resumeChoice, setResumeChoice] = useState(null); // { lastRun, startFresh, startResume }
   const [feishuCreds, setFeishuCreds] = useState([]);
   const { screenToFlowPosition, fitView } = useReactFlow();
   const nodesRef = useRef(nodes);
@@ -654,33 +656,81 @@ export default function App() {
       toast(`无法运行：${error?.message || '保存失败'}`, 'error');
       return;
     }
-    setProgress({});
-    setNodes((nds) => nds.map((n) => ({ ...n, data: { ...n.data, runStatus: 'idle', runError: null, runOutput: undefined, runtimeStructuredOutput: undefined, livePreview: undefined, liveTurns: undefined, runTurns: undefined, runStartedAt: undefined } })));
-    const res = await fetch(apiUrl('/run'), {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        graph: saved.graph,
-        graphFingerprint: saved.graphFingerprint,
-        triggerInput,
-        runInputs,
-        workflowId: runWorkflowId,
-        workflowName: currentWf?.name,
-        canvasId: canvasIdRef.current,
-      }),
-    });
-    const data = await res.json();
-    if (!res.ok) toast(`启动失败：${data.error}`, 'error');
-    else {
-      const stillCurrentScope = workflowScopeEpochRef.current === runScopeEpoch
-        && currentWfIdRef.current === runWorkflowId;
-      if (data.runId && stillCurrentScope) {
-        activeRunIdRef.current = data.runId;
-        runningRef.current = true;
-        setInspectedRunId(data.runId);
-        setRunStatus((current) => ({ ...current, running: true, runId: data.runId, done: 0, total: graph.nodes.length }));
+    // 断点续跑：上次运行失败/取消且图未变时，让用户选重新跑还是接着跑
+    const startFresh = () => {
+      setProgress({});
+      setNodes((nds) => nds.map((n) => ({ ...n, data: { ...n.data, runStatus: 'idle', runError: null, runOutput: undefined, runtimeStructuredOutput: undefined, livePreview: undefined, liveTurns: undefined, runTurns: undefined, runStartedAt: undefined } })));
+      return fetch(apiUrl('/run'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          graph: saved.graph,
+          graphFingerprint: saved.graphFingerprint,
+          triggerInput,
+          runInputs,
+          workflowId: runWorkflowId,
+          workflowName: currentWf?.name,
+          canvasId: canvasIdRef.current,
+        }),
+      })
+        .then((res) => res.json().then((data) => ({ res, data })))
+        .then(({ res, data }) => {
+          if (!res.ok) { toast(`启动失败：${data.error}`, 'error'); return null; }
+          return data.runId;
+        })
+        .catch(() => { toast('启动失败：网络错误', 'error'); return null; });
+    };
+    const startResume = async () => {
+      const res = await fetch(apiUrl('/runs/resume'), {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ runId: resumeCandidate.runId, graph: saved.graph, graphFingerprint: saved.graphFingerprint, canvasId: canvasIdRef.current }),
+      });
+      const data = await res.json();
+      if (!res.ok) { toast(`续跑失败：${data.error}`, 'error'); return null; }
+      return data.runId;
+    };
+    // 找上次可续跑运行：同工作流（或同草稿）、非 live、resumable
+    let resumeCandidate = null;
+    try {
+      const listRes = await fetch(apiUrl('/runs'));
+      if (listRes.ok) {
+        const { runs = [] } = await listRes.json();
+        resumeCandidate = runs.find((r) => r.resumable
+          && !r.live
+          && (r.workflowId || null) === (runWorkflowId || null)) || null;
       }
-      if (data.lint?.issues?.length) toast(`提示：${data.lint.issues.length} 条警告（见图检查）`, 'warn');
+    } catch { /* 历史不可读不阻塞正常运行 */ }
+    let runId;
+    if (resumeCandidate) {
+      const choice = await new Promise((resolve) => {
+        setResumeChoice({
+          lastRun: resumeCandidate,
+          startFresh: () => resolve('fresh'),
+          startResume: () => resolve('resume'),
+        });
+      });
+      setResumeChoice(null);
+      if (choice === 'resume') {
+        // 保留画布上已完成节点的状态展示；只清未完成节点的错误残留
+        setNodes((nds) => nds.map((n) => (['error', 'canceled', 'running'].includes(n.data?.runStatus)
+          ? { ...n, data: { ...n.data, runStatus: 'idle', runError: null } }
+          : n)));
+        runId = await startResume();
+        if (runId) toast(`已续跑：复用上次 ${resumeCandidate.progress?.succeeded ?? '?'} 个已完成节点`, 'success');
+      } else {
+        runId = await startFresh();
+      }
+    } else {
+      runId = await startFresh();
+    }
+    if (!runId) return;
+    const stillCurrentScope = workflowScopeEpochRef.current === runScopeEpoch
+      && currentWfIdRef.current === runWorkflowId;
+    if (runId && stillCurrentScope) {
+      activeRunIdRef.current = runId;
+      runningRef.current = true;
+      setInspectedRunId(runId);
+      setRunStatus((current) => ({ ...current, running: true, runId, done: 0, total: graph.nodes.length }));
     }
   }, [save, setNodes, toGraph, triggerInput, runInputs, currentWf, toast, doLint]);
 
@@ -1401,11 +1451,74 @@ export default function App() {
           onClose={() => setCanvasMenu(null)}
         />
       )}
-      {historyOpen && <RunHistory onClose={() => setHistoryOpen(false)} onSelect={(runId) => {
+      {resumeChoice && (
+        <Modal
+          title="检测到未完成的运行"
+          onClose={() => { resumeChoice.startFresh(); }}
+          footer={(
+            <>
+              <button className="btn" onClick={resumeChoice.startFresh}>重新运行</button>
+              <button className="btn btn-primary" onClick={resumeChoice.startResume}>从上次继续</button>
+            </>
+          )}
+        >
+          <p className="panel-note" style={{ marginBottom: 8 }}>
+            上次运行（{new Date(resumeChoice.lastRun.startedAt).toLocaleString('zh-CN', { hour12: false })}）
+            {resumeChoice.lastRun.status === 'error' ? '失败' : '被取消'}，
+            已完成 <strong>{resumeChoice.lastRun.progress?.succeeded ?? '?'}/{resumeChoice.lastRun.progress?.total ?? '?'}</strong> 个节点。
+          </p>
+          <p className="sec-hint">「从上次继续」复用已完成节点的输出，只补跑未完成部分（图未修改）。「重新运行」全部节点从头执行。</p>
+        </Modal>
+      )}
+      {historyOpen && <RunHistory onClose={() => setHistoryOpen(false)}
+        onResume={(runId, resumedNodes) => {
+          activeRunIdRef.current = runId;
+          runningRef.current = true;
+          setInspectedRunId(runId);
+          setRunStatus((current) => ({ ...current, running: true, runId }));
+          toast(`已从上次运行续跑（复用 ${resumedNodes} 个已完成节点）`, 'success');
+        }}
+        onSelect={(runId) => {
         setInspectedRunId(runId);
-        if (!runDetails[runId]) fetch(apiUrl(`/runs/detail?id=${encodeURIComponent(runId)}`))
+        const applyDetail = (detail) => {
+          // 历史恢复：把该次运行的节点状态/输出投影回画布（与 SSE snapshot 同形）
+          for (const [nodeId, st] of Object.entries(detail.nodeStates || {})) {
+            setNodes((nds) => nds.map((n) => {
+              if (n.id !== nodeId) return n;
+              const data = { ...n.data, runStatus: st.status };
+              if (st.startedAt) data.runStartedAt = st.startedAt;
+              if (st.chars != null) data.runChars = st.chars;
+              if (st.turns != null) data.runTurns = st.turns;
+              if (st.error) data.runError = st.error;
+              if (st.durationMs != null) data.durationMs = st.durationMs;
+              if (st.model) data.runtimeModel = st.model;
+              if (st.artifacts) { data.artifacts = st.artifacts; data.artifactsRunId = runId; }
+              const out = (detail.outputs || {})[nodeId];
+              if (out != null) data.runOutput = String(out).slice(0, 4000);
+              return { ...n, data };
+            }));
+          }
+          const restored = Object.entries(detail.nodeStates || {})
+            .filter(([, st]) => st.status !== 'queued')
+            .map(([nodeId, st]) => ({
+              t: Date.now(), kind: 'node', runId, nodeId,
+              nodeLabel: labelOf(nodesRef.current, nodeId).replace(/\(.*\)$/, ''),
+              status: st.status, text: st.error, chars: st.chars, durationMs: st.durationMs,
+            }));
+          setEventsByRunId((current) => ({ ...current, [runId]: [...restored, {
+            t: Date.now(), kind: 'run', runId, status: detail.status,
+            text: `历史运行：${STATUS_CN[detail.status] || detail.status}`,
+          }] }));
+          setRunStatus((current) => ({ ...current, running: false, runId, last: detail.status }));
+        };
+        const cached = runDetails[runId];
+        if (cached) applyDetail(cached);
+        fetch(apiUrl(`/runs/detail?id=${encodeURIComponent(runId)}`))
           .then((response) => response.ok ? response.json() : Promise.reject(new Error('运行记录不存在')))
-          .then((detail) => setRunDetails((current) => ({ ...current, [runId]: detail })))
+          .then((detail) => {
+            setRunDetails((current) => ({ ...current, [runId]: detail }));
+            applyDetail(detail);
+          })
           .catch(() => toast('加载历史运行失败', 'error'));
       }} />}
       {nodeDetail && (

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1431,6 +1431,7 @@ export default function App() {
             triggerInput={triggerInput}
             onTriggerChange={setTriggerInput}
             onOpenHistory={() => setHistoryOpen(true)}
+            onClose={() => setLogOpen(false)}
             onFocusNode={focusNode}
             onOpenNodeDetail={(runId, nodeId) => setNodeDetail({ runId, nodeId })}
           />}

--- a/web/src/ArtifactPreview.jsx
+++ b/web/src/ArtifactPreview.jsx
@@ -28,6 +28,17 @@ function legacyArtifact(nodeLabel, file) {
   });
 }
 
+/** 新架构产物 URL：run + nodeId 定位节点工作区/运行快照（后端 /wf1/api/artifact） */
+function runArtifact(runId, nodeId, file) {
+  const query = `run=${encodeURIComponent(runId)}&node=${encodeURIComponent(nodeId)}&file=${encodeURIComponent(file)}`;
+  const base = apiUrl(`/artifact?${query}`);
+  return normalizeArtifact({
+    name: file,
+    previewUrl: `${base}&preview=1`,
+    downloadUrl: base,
+  });
+}
+
 export function ArtifactPreviewModal({ artifact, onClose }) {
   return <DocumentPreviewDialog document={normalizeArtifact(artifact)} onClose={onClose} title="文件预览" />;
 }
@@ -71,14 +82,17 @@ export function findArtifactByName(files = [], name) {
   return null;
 }
 
-export function ArtifactLinks({ nodeLabel, artifacts = [] }) {
+export function ArtifactLinks({ nodeLabel, runId, nodeId, artifacts = [] }) {
   const files = artifacts.filter((file) => file && !file.endsWith('/'));
   const dirs = artifacts.filter((file) => file?.endsWith('/'));
+  const artifactFor = (file) => (
+    runId && nodeId ? runArtifact(runId, nodeId, file) : legacyArtifact(nodeLabel, file)
+  );
 
   return (
     <div className="artifact-list">
       {files.map((file) => {
-        const artifact = legacyArtifact(nodeLabel, file);
+        const artifact = artifactFor(file);
         return (
           <div key={file} className="artifact-row">
             <ArtifactNameLink artifact={artifact} className="artifact-name" />

--- a/web/src/NodeDetailModal.jsx
+++ b/web/src/NodeDetailModal.jsx
@@ -159,6 +159,8 @@ export function NodeDetailModal({ runId, nodeId, onClose }) {
                   <span className="trace-block-label">工作区产物</span>
                   <ArtifactLinks
                     nodeLabel={data.label || nodeId}
+                    runId={runId}
+                    nodeId={nodeId}
                     artifacts={data.state.artifacts}
                   />
                 </div>

--- a/web/src/NodePanel.jsx
+++ b/web/src/NodePanel.jsx
@@ -737,7 +737,7 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
         {d.artifacts?.length > 0 && (
           <>
             <div className="result-head"><span className="result-title">工作区产物</span></div>
-            <ArtifactLinks nodeLabel={d.label || node.id} artifacts={d.artifacts} />
+            <ArtifactLinks nodeLabel={d.label || node.id} runId={d.artifactsRunId} nodeId={node.id} artifacts={d.artifacts} />
           </>
         )}
         {d.runError && <p className="panel-error">错误：{d.runError}</p>}

--- a/web/src/ResultPanel.jsx
+++ b/web/src/ResultPanel.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Archive, Check, ChevronRight, Clock3, FolderDown, History, LoaderCircle, RefreshCw, Timer } from 'lucide-react';
+import { Archive, Check, ChevronRight, Clock3, FolderDown, History, LoaderCircle, RefreshCw, Timer, X } from 'lucide-react';
 import { apiUrl } from './api.js';
 import {
   adaptRunResults,
@@ -116,6 +116,7 @@ export function ResultPanel({
   triggerInput = '',
   onTriggerChange,
   onOpenHistory,
+  onClose,
   onFocusNode,
   onOpenNodeDetail,
   sessionId = '',
@@ -236,6 +237,7 @@ export function ResultPanel({
         <div className="result-head-actions">
           <button className="btn-icon" title="刷新成果" aria-label="刷新成果" onClick={refresh} disabled={!runId || loading}><RefreshCw size={15} className={loading ? 'result-spin' : ''} /></button>
           <button className="btn-icon" title="运行历史" aria-label="打开运行历史" onClick={onOpenHistory}><History size={15} /></button>
+          {onClose && <button className="btn-icon" title="关闭面板" aria-label="关闭面板" onClick={onClose}><X size={16} /></button>}
         </div>
       </header>
 

--- a/web/src/RunHistory.jsx
+++ b/web/src/RunHistory.jsx
@@ -1,34 +1,72 @@
-// 运行历史抽屉：最近运行 + 点开看节点状态与输出 + 一键重放（原输入原图重跑）。
+// 运行历史抽屉：最近运行 + 进度（3/4）+ 点开看节点状态与输出 + 重放 / 断点续跑。
 import { useEffect, useState } from 'react';
 import { apiUrl } from './api.js';
 import { Modal } from './ui.jsx';
 
 const STATUS_LABEL = { running: '运行中', success: '成功', error: '失败', canceled: '已取消' };
 
-export function RunHistory({ onClose, onSelect }) {
+function progressText(r) {
+  const p = r.progress;
+  if (!p || !p.total) return '';
+  return `${p.done}/${p.total}`;
+}
+
+export function RunHistory({ onClose, onSelect, onResume }) {
   const [runs, setRuns] = useState([]);
+  const [resuming, setResuming] = useState('');
 
   const load = () => {
     fetch(apiUrl('/runs')).then((r) => r.json()).then((d) => setRuns(d.runs || [])).catch(() => {});
   };
   useEffect(load, []);
 
+  const resumeRun = async (runId) => {
+    if (resuming) return;
+    setResuming(runId);
+    try {
+      const res = await fetch(apiUrl('/runs/resume'), {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ runId }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || '续跑失败');
+      onResume?.(data.runId, data.resumedNodes);
+      onClose();
+    } catch (e) {
+      alert(`无法续跑：${e.message}`);
+      load();
+    } finally {
+      setResuming('');
+    }
+  };
+
   return (
     <Modal title="运行历史" onClose={onClose}>
       <div className="rh-list">
         {runs.length === 0 && <p className="panel-empty">还没有运行记录。</p>}
         {runs.map((r) => (
-          <button key={r.runId} className={`rh-row st-${r.status} ${r.live ? 'rh-live' : ''}`} onClick={() => { onSelect?.(r.runId); onClose(); }}>
-            <span className={`rh-status st-${r.status}`}>{STATUS_LABEL[r.status] || r.status}</span>
-            <span className="rh-name">{r.workflowName || '草稿'}</span>
-            <span className="rh-meta">
-              {new Date(r.startedAt).toLocaleString('zh-CN', { hour12: false })}
-              {r.durationMs != null && ` · ${(r.durationMs / 1000).toFixed(1)}s`}
-              {r.canceled && ' · 已取消'}
-              {r.replayOf && ' · 重放'}
-            </span>
-            {r.live && <span className="badge badge-plan">LIVE</span>}
-          </button>
+          <div key={r.runId} className={`rh-row-wrap ${r.live ? 'rh-live' : ''}`}>
+            <button className={`rh-row st-${r.status}`} onClick={() => { onSelect?.(r.runId); onClose(); }}>
+              <span className={`rh-status st-${r.status}`}>{STATUS_LABEL[r.status] || r.status}</span>
+              <span className="rh-name">{r.workflowName || '草稿'}</span>
+              <span className="rh-meta">
+                {new Date(r.startedAt).toLocaleString('zh-CN', { hour12: false })}
+                {r.durationMs != null && ` · ${(r.durationMs / 1000).toFixed(1)}s`}
+                {r.canceled && ' · 已取消'}
+                {r.replayOf && ' · 重放'}
+                {r.resumedFrom && ' · 续跑'}
+              </span>
+              {progressText(r) && <span className="rh-progress">{progressText(r)}</span>}
+              {r.live && <span className="badge badge-plan">LIVE</span>}
+            </button>
+            {r.resumable && (
+              <button className="btn btn-sm rh-resume" disabled={resuming === r.runId}
+                title="从上次完成的节点之后继续运行（图未修改时可用）"
+                onClick={() => resumeRun(r.runId)}>
+                {resuming === r.runId ? '启动中…' : `续跑 ${progressText(r)}`}
+              </button>
+            )}
+          </div>
         ))}
       </div>
     </Modal>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -905,6 +905,15 @@ body {
 .rh-meta { color: var(--fg-faint); margin-left: auto; white-space: nowrap; font-size: 12px; }
 .rh-node { border: 1px solid var(--border); border-radius: 8px; padding: 6px 10px; margin-top: 6px; font-size: 13px; }
 .rh-node summary { cursor: pointer; display: flex; align-items: center; gap: 8px; }
+/* 断点续跑：历史行右侧动作按钮 + 进度徽标 */
+.rh-row-wrap { display: flex; align-items: stretch; gap: 6px; }
+.rh-row-wrap .rh-row { flex: 1; min-width: 0; }
+.rh-resume { flex: none; align-self: center; }
+.rh-progress {
+  flex: none; font-family: var(--font-mono); font-size: 12px; font-weight: 600;
+  color: var(--fg-muted); background: var(--bg-raised);
+  border: 1px solid var(--border); border-radius: 999px; padding: 2px 8px;
+}
 
 /* ============ 模板库 ============ */
 .tpl-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; min-width: 540px; }


### PR DESCRIPTION
## 背景

工作区累积的四组主题改动，按 Conventional Commits 拆成 4 个提交：

1. **产物预览 409 修复**（`2fa1970`）：成果面板点击文件预览/下载报 `Failed to load document (HTTP 409)`。根因是 `/wf1/api/run-results` 响应里 `createRunResults` 生成的产物 URL 不带 sessionId，前端原样 fetch 时 scoped 路由解析不到会话工作目录（409 workspace-session-required）。修复：URL 继承请求的 sessionId；集成测试补了端到端链路断言（响应 URL 原样请求得 200）。
2. **断点续跑**（`b775c08`）：失败/取消的运行从已完成节点之后继续。引擎 resume 种子搬运 success 节点输出并回放分支跳过；新增 `POST /wf1/api/runs/resume`（图 fingerprint 一致才可续跑）；运行历史行内续跑按钮 + 触发时「重新运行/从上次继续」选择框 + 历史记录投影回画布。
3. **节点产物预览 404 修复**（`023c74d`）：`.workflow-one/` 迁移后产物路径变了，前端预览 URL 仍用旧 label 格式导致 404。`/wf1/api/artifact` 支持 `?run=&node=<nodeId>&file=` 新格式（快照优先、运行中回退节点工作区），前端 ArtifactLinks 带 runId/nodeId 走新链路，旧格式保留兼容。
4. **成果面板关闭按钮**（`6390fc5`）：ResultPanel 可选 onClose，App 传 setLogOpen(false) 收起。

## 验证

- 聚合 28 套单测全部通过（`npm test`：web 10 + orchestrator 15（新增 engine-resume）+ llm-guard + canvasui + document-preview）
- 409 已在运行实例上复现（无 sessionId 请求即 `workspace-session-required`），修复后集成测试断言同链路 200
- 404 修复经真实运行端到端实测（新格式下载/预览均 200）

## 已知残留

404 修复之前产生的旧运行记录，节点面板产物回退旧格式仍会 404，重新运行工作流即走新链路。