### PR TITLE
fix(workflow): 修复运行恢复与成果加载

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -162,13 +162,13 @@ window.__ModuleLoader__.load({
 
     var RUN_STATUS_CN = {
       running: "运行中", success: "已完成", error: "失败",
-      canceled: "已取消", skipped: "已跳过", waiting: "等待审批",
+      canceled: "已取消", interrupted: "异常中断", skipped: "已跳过", waiting: "等待审批",
       queued: "等待中", pending: "未开始",
     };
     function runDotState(run, fallback) {
       var s = run ? run.status : fallback;
       if (s === "success") return "success";
-      if (s === "error" || s === "canceled") return "error";
+      if (s === "error" || s === "canceled" || s === "interrupted") return "error";
       if (s === "waiting") return "waiting";
       if (s === "running" || !run) return "running";
       return "pending";

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -212,6 +212,7 @@ assert.equal(client.__test.runDotState({ status: "running" }), "running");
 assert.equal(client.__test.runDotState({ status: "error" }), "error");
 assert.equal(client.__test.runDotState({ status: "waiting" }), "waiting");
 assert.equal(client.__test.runDotState({ status: "canceled" }), "error");
+assert.equal(client.__test.runDotState({ status: "interrupted" }), "error");
 assert.equal(client.__test.runDotState(null, "running"), "running");
 assert.equal(client.__test.runDotState(null), "running"); // 无数据按运行中
 

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -69,8 +69,18 @@ const parseCronExpression = cronParser.parseExpression?.bind(cronParser)
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const LEGACY_DATA_DIR = join(__dirname, '..', 'data');
 const RUNS_KEEP = 100; // 运行历史保留条数（按开始时间新→旧）
+const REQUEST_BODY_LIMIT = 8_000_000;
+const TERMINAL_NODE_STATUSES = new Set(['success', 'error', 'canceled', 'skipped']);
 let runIdSeq = 0;
 let ctxRef = null;
+
+class RequestBodyError extends Error {
+  constructor(message, status, code) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
 
 // 原子写入：临时文件 + rename，进程中途挂掉不会留截断 JSON
 const atomicWrite = (file, data) => {
@@ -201,10 +211,35 @@ export function apply(ctx, config) {
     res.writeHead(code, { 'Content-Type': 'application/json; charset=utf-8' });
     res.end(JSON.stringify(body));
   };
-  const readBody = (req) => new Promise((resolve) => {
-    let buf = '';
-    req.on('data', (d) => { buf += d; if (buf.length > 8e6) req.destroy(); });
-    req.on('end', () => { try { resolve(JSON.parse(buf || '{}')); } catch { resolve({}); } });
+  const readBody = (req) => new Promise((resolve, reject) => {
+    const chunks = [];
+    let bytes = 0;
+    let failed = false;
+    req.on('data', (value) => {
+      if (failed) return;
+      const chunk = Buffer.isBuffer(value) ? value : Buffer.from(value);
+      bytes += chunk.length;
+      if (bytes > REQUEST_BODY_LIMIT) {
+        failed = true;
+        reject(new RequestBodyError('请求体过大', 413, 'request-body-too-large'));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on('error', (error) => {
+      if (failed) return;
+      failed = true;
+      reject(error);
+    });
+    req.on('end', () => {
+      if (failed) return;
+      try {
+        const text = new TextDecoder('utf-8', { fatal: true }).decode(Buffer.concat(chunks, bytes));
+        resolve(JSON.parse(text || '{}'));
+      } catch {
+        reject(new RequestBodyError('请求体不是有效的 UTF-8 JSON', 400, 'invalid-request-body'));
+      }
+    });
   });
   const sessionStore = (sessionId) => {
     if (!sessionId) throw new Error('缺少当前会话');
@@ -224,11 +259,21 @@ export function apply(ctx, config) {
       handler(req, res) {
         if (!scoped) return handler(req, res);
         try {
-          return workspaceContext.run(requestStore(req), () => {
+          const result = workspaceContext.run(requestStore(req), () => {
             hydrateHistory();
             ensureTriggers();
             return handler(req, res);
           });
+          return result && typeof result.catch === 'function'
+            ? result.catch((error) => {
+                if (!(error instanceof RequestBodyError)) throw error;
+                if (res.writableEnded) return undefined;
+                return json(res, Number(error?.status) || 500, {
+                  error: String(error?.message || error),
+                  code: error?.code || 'request-failed',
+                });
+              })
+            : result;
         } catch (error) {
           return json(res, 409, { error: String(error.message || error), code: 'workspace-session-required' });
         }
@@ -437,7 +482,29 @@ export function apply(ctx, config) {
       try {
         for (const file of readdirSync(dir).filter((name) => name.endsWith('.json'))) {
           try {
-            const run = normalizeRunDocument(JSON.parse(readFileSync(join(dir, file), 'utf8')));
+            const runFile = join(dir, file);
+            let run = normalizeRunDocument(JSON.parse(readFileSync(runFile, 'utf8')));
+            if (run.status === 'running') {
+              const interruptedAt = statSync(runFile).mtime.toISOString();
+              const startedAtMs = run.startedAt ? new Date(run.startedAt).getTime() : NaN;
+              const states = (run.graph?.nodes || []).map((node) => run.nodeStates?.[node.id]);
+              const fullyTerminal = states.length > 0
+                && states.every((state) => TERMINAL_NODE_STATUSES.has(state?.status));
+              const recoveredStatus = fullyTerminal
+                ? states.some((state) => state?.status === 'error') ? 'error'
+                  : states.some((state) => state?.status === 'canceled') ? 'canceled'
+                    : 'success'
+                : 'interrupted';
+              run = normalizeRunDocument({
+                ...run,
+                status: recoveredStatus,
+                interruptedAt,
+                finishedAt: interruptedAt,
+                durationMs: Number.isFinite(startedAtMs) ? Math.max(0, new Date(interruptedAt).getTime() - startedAtMs) : run.durationMs,
+                ...(recoveredStatus === 'interrupted' ? { error: run.error || '运行进程异常终止' } : {}),
+              });
+              atomicJson(runFile, run);
+            }
             if (!byId.has(run.runId)) byId.set(run.runId, run);
           } catch { /* 单条损坏不阻塞其他历史 */ }
         }
@@ -537,6 +604,23 @@ export function apply(ctx, config) {
     else history.unshift(document);
     return document;
   };
+  const checkpointRun = (runId) => {
+    const live = orch?.runs.get(runId);
+    if (!live || live.run.workspaceRoot !== currentStore().workspaceRoot) return;
+    const { workspaceRoot: _workspaceRoot, ...run } = live.run;
+    const graph = {
+      nodes: live.s.graph.nodes.map((node) => ({ id: node.id, type: node.type, position: node.position, data: node.data })),
+      edges: live.s.graph.edges,
+    };
+    writeRun({ ...run, graph, graphFingerprint: graphFingerprint(graph), checkpointedAt: new Date().toISOString() });
+  };
+  const onOrchestratorEvent = (event, payload) => {
+    if (event === 'node-status' && TERMINAL_NODE_STATUSES.has(payload?.status)) {
+      try { checkpointRun(payload.runId); }
+      catch (error) { ctx.logger?.error?.(`dsh-ccpg 运行检查点写入失败（${payload?.runId || 'unknown'}）：${error.message}`); }
+    }
+    broadcast(event, payload);
+  };
 
   // ---- 工作流库 ----
   const wfFile = (id, dir = currentPaths().workflows) => join(dir, `${safeFileId(id, 'invalid')}.json`);
@@ -598,12 +682,12 @@ export function apply(ctx, config) {
     }
   };
   const routeError = (res, error) => {
-    const status = error instanceof VariableStoreError ? error.status : 400;
+    const status = error instanceof VariableStoreError ? error.status : Number(error?.status) || 400;
     json(res, status, { ok: false, error: String(error.message || error), code: error.code || 'invalid-request' });
   };
 
   // ---- 引擎 ----
-  orch = new Orchestrator(ctx, { onEvent: broadcast, renderTemplate });
+  orch = new Orchestrator(ctx, { onEvent: onOrchestratorEvent, renderTemplate });
   orch.nodeRunner = async (node, run, s, ctl) => runAgentNode(ctx, node, run, s, ctl);
   orch.scriptRunner = async ({ node, input, signal, timeoutMs, workflowId, runId }) => {
     const ws = workspaceFor(node, { workflowId: workflowId || 'draft', runId });
@@ -1354,10 +1438,10 @@ export function apply(ctx, config) {
       return { done, total, succeeded };
     };
     const resumable = (r, isLive) => !isLive
-      && ['error', 'canceled'].includes(r.status)
+      && ['error', 'canceled', 'interrupted'].includes(r.status)
       && Boolean(r.graph?.nodes?.length)
       && Object.values(r.nodeStates || {}).some((st) => st?.status === 'success')
-      && Object.values(r.nodeStates || {}).some((st) => !['success', 'skipped'].includes(st?.status));
+      && r.graph.nodes.some((node) => !['success', 'skipped'].includes(r.nodeStates?.[node.id]?.status));
     json(res, 200, {
       runs: runHistory.slice(0, 20).map((r) => {
         const { structuredOutputs, graph, ...summary } = r;
@@ -1548,19 +1632,31 @@ export function apply(ctx, config) {
     if (!prev.graph || !Array.isArray(prev.graph.nodes)) return json(res, 400, { error: '该运行没有图快照，无法续跑' });
     const succeeded = Object.values(prev.nodeStates || {}).filter((st) => st?.status === 'success');
     if (!succeeded.length) return json(res, 400, { error: '该运行没有已完成的节点，无需续跑', code: 'nothing-to-resume' });
-    // 图来源：优先当前画布图（可能是保存后的同名图），须与上次 fingerprint 一致
-    let graph = body.graph || prev.graph;
-    if (graphFingerprint(graph) !== prev.graphFingerprint) {
+    const persistedWorkflow = prev.workflowId ? readWf(prev.workflowId) : null;
+    if (prev.workflowId && !persistedWorkflow) return json(res, 404, { error: '工作流不存在，无法续跑' });
+    let draftGraph = null;
+    if (!prev.workflowId && existsSync(currentStore().graphFile)) {
+      try {
+        const stored = JSON.parse(readFileSync(currentStore().graphFile, 'utf8'));
+        if (!stored.workflowId && Array.isArray(stored.nodes)) draftGraph = stored;
+      } catch { /* 草稿损坏时回退请求图或运行快照 */ }
+    }
+    // 命名工作流以服务端已保存版本为准；草稿优先使用刚保存的服务端图。
+    const graph = persistedWorkflow?.graph || draftGraph || body.graph || prev.graph;
+    const currentFingerprint = graphFingerprint(graph);
+    const previousFingerprint = graphFingerprint(prev.graph);
+    if (currentFingerprint !== previousFingerprint) {
       return json(res, 409, {
         error: '画布图已修改，与上次运行不一致；请重新运行或还原画布',
         code: 'workflow-graph-mismatch',
+        currentFingerprint,
+        previousFingerprint,
       });
     }
     // 沿用上次的触发输入与运行输入：续跑语义是“同样的输入，只补跑没跑完的节点”
     const triggerInput = String(prev.triggerInput || '');
     let runInputs; try { runInputs = assertSafeContextObject(prev.runInputs, 'runInputs'); } catch (error) { return routeError(res, error); }
     let globals; try { globals = globalContext(); } catch (error) { return routeError(res, error); }
-    const persistedWorkflow = prev.workflowId ? readWf(prev.workflowId) : null;
     const workflowVariables = variableDefinitionsToValues(persistedWorkflow?.variables || []);
     const lint = lintGraph(graph);
     if (!lint.ok) return json(res, 400, { error: lint.issues.find((i) => i.level === 'error').message, lint });

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
@@ -24,13 +24,21 @@ function responseCapture() {
   };
 }
 
-function request(method, url, body) {
+function request(method, url, body, splitAt) {
   const req = new EventEmitter();
   req.method = method;
   req.url = url;
   req.headers = {};
   queueMicrotask(() => {
-    if (body !== undefined) req.emit('data', Buffer.from(JSON.stringify(body)));
+    if (body !== undefined) {
+      const raw = Buffer.from(JSON.stringify(body));
+      if (Number.isInteger(splitAt)) {
+        req.emit('data', raw.subarray(0, splitAt));
+        req.emit('data', raw.subarray(splitAt));
+      } else {
+        req.emit('data', raw);
+      }
+    }
     req.emit('end');
   });
   return req;
@@ -58,6 +66,25 @@ const seedLegacy = () => {
   writeFileSync(join(legacyDataDir, 'runs', 'run_it_legacy.json'), JSON.stringify({
     runId: 'run_it_legacy', startedAt: '2026-08-01T00:00:00.000Z', finishedAt: '2026-08-01T00:00:01.000Z',
     status: 'success', triggerInput: '', outputs: {}, structuredOutputs: {}, nodeStates: {}, nodeOrder: [], schemaVersion: 3,
+  }));
+  writeFileSync(join(legacyDataDir, 'runs', 'run_it_interrupted.json'), JSON.stringify({
+    runId: 'run_it_interrupted', startedAt: '2026-08-02T00:00:00.000Z', status: 'running',
+    triggerInput: '', outputs: { input: 'done' }, structuredOutputs: {}, schemaVersion: 3,
+    graph: {
+      nodes: [
+        { id: 'input', type: 'input', position: { x: 0, y: 0 }, data: { label: '输入', text: 'done' } },
+        { id: 'output', type: 'output', position: { x: 200, y: 0 }, data: { label: '输出' } },
+      ],
+      edges: [{ source: 'input', target: 'output' }],
+    },
+    nodeStates: { input: { status: 'success' } },
+    nodeOrder: ['input'],
+  }));
+  writeFileSync(join(legacyDataDir, 'runs', 'run_it_finished_checkpoint.json'), JSON.stringify({
+    runId: 'run_it_finished_checkpoint', startedAt: '2026-08-03T00:00:00.000Z', status: 'running',
+    triggerInput: '', outputs: { input: 'done' }, structuredOutputs: {}, schemaVersion: 3,
+    graph: { nodes: [{ id: 'input', type: 'input', position: { x: 0, y: 0 }, data: { label: '输入', text: 'done' } }], edges: [] },
+    nodeStates: { input: { status: 'success' } }, nodeOrder: ['input'],
   }));
   writeFileSync(join(legacyDataDir, 'state', 'graph.json'), JSON.stringify({ nodes: [], edges: [] }));
 };
@@ -98,6 +125,13 @@ try {
   assert.equal(workflowsA.status, 200);
   assert.ok(workflowsA.json().workflows.some((row) => row.id === 'wf_it_legacy'));
 
+  const runsA = responseCapture();
+  await route('/wf1/api/runs')(request('GET', withSession('/wf1/api/runs', 'session-a')), runsA);
+  const interruptedRun = runsA.json().runs.find((run) => run.runId === 'run_it_interrupted');
+  assert.equal(interruptedRun.status, 'interrupted');
+  assert.equal(interruptedRun.resumable, true);
+  assert.equal(runsA.json().runs.find((run) => run.runId === 'run_it_finished_checkpoint').status, 'success');
+
   const workflowsB = responseCapture();
   await route('/wf1/api/workflows')(request('GET', withSession('/wf1/api/workflows', 'session-b')), workflowsB);
   assert.equal(workflowsB.status, 200);
@@ -110,6 +144,18 @@ try {
   assert.equal(createA.status, 200);
   assert.equal(existsSync(join(workspaceA, '.workflow-one', 'workflows', 'wf_only_a.json')), true);
   assert.equal(existsSync(join(workspaceB, '.workflow-one', 'workflows', 'wf_only_a.json')), false);
+
+  const utf8Workflow = {
+    id: 'wf_utf8', name: '中文分块',
+    graph: { nodes: [{ id: 'utf8_input', type: 'input', position: { x: 0, y: 0 }, data: { label: '输入', text: '审核对象' } }], edges: [] },
+  };
+  const utf8Raw = Buffer.from(JSON.stringify(utf8Workflow));
+  const utf8Split = utf8Raw.indexOf(Buffer.from('审核对象')) + 1;
+  const utf8Create = responseCapture();
+  await route('/wf1/api/workflows')(request('POST', withSession('/wf1/api/workflows', 'session-b'), utf8Workflow, utf8Split), utf8Create);
+  assert.equal(utf8Create.status, 200);
+  const utf8Saved = JSON.parse(readFileSync(join(workspaceB, '.workflow-one', 'workflows', 'wf_utf8.json'), 'utf8'));
+  assert.equal(utf8Saved.graph.nodes[0].data.text, '审核对象');
 
   const runRes = responseCapture();
   await route('/wf1/api/run')(request('POST', withSession('/wf1/api/run', 'session-b'), {
@@ -175,6 +221,12 @@ try {
     assert.equal(liveDetail.nodeStates.live_output, undefined);
     assert.equal(liveDetail.workspaceRoot, undefined);
 
+    const liveCheckpoint = JSON.parse(readFileSync(join(runsDirB, `${liveRunId}.json`), 'utf8'));
+    assert.equal(liveCheckpoint.status, 'running');
+    assert.equal(liveCheckpoint.nodeStates.live_input.status, 'success');
+    assert.equal(liveCheckpoint.outputs.live_input, 'hello');
+    assert.equal(liveCheckpoint.workspaceRoot, undefined);
+
     const crossWorkspaceDetail = responseCapture();
     await route('/wf1/api/runs/detail')(request('GET', withSession(`/wf1/api/runs/detail?id=${liveRunId}`, 'session-a')), crossWorkspaceDetail);
     assert.equal(crossWorkspaceDetail.status, 404);
@@ -201,7 +253,7 @@ try {
   writeFileSync(join(runsDirB, 'run_resume_seed.json'), JSON.stringify({
     runId: 'run_resume_seed', schemaVersion: 3, status: 'error',
     startedAt: '2026-08-24T00:00:00.000Z', finishedAt: '2026-08-24T00:00:01.000Z', durationMs: 1000,
-    triggerInput: '', runInputs: {}, graph: resumeGraph, graphFingerprint: graphFingerprint(resumeGraph),
+    triggerInput: '', runInputs: {}, graph: resumeGraph, graphFingerprint: 'legacy-fingerprint',
     nodeStates: { resume_input: { status: 'success' }, resume_output: { status: 'error', error: '模拟失败' } },
     outputs: { resume_input: 'hello' }, structuredOutputs: {}, nodeOrder: ['resume_input', 'resume_output'],
   }));
@@ -221,6 +273,36 @@ try {
   }), matchingResume);
   assert.equal(matchingResume.status, 200);
   assert.equal(matchingResume.json().resumedFrom, 'run_resume_seed');
+
+  const namedCreate = responseCapture();
+  await route('/wf1/api/workflows')(request('POST', withSession('/wf1/api/workflows', 'session-b'), {
+    id: 'wf_resume_named', name: '命名续跑', graph: changedGraph,
+  }), namedCreate);
+  assert.equal(namedCreate.status, 200);
+  writeFileSync(join(runsDirB, 'run_resume_named_seed.json'), JSON.stringify({
+    runId: 'run_resume_named_seed', schemaVersion: 3, status: 'interrupted', workflowId: 'wf_resume_named',
+    startedAt: '2026-08-24T00:00:00.000Z', finishedAt: '2026-08-24T00:00:01.000Z', durationMs: 1000,
+    triggerInput: '', runInputs: {}, graph: resumeGraph, graphFingerprint: graphFingerprint(resumeGraph),
+    nodeStates: { resume_input: { status: 'success' }, resume_output: { status: 'running' } },
+    outputs: { resume_input: 'hello' }, structuredOutputs: {}, nodeOrder: ['resume_input', 'resume_output'],
+  }));
+  const namedMismatch = responseCapture();
+  await route('/wf1/api/runs/resume')(request('POST', withSession('/wf1/api/runs/resume', 'session-b'), {
+    runId: 'run_resume_named_seed', graph: resumeGraph,
+  }), namedMismatch);
+  assert.equal(namedMismatch.status, 409);
+
+  const namedRestore = responseCapture();
+  await route('/wf1/api/workflows')(request('POST', withSession('/wf1/api/workflows', 'session-b'), {
+    id: 'wf_resume_named', name: '命名续跑', graph: resumeGraph,
+  }), namedRestore);
+  assert.equal(namedRestore.status, 200);
+  const namedResume = responseCapture();
+  await route('/wf1/api/runs/resume')(request('POST', withSession('/wf1/api/runs/resume', 'session-b'), {
+    runId: 'run_resume_named_seed',
+  }), namedResume);
+  assert.equal(namedResume.status, 200);
+  assert.equal(namedResume.json().resumedFrom, 'run_resume_named_seed');
 
   const missingSession = responseCapture();
   await route('/wf1/api/graph')(request('GET', '/wf1/api/graph'), missingSession);

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "test:variables": "node src/variables.test.mjs && node src/global-variables.test.mjs && node src/json-response.test.mjs && node src/api-base.test.mjs && node src/trial-request.test.mjs && node src/variable-scope.test.mjs && node src/run-event-routing.test.mjs && node src/workflow-serialization.test.mjs",
     "test:results": "node src/result-adapter.test.mjs",
     "test:scripts": "node src/script-parameters.test.mjs",
-    "test:ui": "node src/toolbar-responsive.test.mjs"
+    "test:ui": "node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -20,7 +20,7 @@ import {
 import { eventBelongsToCanvas, eventBelongsToRun } from './run-event-routing.js';
 import { useToast, PromptModal, ConfirmModal, Modal } from './ui.jsx';
 
-const STATUS_CN = { running: '运行中', success: '成功', error: '失败', canceled: '已取消', skipped: '跳过', waiting: '等待审批' };
+const STATUS_CN = { running: '运行中', success: '成功', error: '失败', canceled: '已取消', interrupted: '异常中断', skipped: '跳过', waiting: '等待审批' };
 
 import { FlowNode } from './FlowNode.jsx';
 import { EdgeLine } from './EdgeLine.jsx';
@@ -683,7 +683,7 @@ export default function App() {
     const startResume = async () => {
       const res = await fetch(apiUrl('/runs/resume'), {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ runId: resumeCandidate.runId, graph: saved.graph, canvasId: canvasIdRef.current }),
+        body: JSON.stringify({ runId: resumeCandidate.runId, canvasId: canvasIdRef.current }),
       });
       const data = await res.json();
       if (!res.ok) { toast(`续跑失败：${data.error}`, 'error'); return null; }
@@ -695,9 +695,8 @@ export default function App() {
       const listRes = await fetch(apiUrl('/runs'));
       if (listRes.ok) {
         const { runs = [] } = await listRes.json();
-        resumeCandidate = runs.find((r) => r.resumable
-          && !r.live
-          && (r.workflowId || null) === (runWorkflowId || null)) || null;
+        const latestRun = runs.find((r) => (r.workflowId || null) === (runWorkflowId || null)) || null;
+        resumeCandidate = latestRun?.resumable && !latestRun.live ? latestRun : null;
       }
     } catch { /* 历史不可读不阻塞正常运行 */ }
     let runId;
@@ -1468,7 +1467,7 @@ export default function App() {
         >
           <p className="panel-note" style={{ marginBottom: 8 }}>
             上次运行（{new Date(resumeChoice.lastRun.startedAt).toLocaleString('zh-CN', { hour12: false })}）
-            {resumeChoice.lastRun.status === 'error' ? '失败' : '被取消'}，
+            {resumeChoice.lastRun.status === 'interrupted' ? '异常中断' : resumeChoice.lastRun.status === 'error' ? '失败' : '被取消'}，
             已完成 <strong>{resumeChoice.lastRun.progress?.succeeded ?? '?'}/{resumeChoice.lastRun.progress?.total ?? '?'}</strong> 个节点。
           </p>
           <p className="sec-hint">「从上次继续」复用已完成节点的输出，只补跑未完成部分（图未修改）。「重新运行」全部节点从头执行。</p>

--- a/web/src/ResultPanel.jsx
+++ b/web/src/ResultPanel.jsx
@@ -8,6 +8,7 @@ import {
   getArtifactIds,
   getRunId,
   isRunResultsReady,
+  loadRunResults,
   RUN_ARTIFACT_SAVE_PATH,
   saveRunArtifacts,
 } from './result-adapter.js';
@@ -135,22 +136,21 @@ export function ResultPanel({
   const [savedNames, setSavedNames] = useState([]);
   const initialReadyTokenRef = useRef(resultsReadyToken);
   const readyTokenRunRef = useRef(runId);
+  const observedStatus = status?.running
+    ? 'running'
+    : (status?.last || status?.status || runDetail?.status);
+  const runEnded = isRunResultsReady({ runId, status: observedStatus }, true);
 
-  const loadResults = async (signal) => {
+  const loadResults = async (signal, waitUntilReady = false) => {
     if (!runId) return;
     setLoading(true);
     setLoadError('');
     try {
-      for (let attempt = 0; attempt < 8; attempt += 1) {
-        if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, 250 * attempt));
-        const response = await fetch(apiUrl(`/run-results?id=${encodeURIComponent(runId)}`), { signal });
-        const data = await response.json().catch(() => ({}));
-        if (response.ok) {
-          setRemoteResults(data);
-          return;
-        }
-        if (response.status !== 404 || attempt === 7) throw new Error(data.error || `加载成果失败（HTTP ${response.status}）`);
-      }
+      const data = await loadRunResults(
+        apiUrl(`/run-results?id=${encodeURIComponent(runId)}`),
+        { signal, waitUntilReady },
+      );
+      setRemoteResults(data);
     } catch (error) {
       if (error?.name !== 'AbortError') setLoadError(error?.message || String(error));
     } finally {
@@ -164,11 +164,14 @@ export function ResultPanel({
     setActiveTab('result');
     setSaveError('');
     setSavedNames([]);
+  }, [runId, results]);
+
+  useEffect(() => {
     if (!runId || results !== undefined) return undefined;
     const controller = new AbortController();
-    loadResults(controller.signal);
+    loadResults(controller.signal, runEnded);
     return () => controller.abort();
-  }, [runId, results]);
+  }, [runId, results, runEnded]);
 
   useEffect(() => {
     if (readyTokenRunRef.current !== runId) {
@@ -179,7 +182,7 @@ export function ResultPanel({
     if (resultsReadyToken === initialReadyTokenRef.current) return undefined;
     if (!runId || results !== undefined || resultsReadyToken === undefined) return undefined;
     const controller = new AbortController();
-    loadResults(controller.signal);
+    loadResults(controller.signal, true);
     return () => controller.abort();
   }, [resultsReadyToken, runId, results]);
 
@@ -223,7 +226,7 @@ export function ResultPanel({
   const refresh = () => {
     if (!runId) return;
     const controller = new AbortController();
-    loadResults(controller.signal);
+    loadResults(controller.signal, runEnded);
   };
 
   return (
@@ -257,7 +260,7 @@ export function ResultPanel({
 
       <div className="result-panel-body">
         {loadError && <div className="result-load-error"><span>{loadError}</span><button onClick={refresh}>重试</button></div>}
-        {activeTab === 'result' && model.runId && !resultsReady && (
+        {activeTab === 'result' && model.runId && !resultsReady && !loadError && (
           <div className="result-loading"><LoaderCircle className="result-spin" size={17} />正在整理成果</div>
         )}
         {!loading && !model.runId && <p className="result-empty result-empty-run">运行工作流后，成果、过程和问题会显示在这里。</p>}

--- a/web/src/RunHistory.jsx
+++ b/web/src/RunHistory.jsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import { apiUrl } from './api.js';
 import { Modal } from './ui.jsx';
 
-const STATUS_LABEL = { running: '运行中', success: '成功', error: '失败', canceled: '已取消' };
+const STATUS_LABEL = { running: '运行中', success: '成功', error: '失败', canceled: '已取消', interrupted: '异常中断' };
 
 function progressText(r) {
   const p = r.progress;

--- a/web/src/result-adapter.js
+++ b/web/src/result-adapter.js
@@ -142,6 +142,22 @@ export function isRunResultsReady(model, hasLoadedResults = true) {
   return !['idle', 'queued', 'pending', 'running', 'waiting'].includes(model.status);
 }
 
+export async function loadRunResults(url, { signal, waitUntilReady = false } = {}, fetchImpl = globalThis.fetch) {
+  const attempts = waitUntilReady ? 32 : 8;
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, Math.min(250 * attempt, 1000)));
+    const response = await fetchImpl(url, { signal });
+    const data = await response.json().catch(() => ({}));
+    if (response.ok && (!waitUntilReady || isRunResultsReady(data, true))) return data;
+    if (response.ok || response.status === 404) {
+      if (attempt < attempts - 1) continue;
+      throw new Error(waitUntilReady ? '成果整理超时，请重试' : (data.error || '运行记录不存在'));
+    }
+    throw new Error(data.error || `加载成果失败（HTTP ${response.status}）`);
+  }
+  throw new Error('加载成果失败');
+}
+
 function normalizeLink(link) {
   if (typeof link === 'string') return { url: link, label: link };
   const value = asObject(link);

--- a/web/src/result-adapter.test.mjs
+++ b/web/src/result-adapter.test.mjs
@@ -45,6 +45,7 @@ const runDetail = {
 
 assert.equal(getRunId(runDetail, {}, {}), 'run-42');
 assert.equal(getRunId(null, { runId: 'run-live' }, null), 'run-live');
+assert.deepEqual(getRunStatusMeta('interrupted'), { label: '异常中断', tone: 'danger' });
 
 const fallback = adaptRunResults({}, { runDetail });
 assert.equal(fallback.runId, 'run-42');

--- a/web/src/result-adapter.test.mjs
+++ b/web/src/result-adapter.test.mjs
@@ -9,6 +9,7 @@ import {
   getRunId,
   isRunResultsReady,
   isTechnicalArtifact,
+  loadRunResults,
   normalizeRunEvent,
   RUN_ARTIFACT_SAVE_PATH,
   saveRunArtifacts,
@@ -201,6 +202,18 @@ assert.deepEqual(savedArtifactNames(['/Users/demo/report.pdf', 'folder\\slides.p
 assert.equal(isRunResultsReady({ runId: 'r1', status: 'running' }, true), false);
 assert.equal(isRunResultsReady({ runId: 'r1', status: 'success' }, false), false);
 assert.equal(isRunResultsReady({ runId: 'r1', status: 'success' }, true), true);
+
+let resultRequests = 0;
+const completedResults = await loadRunResults('/run-results?id=r1', { waitUntilReady: true }, async () => {
+  resultRequests += 1;
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ runId: 'r1', status: resultRequests === 1 ? 'running' : 'success' }),
+  };
+});
+assert.equal(resultRequests, 2, '运行结束后应跳过旧的 running 快照并继续拉取最终成果');
+assert.equal(completedResults.status, 'success');
 
 let saveRequest;
 const saveResponse = await saveRunArtifacts('/wf1/api/run-artifacts/save', {

--- a/web/src/resume-workflow.test.mjs
+++ b/web/src/resume-workflow.test.mjs
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const app = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'App.jsx'), 'utf8');
+
+assert.match(app, /const latestRun = runs\.find/);
+assert.match(app, /resumeCandidate = latestRun\?\.resumable/);
+assert.doesNotMatch(app, /runId: resumeCandidate\.runId, graph:/);
+
+console.log('resume workflow tests: passed');

--- a/web/src/run-view-state.js
+++ b/web/src/run-view-state.js
@@ -12,6 +12,7 @@ const STATUS_META = {
   success: { label: '已完成', tone: 'success' },
   error: { label: '运行失败', tone: 'danger' },
   canceled: { label: '已取消', tone: 'neutral' },
+  interrupted: { label: '异常中断', tone: 'danger' },
 };
 
 export function getRunStatusMeta(status) {

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -929,6 +929,7 @@ body {
 .rh-status.st-error { background: var(--danger); }
 .rh-status.st-running { background: var(--warn); }
 .rh-status.st-canceled { background: var(--fg-faint); }
+.rh-status.st-interrupted { background: var(--danger); }
 .rh-name { font-weight: 600; }
 .rh-meta { color: var(--fg-faint); margin-left: auto; white-space: nowrap; font-size: 12px; }
 .rh-node { border: 1px solid var(--border); border-radius: 8px; padding: 6px 10px; margin-top: 6px; font-size: 13px; }


### PR DESCRIPTION
## 背景

大工作流异常终止后无法从已完成节点继续，前端误报画布已修改；同时成果面板可能先读到运行中的旧快照，在最终事件漏失或请求竞态后永久显示“正在整理成果”。

## 方案

- 请求体按 Buffer 聚合后一次性严格 UTF-8 解码，按字节限制大小
- 节点进入终态时原子写入轻量运行检查点
- 启动时将孤立 running 恢复为 interrupted；完整终态检查点直接收敛为最终状态
- 续跑由服务端加载当前持久化图，并与历史图快照重新计算指纹
- 自动续跑只检查当前工作流最近一次运行，不再回退到旧取消记录
- web 与消息卡展示“异常中断”状态
- 成果面板在运行结束后主动等待终态快照，超时显示可重试错误，不再永久转圈
- 保留 run-results-ready 事件作为快速刷新通道

## 验证

- `npm test`：全部单测通过
- `cd web && npm test`
- `sh dsh-plugins/build-canvasui.sh --check`
- `sh dsh-plugins/build-web.sh`
- CI `test + build` 通过
- 集成覆盖：中文跨网络分块、终态检查点、孤立运行恢复、旧指纹兼容、命名工作流服务端权威图校验、旧 running 成果快照后继续拉取终态结果

## 工作区恢复

已在目标工作区外部完成数据修复：恢复 n_rv2 干净提示词，工作流与草稿镜像指纹一致；原始 `.workflow-one` 已保留时间戳备份。
