### PR TITLE
docs(readme): 提升 Workflow One 项目发现与安装转化

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,28 @@
-# harness-one — dsh 插件开发工作区
+# Workflow One
 
-本仓库是 **dsh（DeepSeek Harness）插件开发工作区**：在这里开发、构建、分发跑在 dsh 进程内的 Cordis 插件；未来任何新 dsh 插件都在这里孵化，命名延续 `dsh-ccpg-*` 前缀（ccpg 系列）。
+**运行在 [DeepSeek Harness（dsh）](https://github.com/deepseek-ai/deepseek-harness) 中的可视化 AI 工作流编排器。** 用拖拽 DAG 组合真实 dsh agent、脚本、条件分支和 HTTP 节点，实时查看运行进度，异常后从中断节点恢复，并将成果写回飞书。
 
-当前主体是 **Workflow One 物业智能体编排套件**（7 个默认 `dsh-ccpg-*` 插件 + 独立可选 brand + `web/` 画布）：拖拽式工作流画布跑在 dsh 进程内，**每个智能体节点是一个真实 dsh agent**（自主循环、bash/文件系统工具、会话持久化、技能系统），以当前 dsh 会话工作目录为 cwd 读取项目文件，节点交付物隔离写入工作区 `.workflow-one/runtime/`。画布 → 拓扑调度 → 节点状态实时回流，全链路闭环。
+[![npm](https://img.shields.io/npm/v/dsh-ccpg-one)](https://www.npmjs.com/package/dsh-ccpg-one)
+[![CI](https://github.com/chumingjun/harness-one/actions/workflows/ci.yml/badge.svg)](https://github.com/chumingjun/harness-one/actions/workflows/ci.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/chumingjun/harness-one)](https://github.com/chumingjun/harness-one/releases/latest)
+[![MIT License](https://img.shields.io/github/license/chumingjun/harness-one)](LICENSE)
 
-- 画布入口：`http://127.0.0.1:4021/wf1/`（dsh web profile）
-- 官方 dsh Web UI：`http://127.0.0.1:4021/`（同进程同端口；主区保留官方对话，点击输入框旁工作流按钮展开右侧画布）
-- 右侧工作台侧边栏：官方 UI 右侧为 [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar)（setup.sh 默认从 npm 安装）；我们的「工作流」tab 排在其 + 菜单第一位
+![Workflow One 完整工作流画布](images/workflow01.png)
 
-> 远程访问：setup.sh 里 webserver host 默认 `127.0.0.1`，局域网/Tailscale 需改 `0.0.0.0`（dsh agent 有 bash 能力，仅在可信网络开放）。官方 UI 的 settings/credentials 等特权页仅限 loopback（远程 403 属安全设计），插件自有路由不受影响。
+## 立即安装
+
+Node.js >= 20 且已安装 `@deepseek-ai/dsh`：
+
+```sh
+dsh plugin --profile web add dsh-ccpg-one@0.1.1
+dsh web
+```
+
+Harness Desktop 用户在 **Open DSH Terminal** 中执行 `dsh plugin add dsh-ccpg-one@0.1.1`，然后重启 Desktop。也可以从 [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest) 下载离线聚合包。
 
 ## 界面与使用方式
 
 Workflow One 嵌在 dsh 官方界面中：左侧保留与智能体的对话，中间是可缩放的工作流画布。节点按连线组成 DAG，可以串行执行，也可以并行分组、条件分支和失败打回。紫色节点是智能体，橙色节点负责条件判定；运行时节点会直接显示排队、执行、成功或失败状态。
-
-![Workflow One 完整工作流画布](images/workflow01.png)
 
 典型使用流程：
 
@@ -32,7 +40,7 @@ Workflow One 嵌在 dsh 官方界面中：左侧保留与智能体的对话，�
 **Harness Desktop（npm 包发布后）**：从 Desktop 托盘打开 **Open DSH Terminal**，对当前 profile 安装并重启 Desktop：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.1.0
+dsh plugin add dsh-ccpg-one@0.1.1
 ```
 
 Desktop 使用官方 DSH/Cordis 插件组合，不需要另一套插件。不要在 Desktop 里运行 `setup.sh`：Desktop 自己管理 profile、Node/pnpm 和随机 loopback 端口；飞书账号页首次点击「自动安装」时，lark-cli 会通过 Desktop 的受管 pnpm 安装到当前 profile。安装使用细节、环境差异与常见问题排查见 [`dsh-plugins/DESKTOP.md`](dsh-plugins/DESKTOP.md)；Desktop 开发兼容契约（`desktopProfiles`/`desktopPnpm` 动态探测、跨环境插件写法）也在该文档第 2 节。

--- a/dsh-plugins/DESKTOP.md
+++ b/dsh-plugins/DESKTOP.md
@@ -13,7 +13,7 @@ TL;DR：**Desktop 不需要任何专用安装脚本或专用插件分支**——
 从 Desktop 托盘菜单打开 **Open DSH Terminal**（该终端已绑定当前 profile），执行：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.1.0
+dsh plugin add dsh-ccpg-one@0.1.1
 ```
 
 聚合包自带 `dsh.bundle.patch`：`dsh plugin add` 一步完成「装依赖 + 进 bundles 层 + 挂载」7 个默认插件与 better-sidebar。安装完成后**重启 Desktop**（新 bundle 要在下一次 Loader 组合中生效）。

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -22,7 +22,7 @@
 从 Desktop 托盘打开 **Open DSH Terminal**；该终端已绑定当前 profile：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.1.0
+dsh plugin add dsh-ccpg-one@0.1.1
 ```
 
 安装后重启 Desktop，让新 bundle 进入 Loader 组合。compatibility 与 advanced 模式都继续使用普通 DSH Web Client；画布、同源 `/wf1/api/*`、侧栏和预览无需 Desktop 专用注册。飞书账号页首次点击「自动安装」时，插件通过公开 `desktopPnpm` service 把固定版本 lark-cli 安装到当前 profile，并在 profile 切换或退出时取消仍在运行的操作。
@@ -109,7 +109,7 @@ sh start.sh dev
 聚合包和 7 个默认插件均为带 `dsh.bundle.patch` 的自描述包。推荐一条命令：
 
 ```sh
-dsh plugin --profile myprofile add dsh-ccpg-one@0.1.0
+dsh plugin --profile myprofile add dsh-ccpg-one@0.1.1
 ```
 
 需要 CCPG 品牌外观时，再显式安装独立插件：

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package-lock.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-ccpg-document-preview",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@file-viewer/pptx": "2.3.0",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,13 +1,32 @@
 {
   "name": "dsh-ccpg-one",
-  "version": "0.1.0",
-  "description": "Workflow One 聚合壳：一条命令装齐七个默认 dsh-ccpg 插件（可选件按 CCPG_* 环境变量门控）",
+  "version": "0.1.1",
+  "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/chumingjun/harness-one.git",
     "directory": "dsh-plugins/dsh-ccpg-one"
   },
+  "homepage": "https://github.com/chumingjun/harness-one#readme",
+  "bugs": {
+    "url": "https://github.com/chumingjun/harness-one/issues"
+  },
+  "keywords": [
+    "deepseek",
+    "dsh",
+    "dsh-plugin",
+    "ai-agents",
+    "agentic-workflow",
+    "workflow-automation",
+    "visual-workflow",
+    "multi-agent",
+    "dag",
+    "react-flow",
+    "feishu",
+    "lark",
+    "cordis"
+  ],
   "engines": {
     "node": ">=20"
   },
@@ -23,13 +42,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.15.2",
-    "dsh-ccpg-canvasui": "0.1.0",
-    "dsh-ccpg-document-preview": "0.1.0",
-    "dsh-ccpg-larkauth": "0.1.0",
-    "dsh-ccpg-llm-guard": "0.1.0",
-    "dsh-ccpg-orchestrator": "0.1.0",
-    "dsh-ccpg-tools": "0.1.0",
-    "dsh-ccpg-web": "0.1.0"
+    "dsh-ccpg-canvasui": "0.1.1",
+    "dsh-ccpg-document-preview": "0.1.1",
+    "dsh-ccpg-larkauth": "0.1.1",
+    "dsh-ccpg-llm-guard": "0.1.1",
+    "dsh-ccpg-orchestrator": "0.1.1",
+    "dsh-ccpg-tools": "0.1.1",
+    "dsh-ccpg-web": "0.1.1"
   },
   "bundleDependencies": [
     "dsh-ccpg-canvasui",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-ccpg-orchestrator",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 背景

仓库已公开并发布 npm 聚合包，但 GitHub 首屏仍以开发工作区为主，搜索元数据和 npm 关键词不足，社区用户难以快速理解和安装。

## 方案

- README 首屏改为 Workflow One 产品定位、真实画布截图和一条安装命令
- 补齐 npm homepage、bugs、keywords 与英文搜索描述
- 同步聚合包及七个内置插件版本为 0.1.1
- GitHub 仓库描述、Homepage 与 `dsh-plugin` 等 topics 已同步更新

## 验证

- `npm test`
- `sh dsh-plugins/build-web.sh`
- `node scripts/verify-plugin-packages.mjs`
- `SKIP_BUILD=1 sh dsh-plugins/publish-npm.sh --dry-run`
- 聚合包全新安装 smoke：通过（7 bundled dependencies，109 files）