### PR TITLE
fix(web): 优化窄屏画布工具栏

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -6,10 +6,11 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "test": "npm run test:variables && npm run test:results && npm run test:scripts",
+    "test": "npm run test:variables && npm run test:results && npm run test:scripts && npm run test:ui",
     "test:variables": "node src/variables.test.mjs && node src/global-variables.test.mjs && node src/json-response.test.mjs && node src/api-base.test.mjs && node src/trial-request.test.mjs && node src/variable-scope.test.mjs && node src/run-event-routing.test.mjs && node src/workflow-serialization.test.mjs",
     "test:results": "node src/result-adapter.test.mjs",
-    "test:scripts": "node src/script-parameters.test.mjs"
+    "test:scripts": "node src/script-parameters.test.mjs",
+    "test:ui": "node src/toolbar-responsive.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1258,30 +1258,33 @@ export default function App() {
   return (
     <div className="app">
       <header className="toolbar">
-        <strong>Workflow One</strong>
+        <strong className="toolbar-brand">Workflow One</strong>
         <nav className="view-tabs">
           <button className={`view-tab ${view === 'canvas' ? 'view-tab-on' : ''}`} onClick={() => setView('canvas')}>画布</button>
           <button className={`view-tab ${view === 'workflows' ? 'view-tab-on' : ''}`} onClick={() => setView('workflows')}>工作流</button>
           <button className={`view-tab ${historyOpen ? 'view-tab-on' : ''}`} onClick={() => setHistoryOpen(true)}>历史</button>
         </nav>
-        {view === 'canvas' && currentWf && <span className="mode-badge" title="当前编辑的工作流">{currentWf.name}{dirty ? ' •' : ''}</span>}
+        {view === 'canvas' && currentWf && <span className="mode-badge toolbar-workflow-badge" title={`当前编辑的工作流：${currentWf.name}`}>{currentWf.name}{dirty ? ' •' : ''}</span>}
         {runtime && (
-          <span className={`mode-badge ${runtime.available ? 'mode-glm' : ''}`} title={runtime.available ? 'agent 节点默认由 dsh (DeepSeek Harness) 驱动' : (runtime.reasons || []).join('；')}>
+          <span className={`mode-badge toolbar-runtime-badge ${runtime.available ? 'mode-glm' : ''}`} title={runtime.available ? 'agent 节点默认由 dsh (DeepSeek Harness) 驱动' : (runtime.reasons || []).join('；')}>
             {runtime.available ? '⚡ dsh 底座' : '内置循环（dsh 不可用）'}
           </span>
         )}
         <div className="toolbar-spacer" />
         {view === 'canvas' && (
           <>
-            {runStatus.running && <span className="mode-badge mode-glm">{doneCount}/{runStatus.total || nodes.length} 节点</span>}
-            <button className="btn tb-refresh-btn" onClick={() => window.location.reload()} title="重新加载当前画布" aria-label="刷新画布"><span aria-hidden="true">⟳</span> 刷新</button>
+            {runStatus.running && <span className="mode-badge mode-glm toolbar-progress-badge">{doneCount}/{runStatus.total || nodes.length} 节点</span>}
+            <button className="btn tb-refresh-btn toolbar-compact-hide" onClick={() => window.location.reload()} title="重新加载当前画布" aria-label="刷新画布"><span aria-hidden="true">⟳</span> 刷新</button>
             <AddNodeMenu onPick={(type) => addNode(type)} />
-            <button className="btn tb-icon-btn" onClick={undo} disabled={!undoInfo.canUndo} title="撤销（Cmd+Z）" aria-label="撤销">↩</button>
-            <button className="btn tb-icon-btn" onClick={redo} disabled={!undoInfo.canRedo} title="重做（Cmd+Shift+Z）" aria-label="重做">↪</button>
+            <button className="btn tb-icon-btn toolbar-compact-hide" onClick={undo} disabled={!undoInfo.canUndo} title="撤销（Cmd+Z）" aria-label="撤销">↩</button>
+            <button className="btn tb-icon-btn toolbar-compact-hide" onClick={redo} disabled={!undoInfo.canRedo} title="重做（Cmd+Shift+Z）" aria-label="重做">↪</button>
             <button className="btn tb-icon-btn" onClick={save} title={dirty ? '保存（Cmd+S）· 有未保存改动' : '保存（Cmd+S）'} aria-label="保存">
               <span className={dirty ? 'save-dot' : ''}>💾</span>
             </button>
             <MoreMenu items={[
+              { key: 'refresh', icon: '⟳', label: '刷新画布', compactOnly: true, onClick: () => window.location.reload() },
+              { key: 'undo', icon: '↩', label: '撤销', hint: 'Cmd+Z', compactOnly: true, disabled: !undoInfo.canUndo, onClick: undo },
+              { key: 'redo', icon: '↪', label: '重做', hint: 'Cmd+Shift+Z', compactOnly: true, disabled: !undoInfo.canRedo, onClick: redo },
               larkStatus?.installed ? { key: 'lark', icon: '◈', label: larkStatus.user?.tokenStatus === 'valid' ? `飞书已登录：${larkStatus.user.userName}` : '飞书登录 / 设置', onClick: () => { setFocusLark(true); setCredOpen(true); } } : null,
               { key: 'variables', icon: '⌘', label: '变量与输入', hint: '实例变量 / 工作流变量 / 运行输入', onClick: () => setVariableCenterOpen(true) },
               { key: 'settings', icon: '⚙', label: '设置', hint: '凭据 / 飞书', onClick: () => setCredOpen(true) },
@@ -1289,9 +1292,9 @@ export default function App() {
               { key: 'reset', icon: '⟲', label: '重置为示例', danger: true, onClick: resetGraph },
             ]} />
             {runStatus.running ? (
-              <button className="btn btn-danger" onClick={cancelRun}>■ 取消</button>
+              <button className="btn btn-danger tb-run-btn" onClick={cancelRun} aria-label="取消运行"><span aria-hidden="true">■</span><span className="tb-run-label">取消</span></button>
             ) : (
-              <button className="btn btn-primary" onClick={run}>▶ 运行</button>
+              <button className="btn btn-primary tb-run-btn" onClick={run} aria-label="运行工作流"><span aria-hidden="true">▶</span><span className="tb-run-label">运行</span></button>
             )}
           </>
         )}

--- a/web/src/ToolbarMenus.jsx
+++ b/web/src/ToolbarMenus.jsx
@@ -30,13 +30,14 @@ export function AddNodeMenu({ onPick }) {
   return (
     <div className="tb-menu" ref={ref}>
       <button
-        className={`btn ${open ? 'btn-menu-on' : ''}`}
+        className={`btn tb-add-btn ${open ? 'btn-menu-on' : ''}`}
         onClick={() => setOpen((v) => !v)}
         aria-haspopup="menu"
         aria-expanded={open}
+        aria-label="添加节点"
         title="添加节点（或双击画布空白处）"
       >
-        ＋ 添加 <span className={`tb-caret ${open ? 'tb-caret-open' : ''}`}>▾</span>
+        <span aria-hidden="true">＋</span><span className="tb-add-label">添加</span><span aria-hidden="true" className={`tb-caret ${open ? 'tb-caret-open' : ''}`}>▾</span>
       </button>
       {open && (
         <div className="tb-dropdown" role="menu">
@@ -104,7 +105,7 @@ export function MoreMenu({ items }) {
       {open && (
         <div className="tb-dropdown tb-dropdown-right" role="menu">
           {items.filter(Boolean).map((it) => (
-            <button key={it.key} role="menuitem" className={`tb-menu-item ${it.danger ? 'tb-menu-danger' : ''}`}
+            <button key={it.key} role="menuitem" className={`tb-menu-item ${it.compactOnly ? 'tb-menu-compact-only' : ''} ${it.danger ? 'tb-menu-danger' : ''}`}
               disabled={it.disabled}
               onClick={() => { setOpen(false); it.onClick?.(); }}>
               {it.icon && <span className="tb-menu-icon tb-menu-glyph">{it.icon}</span>}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -73,7 +73,7 @@ body {
 .app { display: flex; flex-direction: column; height: 100%; }
 .main { flex: 1; display: flex; min-height: 0; }
 .canvas-wrap { flex: 1; min-width: 0; position: relative; }
-.toolbar-spacer { flex: 1; }
+.toolbar-spacer { flex: 1 1 0; min-width: 0; }
 
 /* ============ 工具栏 ============ */
 .toolbar {
@@ -82,11 +82,16 @@ body {
   background: var(--bg-panel);
   border-bottom: 1px solid var(--border);
 }
+.toolbar > :not(.toolbar-spacer), .toolbar .btn { flex-shrink: 0; }
+.toolbar .btn { white-space: nowrap; }
 .toolbar > strong {
   font-size: 15px; font-weight: 700; letter-spacing: .2px;
   background: linear-gradient(135deg, var(--fg), var(--primary));
   -webkit-background-clip: text; background-clip: text; color: transparent;
   margin-right: 4px;
+}
+.toolbar-workflow-badge {
+  max-width: 180px; overflow: hidden; text-overflow: ellipsis;
 }
 
 /* 视图 tab（分段控件） */
@@ -153,11 +158,34 @@ body {
 }
 .tb-menu-item:hover:not(:disabled) { background: rgba(139,92,246,.14); color: var(--fg); }
 .tb-menu-item:disabled { opacity: .4; cursor: default; }
+.tb-menu-compact-only { display: none; }
 .tb-menu-icon { display: inline-flex; width: 16px; color: var(--item-color, var(--fg-faint)); flex-shrink: 0; }
 .tb-menu-glyph { color: var(--fg-faint); font-size: 13px; }
 .tb-menu-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
 .tb-menu-sub { font-size: 11px; color: var(--fg-faint); font-weight: 400; }
 .tb-menu-danger:hover:not(:disabled) { background: rgba(239,68,68,.12); color: #F87171; }
+
+@media (max-width: 860px) {
+  .toolbar { gap: 6px; padding: 8px 10px; }
+  .toolbar-runtime-badge, .toolbar .toolbar-compact-hide, .run-last { display: none; }
+  .tb-menu-compact-only { display: flex; }
+}
+@media (max-width: 760px) {
+  .toolbar-brand { display: none; }
+  .toolbar-workflow-badge { max-width: 120px; }
+}
+@media (max-width: 520px) {
+  .toolbar { gap: 4px; padding: 7px 8px; }
+  .toolbar-workflow-badge, .toolbar-progress-badge { display: none; }
+  .view-tab { padding: 5px 8px; }
+  .tb-add-btn { width: 34px; height: 30px; padding: 0; justify-content: center; }
+  .tb-add-label, .tb-add-btn .tb-caret { display: none; }
+}
+@media (max-width: 360px) {
+  .view-tab { padding-inline: 6px; }
+  .tb-run-btn { width: 34px; padding: 6px; justify-content: center; }
+  .tb-run-label { display: none; }
+}
 
 /* 双击/右键画布弹出的浮动加节点菜单 */
 .tb-canvas-menu {

--- a/web/src/toolbar-responsive.test.mjs
+++ b/web/src/toolbar-responsive.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(fileURLToPath(import.meta.url));
+const app = readFileSync(join(root, 'App.jsx'), 'utf8');
+const menus = readFileSync(join(root, 'ToolbarMenus.jsx'), 'utf8');
+const styles = readFileSync(join(root, 'styles.css'), 'utf8');
+
+assert.match(app, /toolbar-compact-hide/);
+assert.match(app, /compactOnly: true/);
+assert.match(menus, /tb-menu-compact-only/);
+assert.match(styles, /@media \(max-width: 860px\)[\s\S]*toolbar \.toolbar-compact-hide[\s\S]*tb-menu-compact-only/);
+assert.match(styles, /@media \(max-width: 520px\)[\s\S]*tb-add-label/);
+
+console.log('toolbar responsive tests: passed');


### PR DESCRIPTION
## 背景

画布顶部工具栏在窄屏下会换行并出现横向溢出，主要操作的可用性较差。

## 方案

- 按宽度逐级隐藏运行环境、品牌和上下文徽标
- 将刷新、撤销、重做收纳到「更多」，保留桌面端原有入口
- 在极窄屏将添加和运行按钮切换为图标模式，并补齐 aria-label
- 增加零依赖响应式样式回归检查

## 验证

- `cd web && npm test`
- `sh dsh-plugins/build-web.sh`
- 浏览器实测 1180 / 820 / 700 / 520 / 360 / 320px，工具栏保持单行且无横向溢出