### PR TITLE
ci(release): 自动发布自包含聚合包

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+          registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: |
             web/package-lock.json
@@ -40,8 +41,26 @@ jobs:
           sh dsh-plugins/boot-smoke.sh \
             "dist-release/dsh-ccpg-plugins-$(echo "$GITHUB_REF_NAME" | sed 's/^v//').tar.gz"
 
+      - name: build aggregate npm package
+        run: sh dsh-plugins/publish-npm.sh --dry-run
+        env:
+          SKIP_BUILD: '1'
+
       - name: upload asset
         uses: softprops/action-gh-release@v2
         with:
-          files: dist-release/dsh-ccpg-plugins-*.tar.gz
+          files: |
+            dist-release/dsh-ccpg-plugins-*.tar.gz
+            dist-release/dsh-ccpg-one-*.tgz
           generate_release_notes: true
+
+      - name: publish aggregate package to npm
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          if npm view "dsh-ccpg-one@$VERSION" version --registry https://registry.npmjs.org >/dev/null 2>&1; then
+            echo "dsh-ccpg-one@$VERSION already published"
+            exit 0
+          fi
+          npm publish "dist-release/dsh-ccpg-one-$VERSION.tgz" --registry https://registry.npmjs.org --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -133,9 +133,9 @@ dsh plugin --profile myprofile add dsh-ccpg-brand
 
 `pack.sh <tag>`：7 个默认插件 + 独立可选 brand 清单校验 → 画布双构建 → orchestrator 依赖 → canvasui bundle 重建并 `--check` → rsync 组装（清运行时数据）→ `dist-release/dsh-ccpg-plugins-<tag>.tar.gz`。通用发布归档仍携带 brand 源包供显式安装，但 `setup.sh` 和 `dsh-ccpg-one` 都不会自动安装它。CI（release.yml）同源执行并作为 release asset 上传。
 
-`sh publish-npm.sh --dry-run` 会构建并逐包执行 npm 发布预检；去掉 `--dry-run` 后按实现包、brand、聚合包的顺序发布。默认发布到官方 npm registry，需要私有 registry 时用 `NPM_REGISTRY` 覆盖。每个 tarball 都必须包含 MIT LICENSE、bundle patch 和自身运行时资源，`scripts/verify-plugin-packages.mjs` 是 CI 门禁。
+`sh publish-npm.sh --dry-run` 会构建并验证单一聚合包 `dsh-ccpg-one`：7 个默认插件作为 `bundleDependencies` 放进同一个 tarball，子插件和 brand 不单独发布。去掉 `--dry-run` 才上传官方 npm registry；tag 必须与聚合包版本一致。GitHub `release.yml` 先上传 release 资产，再使用仓库 Actions Secret `NPM_TOKEN` 发布聚合包，失败后可安全重跑（已存在版本会自动跳过）。
 
 ## 已知边界
 
 - SDK 软链指向本机 dsh 安装——换机器重跑 `setup.sh` 自动重链
-- npm 发布需要仓库所有者配置 npm 身份；代码与包内容不保存 token
+- npm 首次发布需要仓库所有者配置具备 `dsh-ccpg-one` 发布权限的 granular token 为 Actions Secret `NPM_TOKEN`；代码与包内容不保存 token

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -31,6 +31,19 @@
     "dsh-ccpg-tools": "0.1.0",
     "dsh-ccpg-web": "0.1.0"
   },
