### PR TITLE
fix(workflow): 展示消息卡实时节点进度

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -82,6 +82,7 @@ window.__ModuleLoader__.load({
         ".wf1-card-dot[data-s=pending]{background:var(--dsw-alias-border-l2);}",
         "@keyframes wf1-card-pulse{0%,100%{opacity:1}50%{opacity:.35}}",
         ".wf1-card-map{height:108px;border-radius:8px;display:block;width:100%;background:color-mix(in srgb,var(--dsw-alias-border-l1) 18%,transparent);}",
+        ".wf1-card-node[data-s=running]{animation:wf1-card-pulse 1.6s ease-in-out infinite;}",
         ".wf1-card-foot{display:flex;align-items:center;gap:8px;min-width:0;}",
         ".wf1-card-meta{color:var(--dsw-alias-label-tertiary);font-size:13px;line-height:18px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;}",
         ".wf1-card-meta[data-error]{color:var(--dsw-alias-state-error-primary);}",
@@ -160,8 +161,9 @@ window.__ModuleLoader__.load({
     }
 
     var RUN_STATUS_CN = {
-      running: "运行中", success: "成功", error: "失败",
+      running: "运行中", success: "已完成", error: "失败",
       canceled: "已取消", skipped: "已跳过", waiting: "等待审批",
+      queued: "等待中", pending: "未开始",
     };
     function runDotState(run, fallback) {
       var s = run ? run.status : fallback;
@@ -282,13 +284,14 @@ window.__ModuleLoader__.load({
           }, "•••"));
           return;
         }
-        var status = states[item.id] && states[item.id].status;
+        var status = states[item.id] && states[item.id].status || "pending";
         var color = colorOf(status);
         var maxLabel = BOX_W >= 90 ? 7 : BOX_W >= 70 ? 4 : 3;
         var label = item.label.length > maxLabel ? item.label.slice(0, maxLabel) + "…" : item.label;
         elements.push(react.createElement("rect", {
           key: "box-" + item.id, x: x, y: y, width: BOX_W, height: BOX_H, rx: 6,
-          fill: "var(--dsw-alias-bg-base)", stroke: color, "stroke-width": status ? 1.6 : 1,
+          className: "wf1-card-node", "data-s": status,
+          fill: "var(--dsw-alias-bg-base)", stroke: color, "stroke-width": status === "pending" ? 1 : 1.6,
         }));
         elements.push(react.createElement("circle", {
           key: "number-bg-" + item.id, cx: x + 13, cy: y + 14, r: 8, fill: color,
@@ -314,11 +317,30 @@ window.__ModuleLoader__.load({
         "svg", {
           className: "wf1-card-map", viewBox: "0 0 " + W + " " + H, role: "img",
           "aria-label": summary + "：" + model.items.map(function (item) {
-            return item ? item.number + " " + item.label : "省略 " + (model.pathLength - 4) + " 步";
+            var status = item && states[item.id] && states[item.id].status || "pending";
+            return item ? item.number + " " + item.label + " " + RUN_STATUS_CN[status] : "省略 " + (model.pathLength - 4) + " 步";
           }).join("，"),
         },
         elements,
       );
+    }
+
+    function runCardProgress(run) {
+      var graphNodes = (run && run.graph && Array.isArray(run.graph.nodes) ? run.graph.nodes : []).filter(function (n) {
+        return (n.type || (n.data && n.data.nodeType)) !== "note";
+      });
+      var states = run && run.nodeStates || {};
+      var nodeIds = graphNodes.length ? graphNodes.map(function (n) { return n.id; }) : Object.keys(states);
+      var labels = {};
+      graphNodes.forEach(function (n) { labels[n.id] = n.data && n.data.label || n.id; });
+      var result = { total: nodeIds.length, done: 0, currentLabel: "", error: "" };
+      nodeIds.forEach(function (id) {
+        var state = states[id] || {};
+        if (["success", "error", "canceled", "skipped"].indexOf(state.status) >= 0) result.done += 1;
+        if (state.status === "running") result.currentLabel = labels[id] || id;
+        if (!result.error && (state.error || state.toleratedError)) result.error = String(state.error || state.toleratedError);
+      });
+      return result;
     }
 
     function openCanvasFallback() {
@@ -429,22 +451,9 @@ window.__ModuleLoader__.load({
       }
 
       var dot = runDotState(run);
-      var nodeTotal = 0, nodeDone = 0, currentLabel = "", errText = "";
-      if (run && run.nodeStates) {
-        var labels = {};
-        (run.graph && run.graph.nodes ? run.graph.nodes : []).forEach(function (n) {
-          labels[n.id] = (n.data && n.data.label) || n.id;
-        });
-        Object.keys(run.nodeStates).forEach(function (id) {
-          var st = run.nodeStates[id].status;
-          nodeTotal += 1;
-          if (["success", "error", "canceled", "skipped"].indexOf(st) >= 0) nodeDone += 1;
-          if (st === "running") currentLabel = labels[id] || id;
-          if (!errText && (run.nodeStates[id].error || run.nodeStates[id].toleratedError)) {
-            errText = String(run.nodeStates[id].error || run.nodeStates[id].toleratedError);
-          }
-        });
-      }
+      var progress = runCardProgress(run);
+      var nodeTotal = progress.total, nodeDone = progress.done;
+      var currentLabel = progress.currentLabel, errText = progress.error;
       var secs = run && run.durationMs ? Math.round(run.durationMs / 1000) + "s" : "";
       var meta;
       if (dot === "running") {
@@ -847,6 +856,7 @@ window.__ModuleLoader__.load({
       runIdFromText: runIdFromText,
       runIdFromArgs: runIdFromArgs,
       runDotState: runDotState,
+      runCardProgress: runCardProgress,
       flowPreviewModel: flowPreviewModel,
       graphThumbnail: graphThumbnail,
       WorkflowRunCard: WorkflowRunCard,

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -215,6 +215,30 @@ assert.equal(client.__test.runDotState({ status: "canceled" }), "error");
 assert.equal(client.__test.runDotState(null, "running"), "running");
 assert.equal(client.__test.runDotState(null), "running"); // 无数据按运行中
 
+const progressGraph = {
+  nodes: Array.from({ length: 10 }, (_, index) => ({
+    id: `node_${index + 1}`,
+    type: "agent",
+    position: { x: index * 20, y: 0 },
+    data: { label: `节点 ${index + 1}` },
+  })),
+  edges: Array.from({ length: 9 }, (_, index) => ({ source: `node_${index + 1}`, target: `node_${index + 2}` })),
+};
+const progressRun = {
+  graph: progressGraph,
+  nodeStates: {
+    node_1: { status: "success" },
+    node_2: { status: "success" },
+    node_3: { status: "success" },
+    node_4: { status: "success" },
+    node_9: { status: "running" },
+  },
+};
+assert.deepEqual(
+  { ...client.__test.runCardProgress(progressRun) },
+  { total: 10, done: 4, currentLabel: "节点 9", error: "" },
+);
+
 // 分支图摘要取最长路径，主路径连续编号，未展示节点使用中性计数。
 const branchGraph = {
   nodes: [
@@ -293,6 +317,14 @@ const cardContext = {
 vm.runInNewContext(bundle, cardContext, {
   filename: "dsh-ccpg-canvasui/src/client.js",
 });
+
+cardCalls.length = 0;
+cardClient.__test.graphThumbnail(progressGraph, progressRun);
+const nodeBoxes = cardCalls.filter((call) => call.tag === "rect" && call.props?.className === "wf1-card-node");
+assert.equal(nodeBoxes.some((call) => call.props["data-s"] === "success"), true);
+assert.equal(nodeBoxes.some((call) => call.props["data-s"] === "running"), true);
+assert.equal(nodeBoxes.some((call) => call.props["data-s"] === "pending"), true);
+assert.match(cardCalls.find((call) => call.tag === "svg" && call.props?.className === "wf1-card-map").props["aria-label"], /已完成.*运行中.*未开始/);
 
 // SVG 的可访问名称包含视觉摘要，读屏信息与卡片底部文案一致。
 cardCalls.length = 0;

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -511,7 +511,17 @@ export function apply(ctx, config) {
       if (history.length > RUNS_KEEP) history.length = RUNS_KEEP;
     } catch { /* 目录不可读 */ }
   };
+  let orch;
   const readRun = (runId) => {
+    const live = orch?.runs.get(runId);
+    if (live?.run.workspaceRoot === currentStore().workspaceRoot) {
+      const { workspaceRoot: _workspaceRoot, ...run } = live.run;
+      const graph = {
+        nodes: live.s.graph.nodes.map((node) => ({ id: node.id, type: node.type, position: node.position, data: node.data })),
+        edges: live.s.graph.edges,
+      };
+      return normalizeRunDocument({ ...run, graph });
+    }
     const filename = `${safeFileId(runId, 'invalid')}.json`;
     for (const dir of [currentPaths().runs]) {
       try { return normalizeRunDocument(JSON.parse(readFileSync(join(dir, filename), 'utf8'))); } catch { /* 回退下一位置 */ }
@@ -593,7 +603,7 @@ export function apply(ctx, config) {
   };
 
   // ---- 引擎 ----
-  const orch = new Orchestrator(ctx, { onEvent: broadcast, renderTemplate });
+  orch = new Orchestrator(ctx, { onEvent: broadcast, renderTemplate });
   orch.nodeRunner = async (node, run, s, ctl) => runAgentNode(ctx, node, run, s, ctl);
   orch.scriptRunner = async ({ node, input, signal, timeoutMs, workflowId, runId }) => {
     const ws = workspaceFor(node, { workflowId: workflowId || 'draft', runId });

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
@@ -135,6 +135,62 @@ try {
   assert.equal(existsSync(join(workspaceA, '.workflow-one', 'runs', `${newRunId}.json`)), false);
   assert.equal(existsSync(join(dshHome, 'plugin-data', 'dsh-ccpg-orchestrator', 'runs', `${newRunId}.json`)), false);
 
+  const originalFetch = globalThis.fetch;
+  let finishLiveFetch;
+  let liveRunId;
+  try {
+    globalThis.fetch = () => new Promise((resolve) => {
+      finishLiveFetch = () => resolve(new Response('ok', { status: 200 }));
+    });
+    const liveRunRes = responseCapture();
+    await route('/wf1/api/run')(request('POST', withSession('/wf1/api/run', 'session-b'), {
+      graph: {
+        nodes: [
+          { id: 'live_input', type: 'input', position: { x: 0, y: 0 }, data: { label: '实时输入', text: 'hello' } },
+          { id: 'live_http', type: 'http', position: { x: 200, y: 0 }, data: { label: '实时请求', url: 'https://example.test', allowPrivate: true } },
+          { id: 'live_output', type: 'output', position: { x: 400, y: 0 }, data: { label: '实时输出' } },
+        ],
+        edges: [
+          { source: 'live_input', target: 'live_http' },
+          { source: 'live_http', target: 'live_output' },
+        ],
+      },
+      triggerInput: '',
+    }), liveRunRes);
+    assert.equal(liveRunRes.status, 200);
+    liveRunId = liveRunRes.json().runId;
+
+    let liveDetail;
+    for (let attempt = 0; attempt < 30; attempt += 1) {
+      const detailRes = responseCapture();
+      await route('/wf1/api/runs/detail')(request('GET', withSession(`/wf1/api/runs/detail?id=${liveRunId}`, 'session-b')), detailRes);
+      liveDetail = detailRes.json();
+      if (liveDetail.nodeStates?.live_http?.status === 'running') break;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.equal(liveDetail.status, 'running');
+    assert.equal(liveDetail.graph.nodes.length, 3);
+    assert.equal(liveDetail.nodeStates.live_input.status, 'success');
+    assert.equal(liveDetail.nodeStates.live_http.status, 'running');
+    assert.equal(liveDetail.nodeStates.live_output, undefined);
+    assert.equal(liveDetail.workspaceRoot, undefined);
+
+    const crossWorkspaceDetail = responseCapture();
+    await route('/wf1/api/runs/detail')(request('GET', withSession(`/wf1/api/runs/detail?id=${liveRunId}`, 'session-a')), crossWorkspaceDetail);
+    assert.equal(crossWorkspaceDetail.status, 404);
+  } finally {
+    finishLiveFetch?.();
+    globalThis.fetch = originalFetch;
+  }
+
+  let finishedLiveRun;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    finishedLiveRun = JSON.parse(readFileSync(join(runsDirB, `${liveRunId}.json`), 'utf8'));
+    if (finishedLiveRun.status !== 'running') break;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.equal(finishedLiveRun.status, 'success');
+
   const resumeGraph = {
     nodes: [
       { id: 'resume_input', type: 'input', position: { x: 0, y: 0 }, data: { label: '输入', text: 'hello' } },


### PR DESCRIPTION
## 背景

消息流工作流卡虽然已有节点状态渲染和轮询，但运行期间 `/wf1/api/runs/detail` 只返回启动时落盘的空快照，导致进度和节点状态直到整条流程结束都不更新。

## 方案

- 运行详情优先读取同工作区的引擎内存快照，并继续隔离其他工作区、移除本地路径和引擎内部字段
- 卡片按完整运行图统计终态节点，显示 `4/10` 一类实时进度
- 已完成、运行中、未开始使用绿/蓝脉冲/灰三种状态，并把状态写入可访问名称

## 验证

- `node dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs`
- `sh dsh-plugins/build-canvasui.sh --check`
- orchestrator 全套 `test/*.test.mjs`
- 实时详情集成测试覆盖运行中快照、完整图和跨工作区 404