### PR TITLE
fix(workflow): 修正续跑校验并优化流程消息卡

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -242,7 +242,7 @@ window.__ModuleLoader__.load({
       };
     }
 
-    // 语义化流程摘要：真实主路径 + 全图序号，比缩小整张画布更适合消息卡片。
+    // 语义化流程摘要：真实主路径 + 连续序号，比缩小整张画布更适合消息卡片。
     function graphThumbnail(graph, run) {
       var model = flowPreviewModel(graph, run && run.nodeStates);
       if (!model) return null;

--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -81,7 +81,7 @@ window.__ModuleLoader__.load({
         ".wf1-card-dot[data-s=waiting]{background:var(--dsw-alias-state-warn-primary);}",
         ".wf1-card-dot[data-s=pending]{background:var(--dsw-alias-border-l2);}",
         "@keyframes wf1-card-pulse{0%,100%{opacity:1}50%{opacity:.35}}",
-        ".wf1-card-map{height:88px;border-radius:8px;display:block;width:100%;}",
+        ".wf1-card-map{height:108px;border-radius:8px;display:block;width:100%;background:color-mix(in srgb,var(--dsw-alias-border-l1) 18%,transparent);}",
         ".wf1-card-foot{display:flex;align-items:center;gap:8px;min-width:0;}",
         ".wf1-card-meta{color:var(--dsw-alias-label-tertiary);font-size:13px;line-height:18px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;}",
         ".wf1-card-meta[data-error]{color:var(--dsw-alias-state-error-primary);}",
@@ -172,31 +172,81 @@ window.__ModuleLoader__.load({
       return "pending";
     }
 
-    // 图 → SVG 缩略图：节点用 graph 自带 position，按 bounds 等比缩放；点色只表达状态。
-    // run 为 null 时全部节点灰（建图态/无运行）。
-    function graphThumbnail(graph, run) {
+    var NODE_TYPE_CN = {
+      input: "输入", agent: "智能体", condition: "条件", http: "HTTP",
+      script: "脚本", output: "输出",
+    };
+
+    // 取 DAG 最长路径作为卡片主流程；运行态排除明确跳过的节点。
+    function flowPreviewModel(graph, nodeStates) {
       var nodes = (graph && Array.isArray(graph.nodes) ? graph.nodes : []).filter(function (n) {
         return (n.type || (n.data && n.data.nodeType)) !== "note";
       });
       if (!nodes.length) return null;
-      var states = (run && run.nodeStates) || {};
-      var byId = {};
-      nodes.forEach(function (n) { byId[n.id] = n; });
-      var pts = nodes.map(function (n) {
-        var p = n.position || (n.data && n.data.position) || { x: 0, y: 0 };
-        return { x: Number(p.x) || 0, y: Number(p.y) || 0 };
+      var previewNodes = nodes.filter(function (n) {
+        return !nodeStates || !nodeStates[n.id] || nodeStates[n.id].status !== "skipped";
       });
-      var minX = Math.min.apply(null, pts.map(function (p) { return p.x; }));
-      var minY = Math.min.apply(null, pts.map(function (p) { return p.y; }));
-      var maxX = Math.max.apply(null, pts.map(function (p) { return p.x; }));
-      var maxY = Math.max.apply(null, pts.map(function (p) { return p.y; }));
-      var W = 300, H = 88, PAD = 12;
-      var spanX = Math.max(maxX - minX, 1), spanY = Math.max(maxY - minY, 1);
-      var scale = Math.min((W - PAD * 2) / spanX, (H - PAD * 2) / spanY);
-      var offX = (W - spanX * scale) / 2 - minX * scale;
-      var offY = (H - spanY * scale) / 2 - minY * scale;
-      var big = nodes.length > 24;
-      var R = big ? 3 : 4.5;
+      if (!previewNodes.length) previewNodes = nodes;
+      var byId = {}, incoming = {}, outgoing = {};
+      previewNodes.forEach(function (n) { byId[n.id] = n; incoming[n.id] = 0; outgoing[n.id] = []; });
+      (graph.edges || []).forEach(function (edge) {
+        if (!byId[edge.source] || !byId[edge.target]) return;
+        outgoing[edge.source].push(edge.target);
+        incoming[edge.target] += 1;
+      });
+      var position = function (id) {
+        var p = byId[id].position || byId[id].data && byId[id].data.position || {};
+        return [Number(p.x) || 0, Number(p.y) || 0];
+      };
+      var sortIds = function (ids) {
+        return ids.sort(function (a, b) {
+          var ap = position(a), bp = position(b);
+          return ap[0] - bp[0] || ap[1] - bp[1] || a.localeCompare(b);
+        });
+      };
+      var queue = sortIds(previewNodes.filter(function (n) { return incoming[n.id] === 0; }).map(function (n) { return n.id; }));
+      var order = [], paths = {};
+      queue.forEach(function (id) { paths[id] = [id]; });
+      while (queue.length) {
+        var id = queue.shift();
+        order.push(id);
+        outgoing[id].forEach(function (next) {
+          var candidate = (paths[id] || [id]).concat(next);
+          if (!paths[next] || candidate.length > paths[next].length) paths[next] = candidate;
+          incoming[next] -= 1;
+          if (incoming[next] === 0) { queue.push(next); sortIds(queue); }
+        });
+      }
+      if (order.length !== previewNodes.length) order = sortIds(previewNodes.map(function (n) { return n.id; }));
+      var numberById = {};
+      var path = order.reduce(function (best, id) {
+        var candidate = paths[id] || [id];
+        return candidate.length > best.length ? candidate : best;
+      }, []);
+      if (!path.length) path = order;
+      path.forEach(function (id, index) { numberById[id] = index + 1; });
+      var visible = path.length > 5 ? path.slice(0, 2).concat(null, path.slice(-2)) : path;
+      return {
+        items: visible.map(function (id) {
+          if (id === null) return null;
+          var node = byId[id];
+          return {
+            id: id,
+            number: numberById[id],
+            label: String(node.data && node.data.label || id),
+            type: node.type || node.data && node.data.nodeType || "",
+          };
+        }),
+        pathLength: path.length,
+        otherNodeCount: Math.max(0, nodes.length - path.length),
+      };
+    }
+
+    // 语义化流程摘要：真实主路径 + 全图序号，比缩小整张画布更适合消息卡片。
+    function graphThumbnail(graph, run) {
+      var model = flowPreviewModel(graph, run && run.nodeStates);
+      if (!model) return null;
+      var states = (run && run.nodeStates) || {};
       var colorOf = function (st) {
         if (st === "running") return "var(--dsw-alias-state-business-primary)";
         if (st === "success") return "var(--dsw-alias-state-success-primary)";
@@ -204,28 +254,70 @@ window.__ModuleLoader__.load({
         if (st === "waiting") return "var(--dsw-alias-state-warn-primary)";
         return "var(--dsw-alias-border-l2)";
       };
-      var edges = (graph && Array.isArray(graph.edges) ? graph.edges : [])
-        .filter(function (e) { return byId[e.source] && byId[e.target]; })
-        .map(function (e) {
-          var a = byId[e.source].position || { x: 0, y: 0 };
-          var b = byId[e.target].position || { x: 0, y: 0 };
-          return react.createElement("line", {
-            key: "e" + e.id, x1: a.x * scale + offX, y1: a.y * scale + offY,
-            x2: b.x * scale + offX, y2: b.y * scale + offY,
-            stroke: "var(--dsw-alias-border-l2)", "stroke-width": 1,
-          });
-        });
-      var dots = nodes.map(function (n) {
-        var p = n.position || { x: 0, y: 0 };
-        var st = states[n.id] ? states[n.id].status : null;
-        return react.createElement("circle", {
-          key: n.id, cx: p.x * scale + offX, cy: p.y * scale + offY, r: R,
-          fill: colorOf(st),
-        });
+      var W = 360, H = 108, BOX_H = 44;
+      var BOX_W = model.items.length <= 3 ? 96 : model.items.length === 4 ? 74 : 60;
+      var GAP = model.items.length > 1 ? (W - 24 - model.items.length * BOX_W) / (model.items.length - 1) : 0;
+      var contentW = model.items.length * BOX_W + (model.items.length - 1) * GAP;
+      var startX = (W - contentW) / 2, y = 17;
+      var elements = [];
+      model.items.forEach(function (item, index) {
+        var x = startX + index * (BOX_W + GAP);
+        if (index > 0) {
+          var prevX = x - GAP;
+          elements.push(react.createElement("line", {
+            key: "line-" + index, x1: prevX, y1: y + BOX_H / 2, x2: x - 4, y2: y + BOX_H / 2,
+            stroke: "var(--dsw-alias-border-l2)", "stroke-width": 1.4,
+            "stroke-dasharray": item === null || model.items[index - 1] === null ? "3 3" : undefined,
+          }));
+          elements.push(react.createElement("path", {
+            key: "arrow-" + index,
+            d: "M" + (x - 8) + " " + (y + BOX_H / 2 - 3) + " L" + (x - 4) + " " + (y + BOX_H / 2) + " L" + (x - 8) + " " + (y + BOX_H / 2 + 3),
+            fill: "none", stroke: "var(--dsw-alias-border-l2)", "stroke-width": 1.4,
+          }));
+        }
+        if (item === null) {
+          elements.push(react.createElement("text", {
+            key: "ellipsis", x: x + BOX_W / 2, y: y + BOX_H / 2 + 3,
+            "text-anchor": "middle", fill: "var(--dsw-alias-label-caption)", "font-size": 13,
+          }, "•••"));
+          return;
+        }
+        var status = states[item.id] && states[item.id].status;
+        var color = colorOf(status);
+        var maxLabel = BOX_W >= 90 ? 7 : BOX_W >= 70 ? 4 : 3;
+        var label = item.label.length > maxLabel ? item.label.slice(0, maxLabel) + "…" : item.label;
+        elements.push(react.createElement("rect", {
+          key: "box-" + item.id, x: x, y: y, width: BOX_W, height: BOX_H, rx: 6,
+          fill: "var(--dsw-alias-bg-base)", stroke: color, "stroke-width": status ? 1.6 : 1,
+        }));
+        elements.push(react.createElement("circle", {
+          key: "number-bg-" + item.id, cx: x + 13, cy: y + 14, r: 8, fill: color,
+        }));
+        elements.push(react.createElement("text", {
+          key: "number-" + item.id, x: x + 13, y: y + 17,
+          "text-anchor": "middle", fill: "var(--dsw-alias-bg-base)", "font-size": 8.5, "font-weight": 600,
+        }, String(item.number).padStart(2, "0")));
+        elements.push(react.createElement("text", {
+          key: "label-" + item.id, x: x + 25, y: y + 17,
+          fill: "var(--dsw-alias-label-primary)", "font-size": 10.5, "font-weight": 600,
+        }, label));
+        elements.push(react.createElement("text", {
+          key: "type-" + item.id, x: x + 13, y: y + 34,
+          fill: "var(--dsw-alias-label-caption)", "font-size": 9,
+        }, NODE_TYPE_CN[item.type] || item.type || "节点"));
       });
+      var summary = "主流程 " + model.pathLength + " 步" + (model.otherNodeCount ? " · 另有 " + model.otherNodeCount + " 个节点" : "");
+      elements.push(react.createElement("text", {
+        key: "summary", x: 12, y: 94, fill: "var(--dsw-alias-label-tertiary)", "font-size": 10,
+      }, summary));
       return react.createElement(
-        "svg", { className: "wf1-card-map", viewBox: "0 0 " + W + " " + H, "aria-hidden": true },
-        edges.concat(dots),
+        "svg", {
+          className: "wf1-card-map", viewBox: "0 0 " + W + " " + H, role: "img",
+          "aria-label": summary + "：" + model.items.map(function (item) {
+            return item ? item.number + " " + item.label : "省略 " + (model.pathLength - 4) + " 步";
+          }).join("，"),
+        },
+        elements,
       );
     }
 
@@ -755,6 +847,8 @@ window.__ModuleLoader__.load({
       runIdFromText: runIdFromText,
       runIdFromArgs: runIdFromArgs,
       runDotState: runDotState,
+      flowPreviewModel: flowPreviewModel,
+      graphThumbnail: graphThumbnail,
       WorkflowRunCard: WorkflowRunCard,
       GraphPatchCard: GraphPatchCard,
     };

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -215,6 +215,47 @@ assert.equal(client.__test.runDotState({ status: "canceled" }), "error");
 assert.equal(client.__test.runDotState(null, "running"), "running");
 assert.equal(client.__test.runDotState(null), "running"); // 无数据按运行中
 
+// 分支图摘要取最长路径，主路径连续编号，未展示节点使用中性计数。
+const branchGraph = {
+  nodes: [
+    { id: "in", type: "input", position: { x: 0, y: 0 }, data: { label: "报修输入" } },
+    { id: "route", type: "condition", position: { x: 100, y: 0 }, data: { label: "紧急判断" } },
+    { id: "urgent", type: "agent", position: { x: 200, y: 0 }, data: { label: "紧急派单" } },
+    { id: "normal", type: "agent", position: { x: 200, y: 100 }, data: { label: "普通派单" } },
+    { id: "out", type: "output", position: { x: 300, y: 0 }, data: { label: "工单输出" } },
+  ],
+  edges: [
+    { source: "in", target: "route" },
+    { source: "route", target: "urgent" },
+    { source: "route", target: "normal" },
+    { source: "urgent", target: "out" },
+    { source: "normal", target: "out" },
+  ],
+};
+const preview = client.__test.flowPreviewModel(branchGraph);
+assert.deepEqual([...preview.items].map((item) => item && item.id), ["in", "route", "urgent", "out"]);
+assert.deepEqual([...preview.items].map((item) => item && item.number), [1, 2, 3, 4]);
+assert.equal(preview.pathLength, 4);
+assert.equal(preview.otherNodeCount, 1);
+
+// 实际运行命中下方分支时，不能继续展示按画布位置选出的上方分支。
+const executedPreview = client.__test.flowPreviewModel(branchGraph, {
+  in: { status: "success" },
+  route: { status: "success" },
+  urgent: { status: "skipped" },
+  normal: { status: "success" },
+  out: { status: "success" },
+});
+assert.deepEqual([...executedPreview.items].map((item) => item && item.id), ["in", "route", "normal", "out"]);
+assert.deepEqual([...executedPreview.items].map((item) => item && item.number), [1, 2, 3, 4]);
+assert.equal(executedPreview.otherNodeCount, 1);
+
+const longPreview = client.__test.flowPreviewModel({
+  nodes: Array.from({ length: 7 }, (_, index) => ({ id: `n${index + 1}`, type: "agent", data: { label: `步骤${index + 1}` } })),
+  edges: Array.from({ length: 6 }, (_, index) => ({ source: `n${index + 1}`, target: `n${index + 2}` })),
+});
+assert.deepEqual([...longPreview.items].map((item) => item && item.id), ["n1", "n2", null, "n6", "n7"]);
+
 // 卡片组件渲染断言：GraphPatchCard/WorkflowRunCard 的渲染链在 vm 内闭包引用 react——
 // 用第二批 vm context 以 react shim 加载（createElement 记录调用），专门断言 props：
 // running → 应用中；settled 成功带 lint 通过 → 已应用；settled isError → 被拒绝。
@@ -252,6 +293,17 @@ const cardContext = {
 vm.runInNewContext(bundle, cardContext, {
   filename: "dsh-ccpg-canvasui/src/client.js",
 });
+
+// SVG 的可访问名称包含视觉摘要，读屏信息与卡片底部文案一致。
+cardCalls.length = 0;
+const thumbnail = cardClient.__test.graphThumbnail(branchGraph, {
+  nodeStates: {
+    in: { status: "success" }, route: { status: "success" },
+    urgent: { status: "skipped" }, normal: { status: "success" }, out: { status: "success" },
+  },
+});
+assert.match(thumbnail.props["aria-label"], /^主流程 4 步 · 另有 1 个节点：/);
+assert.match(thumbnail.props["aria-label"], /3 普通派单/);
 
 // GraphPatchCard：running（argsRaw 携带 ops）
 cardCalls.length = 0;

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -1540,9 +1540,6 @@ export function apply(ctx, config) {
     if (!succeeded.length) return json(res, 400, { error: '该运行没有已完成的节点，无需续跑', code: 'nothing-to-resume' });
     // 图来源：优先当前画布图（可能是保存后的同名图），须与上次 fingerprint 一致
     let graph = body.graph || prev.graph;
-    if (body.graphFingerprint && body.graphFingerprint !== graphFingerprint(body.graph)) {
-      return json(res, 400, { error: '画布图与请求指纹不一致', code: 'graph-fingerprint-mismatch' });
-    }
     if (graphFingerprint(graph) !== prev.graphFingerprint) {
       return json(res, 409, {
         error: '画布图已修改，与上次运行不一致；请重新运行或还原画布',

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
@@ -4,6 +4,7 @@ import { existsSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSyn
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { apply } from '../lib/index.js';
+import { graphFingerprint } from '../lib/run-scope.js';
 
 function responseCapture() {
   const listeners = new Map();
@@ -133,6 +134,37 @@ try {
   assert.equal(storedRun?.workspaceRoot, undefined);
   assert.equal(existsSync(join(workspaceA, '.workflow-one', 'runs', `${newRunId}.json`)), false);
   assert.equal(existsSync(join(dshHome, 'plugin-data', 'dsh-ccpg-orchestrator', 'runs', `${newRunId}.json`)), false);
+
+  const resumeGraph = {
+    nodes: [
+      { id: 'resume_input', type: 'input', position: { x: 0, y: 0 }, data: { label: '输入', text: 'hello' } },
+      { id: 'resume_output', type: 'output', position: { x: 200, y: 0 }, data: { label: '输出' } },
+    ],
+    edges: [{ source: 'resume_input', target: 'resume_output' }],
+  };
+  writeFileSync(join(runsDirB, 'run_resume_seed.json'), JSON.stringify({
+    runId: 'run_resume_seed', schemaVersion: 3, status: 'error',
+    startedAt: '2026-08-24T00:00:00.000Z', finishedAt: '2026-08-24T00:00:01.000Z', durationMs: 1000,
+    triggerInput: '', runInputs: {}, graph: resumeGraph, graphFingerprint: graphFingerprint(resumeGraph),
+    nodeStates: { resume_input: { status: 'success' }, resume_output: { status: 'error', error: '模拟失败' } },
+    outputs: { resume_input: 'hello' }, structuredOutputs: {}, nodeOrder: ['resume_input', 'resume_output'],
+  }));
+
+  const changedGraph = structuredClone(resumeGraph);
+  changedGraph.nodes[0].data.text = 'changed';
+  const changedResume = responseCapture();
+  await route('/wf1/api/runs/resume')(request('POST', withSession('/wf1/api/runs/resume', 'session-b'), {
+    runId: 'run_resume_seed', graph: changedGraph,
+  }), changedResume);
+  assert.equal(changedResume.status, 409);
+  assert.equal(changedResume.json().code, 'workflow-graph-mismatch');
+
+  const matchingResume = responseCapture();
+  await route('/wf1/api/runs/resume')(request('POST', withSession('/wf1/api/runs/resume', 'session-b'), {
+    runId: 'run_resume_seed', graph: resumeGraph, graphFingerprint: 'stale-client-fingerprint',
+  }), matchingResume);
+  assert.equal(matchingResume.status, 200);
+  assert.equal(matchingResume.json().resumedFrom, 'run_resume_seed');
 
   const missingSession = responseCapture();
   await route('/wf1/api/graph')(request('GET', '/wf1/api/graph'), missingSession);

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -683,7 +683,7 @@ export default function App() {
     const startResume = async () => {
       const res = await fetch(apiUrl('/runs/resume'), {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ runId: resumeCandidate.runId, graph: saved.graph, graphFingerprint: saved.graphFingerprint, canvasId: canvasIdRef.current }),
+        body: JSON.stringify({ runId: resumeCandidate.runId, graph: saved.graph, canvasId: canvasIdRef.current }),
       });
       const data = await res.json();
       if (!res.ok) { toast(`续跑失败：${data.error}`, 'error'); return null; }

--- a/web/src/workflow-serialization.js
+++ b/web/src/workflow-serialization.js
@@ -11,6 +11,7 @@ const RUNTIME_NODE_DATA_FIELDS = new Set([
   'runtimeStructuredOutput',
   'outputPreview',
   'livePreview',
+  'liveTurns',
   'progress',
   'trace',
   'hasTrace',
@@ -18,6 +19,9 @@ const RUNTIME_NODE_DATA_FIELDS = new Set([
   'sessionId',
   'durationMs',
   'runtimeModel',
+  'runStartedAt',
+  'runTurns',
+  'artifactsRunId',
   'test',
 ]);
 

--- a/web/src/workflow-serialization.test.mjs
+++ b/web/src/workflow-serialization.test.mjs
@@ -28,6 +28,7 @@ const nodes = [{
     runtimeStructuredOutput: { type: 'json', value: { runtime: true } },
     outputPreview: 'preview',
     livePreview: 'working',
+    liveTurns: 2,
     progress: { turns: 2 },
     trace: { steps: [] },
     hasTrace: true,
@@ -35,6 +36,9 @@ const nodes = [{
     sessionId: 'session-1',
     durationMs: 123,
     runtimeModel: 'model-1',
+    runStartedAt: '2026-08-24T00:00:00.000Z',
+    runTurns: 3,
+    artifactsRunId: 'run-1',
     test: true,
   },
 }];


### PR DESCRIPTION
## 背景

续跑请求携带的客户端图指纹可能陈旧，部分运行态字段也会污染持久化图，导致未修改画布被错误拒绝。对话中的工作流卡片原缩略图过于抽象，分支流程还可能与实际运行路径不一致。

## 方案

- 续跑仅以服务端保存的上次运行指纹校验当前图，保留真实图变更冲突保护
- 序列化时移除新增的运行态字段，避免影响图指纹
- 消息卡改为带连续序号、节点名称和类型的语义流程摘要
- 按运行状态排除未命中分支，补充其他节点提示和完整无障碍描述

## 验证

- npm test：全部通过
- build-web.sh：document-preview 与画布双 base 构建通过
- build-canvasui.sh --check：bundle 与源码一致
- 应用内浏览器：真实消息卡序号、布局和 aria-label 验证通过