+  "bundleDependencies": [
+    "dsh-ccpg-canvasui",
+    "dsh-ccpg-document-preview",
+    "dsh-ccpg-larkauth",
+    "dsh-ccpg-llm-guard",
+    "dsh-ccpg-orchestrator",
+    "dsh-ccpg-tools",
+    "dsh-ccpg-web"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "dsh": {
     "bundle": {
       "patch": "./cordis.patch.yml"

--- a/dsh-plugins/publish-npm.sh
+++ b/dsh-plugins/publish-npm.sh
@@ -1,19 +1,61 @@
 #!/bin/sh
-# 发布自包含 npm 插件：实现包先发，聚合包最后发。
+# 只发布 dsh-ccpg-one；七个内部插件作为 bundleDependencies 装进同一个 npm 包。
 set -e
 HERE=$(cd "$(dirname "$0")" && pwd)
+REPO_ROOT=$(cd "$HERE/.." && pwd)
 MODE="${1:-}"
 NPM_REGISTRY="${NPM_REGISTRY:-https://registry.npmjs.org}"
+PACK_DIR="${NPM_PACK_DIR:-$REPO_ROOT/dist-release}"
+PACKAGES="dsh-ccpg-tools dsh-ccpg-orchestrator dsh-ccpg-web dsh-ccpg-canvasui dsh-ccpg-document-preview dsh-ccpg-larkauth dsh-ccpg-llm-guard"
 [ -z "$MODE" ] || [ "$MODE" = "--dry-run" ] || { echo "用法: sh publish-npm.sh [--dry-run]"; exit 1; }
 
-sh "$HERE/build-web.sh"
-node "$HERE/../scripts/verify-plugin-packages.mjs"
+VERSION=$(node -e "console.log(require(process.argv[1]).version)" "$HERE/dsh-ccpg-one/package.json")
+[ -z "${GITHUB_REF_NAME:-}" ] || [ "$GITHUB_REF_NAME" = "v$VERSION" ] \
+  || { echo "✗ tag $GITHUB_REF_NAME 与聚合包版本 v$VERSION 不一致"; exit 1; }
 
-for pkg in \
-  dsh-ccpg-tools dsh-ccpg-orchestrator dsh-ccpg-web dsh-ccpg-canvasui \
-  dsh-ccpg-document-preview dsh-ccpg-larkauth dsh-ccpg-llm-guard dsh-ccpg-brand \
-  dsh-ccpg-one
-do
-  echo "→ npm publish $pkg ${MODE}"
-  (cd "$HERE/$pkg" && npm publish --registry "$NPM_REGISTRY" --access public $MODE)
+if [ "${SKIP_BUILD:-}" != "1" ]; then
+  sh "$HERE/build-web.sh"
+  node "$REPO_ROOT/scripts/verify-plugin-packages.mjs"
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT INT TERM
+STAGE="$TMP/dsh-ccpg-one"
+mkdir -p "$STAGE/node_modules" "$TMP/packages" "$PACK_DIR"
+cp "$HERE/dsh-ccpg-one/package.json" "$HERE/dsh-ccpg-one/cordis.patch.yml" "$STAGE/"
+cp -R "$HERE/dsh-ccpg-one/lib" "$STAGE/lib"
+[ ! -f "$HERE/dsh-ccpg-one/LICENSE" ] || cp "$HERE/dsh-ccpg-one/LICENSE" "$STAGE/LICENSE"
+
+for pkg in $PACKAGES; do
+  (cd "$HERE/$pkg" && npm pack --silent --ignore-scripts --pack-destination "$TMP/packages" >/dev/null)
+  mkdir -p "$STAGE/node_modules/$pkg"
+  tar -xzf "$TMP/packages/$pkg-$VERSION.tgz" --strip-components=1 -C "$STAGE/node_modules/$pkg"
 done
+
+(cd "$STAGE" && npm pack --silent --ignore-scripts --pack-destination "$PACK_DIR" >/dev/null)
+TARBALL="$PACK_DIR/dsh-ccpg-one-$VERSION.tgz"
+for pkg in $PACKAGES; do
+  tar -tzf "$TARBALL" "package/node_modules/$pkg/package.json" >/dev/null
+done
+tar -tzf "$TARBALL" package/node_modules/dsh-ccpg-web/web-dist/index.html >/dev/null
+tar -tzf "$TARBALL" package/node_modules/dsh-ccpg-canvasui/lib/client.js >/dev/null
+echo "✓ 聚合 npm 包已校验: $TARBALL ($(du -h "$TARBALL" | cut -f1))"
+
+mkdir -p "$TMP/install-smoke"
+npm install --prefix "$TMP/install-smoke" "$TARBALL" --ignore-scripts --no-audit --no-fund --registry "$NPM_REGISTRY" >/dev/null
+for pkg in $PACKAGES; do
+  [ -f "$TMP/install-smoke/node_modules/dsh-ccpg-one/node_modules/$pkg/package.json" ] \
+    || [ -f "$TMP/install-smoke/node_modules/$pkg/package.json" ] \
+    || { echo "✗ npm 安装后缺少 bundled dependency: $pkg"; exit 1; }
+done
+echo "✓ 聚合 npm 包全新安装 smoke 通过"
+
+if npm view "dsh-ccpg-one@$VERSION" version --registry "$NPM_REGISTRY" >/dev/null 2>&1; then
+  echo "✓ dsh-ccpg-one@$VERSION 已发布，跳过重复 publish"
+  exit 0
+fi
+if [ "$MODE" != "--dry-run" ] && [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+  echo "✗ 缺少 NODE_AUTH_TOKEN（GitHub Actions 中配置 NPM_TOKEN secret）"
+  exit 1
+fi
+npm publish "$TARBALL" --registry "$NPM_REGISTRY" --access public $MODE

--- a/scripts/verify-plugin-packages.mjs
+++ b/scripts/verify-plugin-packages.mjs
@@ -35,6 +35,13 @@ for (const name of packages) {
   assert.equal(pkg.engines?.node, '>=20');
   assert.equal(pkg.dsh?.bundle?.patch, './cordis.patch.yml');
 
+  // 聚合包的最终 bundle 由 publish-npm.sh 在干净 staging 中逐项校验；
+  // 源码目录可能有 pnpm node_modules，直接 dry-run 会错误枚举整个依赖树。
+  if (name === 'dsh-ccpg-one') {
+    console.log(`✓ ${name}: aggregate manifest`);
+    continue;
+  }
+
   const packed = JSON.parse(execFileSync('npm', ['pack', '--dry-run', '--ignore-scripts', '--json'], {
     cwd: dir,
     encoding: 'utf8',
@@ -48,9 +55,11 @@ for (const name of packages) {
 }
 
 const aggregate = JSON.parse(readFileSync(join(pluginsDir, 'dsh-ccpg-one', 'package.json'), 'utf8'));
-for (const name of packages.filter((name) => name !== 'dsh-ccpg-one' && name !== 'dsh-ccpg-brand')) {
+const aggregatePackages = packages.filter((name) => name !== 'dsh-ccpg-one' && name !== 'dsh-ccpg-brand');
+for (const name of aggregatePackages) {
   assert.equal(aggregate.dependencies[name], aggregate.version, `${name} must match aggregate version`);
 }
+assert.deepEqual([...aggregate.bundleDependencies].sort(), [...aggregatePackages].sort(), 'aggregate must bundle every internal package');
 assert.match(aggregate.dependencies['dsh-better-sidebar'], /^\d+\.\d+\.\d+$/);
 assert(!Object.values(aggregate.dependencies).some((version) => String(version).startsWith('file:')));
 console.log('plugin package contracts: ok');


### PR DESCRIPTION
## 背景

GitHub Release 只上传 tar.gz，没有向 npm 发布，导致 dsh plugin add dsh-ccpg-one@0.1.0 返回 404。用户只需要一个聚合包，不希望 7 个实现包分别发布。

## 方案

- 将 7 个默认插件声明为 dsh-ccpg-one 的 bundleDependencies
- 在干净 staging 中组装单一 5.5MB npm tarball，内部插件不单独发布
- release Action 先构建并安装 smoke，再上传 GitHub Release 资产，最后使用 NPM_TOKEN 发布 npm
- tag 与 package 版本必须一致；已发布版本自动跳过，Action 可安全重跑
- brand 保持独立且不发布

## 验证

- sh -n dsh-plugins/publish-npm.sh
- release.yml YAML 解析通过
- SKIP_BUILD=1 sh dsh-plugins/publish-npm.sh --dry-run
- 空目录 npm install smoke 通过，7 个 bundled dependencies 全部存在