### PR TITLE
feat(orchestrator): 断点续跑改为按节点子图校验，改图不再一刀切拒绝

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -1667,8 +1667,7 @@ export function apply(ctx, config) {
     const plan = {
       reusableNodes: reusable.map(nodeLabel),
       rerunNodes: rerun.map(nodeLabel),
-    };
-    if (body?.preview) return json(res, 200, plan);
+    };    if (body?.preview) return json(res, 200, plan);
     if (!reusable.length) {
       return json(res, 400, {
         error: '画布改动已覆盖全部已完成节点的上游，无可复用结果，请直接重新运行',
@@ -1697,7 +1696,8 @@ export function apply(ctx, config) {
       globalVariables: globals.globalVariables, workflowVariables, runInputs,
       source: 'resume', resume: resumeSeed,
     });
-    json(res, 200, { started: true, runId, resumedFrom: prev.runId, resumedNodes: reusable.length, rerunNodes: rerun.length, ...plan });
+    // rerunNodes 为节点 label 数组（明细），数字计数由前端取 length
+    json(res, 200, { started: true, runId, resumedFrom: prev.runId, resumedNodes: reusable.length, rerunCount: rerun.length, ...plan });
   } });
 
   // 工作流导出 / 导入（画布间分享：{ name, graph } 单文件）

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -38,7 +38,7 @@ import {
   snapshotRunArtifacts,
   streamArtifactResponse,
 } from './run-results.js';
-import { graphFingerprint, runMatchesGraphScope, selectScopedRun, summarizeNodeStates, summarizeOutputs, summarizeStructuredOutputs } from './run-scope.js';
+import { graphFingerprint, resumeDiff, runMatchesGraphScope, selectScopedRun, summarizeNodeStates, summarizeOutputs, summarizeStructuredOutputs } from './run-scope.js';
 import { buildVariableSchema } from './variable-schema.js';
 import {
   createStructuredEnvelope,
@@ -67,7 +67,11 @@ const parseCronExpression = cronParser.parseExpression?.bind(cronParser)
   ?? cronParser.default?.parseExpression?.bind(cronParser.default);
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const LEGACY_DATA_DIR = join(__dirname, '..', 'data');
+// 测试可用 WF1_LEGACY_DATA_DIR 指向隔离目录，避免把开发机真实 data/ 当 legacy 导入。
+// 惰性读取：测试在 import 之后才设 env，模块级常量会过早固化成真实路径。
+const legacyDataDir = () => (process.env.WF1_LEGACY_DATA_DIR
+  ? resolve(process.env.WF1_LEGACY_DATA_DIR)
+  : join(__dirname, '..', 'data'));
 const RUNS_KEEP = 100; // 运行历史保留条数（按开始时间新→旧）
 const REQUEST_BODY_LIMIT = 8_000_000;
 const TERMINAL_NODE_STATUSES = new Set(['success', 'error', 'canceled', 'skipped']);
@@ -129,7 +133,7 @@ export function apply(ctx, config) {
     cpSync(source, target, { recursive: true, force: true, errorOnExist: false });
   };
   const initializeStore = (workspaceRoot) => {
-    const paths = createStoragePaths({ workspaceRoot, legacyRoot: LEGACY_DATA_DIR });
+    const paths = createStoragePaths({ workspaceRoot, legacyRoot: legacyDataDir() });
     const rootExisted = existsSync(paths.root);
     const marker = join(paths.state, 'legacy-import.json');
     for (const dir of [paths.root, paths.state, paths.workflows, paths.attachments, paths.runs, paths.runtime, join(paths.state, 'tombstones', 'workflows')]) {
@@ -1636,8 +1640,8 @@ export function apply(ctx, config) {
     json(res, 200, { started: true, runId, replayOf: prev.runId });
   } });
 
-  // 断点续跑：从上次运行的 success 节点之后继续。图必须与上次一致（fingerprint），
-  // 否则产物/模板引用对不上——提示用户重新运行。
+  // 断点续跑：逐节点判定上次 success 输出能否复用（“自身 + 全部上游”子图未变即可复用）。
+  // 改卡住的节点、改没跑过的下游、加删无关节点都不再拦截续跑；只有改到成功节点自身或其上游才让该节点重跑。
   register({ kind: 'exact', path: '/wf1/api/runs/resume', async handler(req, res) {
     if (req.method !== 'POST') return json(res, 405, { error: 'method' });
     const body = await readBody(req);
@@ -1658,30 +1662,42 @@ export function apply(ctx, config) {
     }
     // 命名工作流以服务端已保存版本为准；草稿优先使用刚保存的服务端图。
     const graph = persistedWorkflow?.graph || draftGraph || body.graph || prev.graph;
-    const currentFingerprint = graphFingerprint(graph);
-    const previousFingerprint = graphFingerprint(prev.graph);
-    if (currentFingerprint !== previousFingerprint) {
-      return json(res, 409, {
-        error: '画布图已修改，与上次运行不一致；请重新运行或还原画布',
-        code: 'workflow-graph-mismatch',
-        currentFingerprint,
-        previousFingerprint,
+    const nodeLabel = (nodeId) => (graph.nodes.find((n) => n.id === nodeId)?.data?.label) || nodeId;
+    const { reusable, rerun } = resumeDiff(prev.graph, graph, prev.nodeStates || {});
+    const plan = {
+      reusableNodes: reusable.map(nodeLabel),
+      rerunNodes: rerun.map(nodeLabel),
+    };
+    if (body?.preview) return json(res, 200, plan);
+    if (!reusable.length) {
+      return json(res, 400, {
+        error: '画布改动已覆盖全部已完成节点的上游，无可复用结果，请直接重新运行',
+        code: 'nothing-reusable',
+        ...plan,
       });
     }
-    // 沿用上次的触发输入与运行输入：续跑语义是“同样的输入，只补跑没跑完的节点”
+    // 沿用上次的触发输入与运行输入：续跑语义是“同样的输入，只补跑没跑完的节点”。
+    // resume 种子裁剪到可复用节点：失效的 success 节点与其余未完成节点一并重新执行。
     const triggerInput = String(prev.triggerInput || '');
     let runInputs; try { runInputs = assertSafeContextObject(prev.runInputs, 'runInputs'); } catch (error) { return routeError(res, error); }
     let globals; try { globals = globalContext(); } catch (error) { return routeError(res, error); }
     const workflowVariables = variableDefinitionsToValues(persistedWorkflow?.variables || []);
     const lint = lintGraph(graph);
     if (!lint.ok) return json(res, 400, { error: lint.issues.find((i) => i.level === 'error').message, lint });
+    const reusableSet = new Set(reusable);
+    const resumeSeed = {
+      runId: prev.runId,
+      nodeStates: Object.fromEntries(Object.entries(prev.nodeStates || {}).filter(([id]) => reusableSet.has(id))),
+      outputs: Object.fromEntries(Object.entries(prev.outputs || {}).filter(([id]) => reusableSet.has(id))),
+      structuredOutputs: Object.fromEntries(Object.entries(prev.structuredOutputs || {}).filter(([id]) => reusableSet.has(id))),
+    };
     const { runId } = startRun(graph, {
       triggerInput, workflowName: prev.workflowName || null, workflowId: prev.workflowId || null,
       canvasId: body.canvasId || prev.canvasId || null,
       globalVariables: globals.globalVariables, workflowVariables, runInputs,
-      source: 'resume', resume: prev,
+      source: 'resume', resume: resumeSeed,
     });
-    json(res, 200, { started: true, runId, resumedFrom: prev.runId, resumedNodes: succeeded.length });
+    json(res, 200, { started: true, runId, resumedFrom: prev.runId, resumedNodes: reusable.length, rerunNodes: rerun.length, ...plan });
   } });
 
   // 工作流导出 / 导入（画布间分享：{ name, graph } 单文件）

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/run-scope.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/run-scope.js
@@ -31,7 +31,45 @@ export function graphFingerprint(graph) {
 
 export function upstreamGraphFingerprint(graph, targetNodeId) {
   if (!targetNodeId) return graphFingerprint(graph);
+  const { ancestors } = upstreamScope(graph, targetNodeId);
+  return graphFingerprint({
+    nodes: (graph?.nodes || []).filter((node) => ancestors.has(node.id)),
+    edges: (graph?.edges || []).filter((edge) => ancestors.has(edge.source) && ancestors.has(edge.target)),
+  });
+}
+
+// targetNodeId 及其全部祖先（不含自身）。图快照可能带 position 等非语义字段，统一走 graphFingerprint 的语义归一。
+export function subgraphFingerprint(graph, targetNodeId) {
+  if (!targetNodeId) return graphFingerprint(graph);
+  const { node, ancestors } = upstreamScope(graph, targetNodeId);
+  if (!node) return null; // 目标节点在图中不存在
+  return graphFingerprint({
+    nodes: [node, ...(graph?.nodes || []).filter((n) => ancestors.has(n.id))],
+    edges: (graph?.edges || []).filter((edge) => (ancestors.has(edge.source) || edge.source === targetNodeId)
+      && (ancestors.has(edge.target) || edge.target === targetNodeId)),
+  });
+}
+
+// 断点续跑可用性：逐节点比对“产出该输出的子图”（自身 + 全部上游）是否变化。
+// success 节点：子图未变 → 可复用输出；自身或任一上游变化/消失 → 需重跑。
+// 其余状态节点本来就要执行，不参与判定。
+export function resumeDiff(prevGraph, currentGraph, prevNodeStates = {}) {
+  const reusable = [];
+  const rerun = [];
+  const successIds = Object.entries(prevNodeStates || {})
+    .filter(([, state]) => state?.status === 'success')
+    .map(([nodeId]) => nodeId);
+  for (const nodeId of successIds) {
+    const fp = subgraphFingerprint(prevGraph, nodeId);
+    const reusableNow = fp !== null && fp === subgraphFingerprint(currentGraph, nodeId);
+    (reusableNow ? reusable : rerun).push(nodeId);
+  }
+  return { reusable, rerun };
+}
+
+function upstreamScope(graph, targetNodeId) {
   const edges = graph?.edges || [];
+  const node = (graph?.nodes || []).find((n) => n.id === targetNodeId) || null;
   const ancestors = new Set();
   const pending = edges.filter((edge) => edge.target === targetNodeId).map((edge) => edge.source);
   while (pending.length) {
@@ -42,11 +80,7 @@ export function upstreamGraphFingerprint(graph, targetNodeId) {
       if (edge.target === id && !ancestors.has(edge.source)) pending.push(edge.source);
     }
   }
-  return graphFingerprint({
-    nodes: (graph?.nodes || []).filter((node) => ancestors.has(node.id)),
-    edges: edges.filter((edge) => ancestors.has(edge.source)
-      && (ancestors.has(edge.target) || edge.target === targetNodeId)),
-  });
+  return { node, ancestors };
 }
 
 export function runMatchesGraphScope(run, graph, targetNodeId) {

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/run-scope.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/run-scope.js
@@ -34,11 +34,12 @@ export function upstreamGraphFingerprint(graph, targetNodeId) {
   const { ancestors } = upstreamScope(graph, targetNodeId);
   return graphFingerprint({
     nodes: (graph?.nodes || []).filter((node) => ancestors.has(node.id)),
-    edges: (graph?.edges || []).filter((edge) => ancestors.has(edge.source) && ancestors.has(edge.target)),
+    edges: (graph?.edges || []).filter((edge) => ancestors.has(edge.source)
+      && (ancestors.has(edge.target) || edge.target === targetNodeId)),
   });
 }
 
-// targetNodeId 及其全部祖先（不含自身）。图快照可能带 position 等非语义字段，统一走 graphFingerprint 的语义归一。
+// 目标节点自身 + 全部祖先的子图指纹。图快照可能带 position 等非语义字段，统一走 graphFingerprint 的语义归一。
 export function subgraphFingerprint(graph, targetNodeId) {
   if (!targetNodeId) return graphFingerprint(graph);
   const { node, ancestors } = upstreamScope(graph, targetNodeId);

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/engine-resume.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/engine-resume.test.mjs
@@ -143,4 +143,31 @@ await test('续跑种子为空对象时行为等同全新运行', async () => {
   assert.equal(run.resumedFrom, undefined);
 });
 
-console.log(passed === 3 ? 'engine resume tests: ALL PASS' : 'engine resume tests: FAILED');
+await test('续跑种子被裁剪时：不在种子里的 success 节点照常重跑', async () => {
+  // 入口层按“子图指纹”裁剪失效节点后传入部分种子：mid 因自身被改被剔除，
+  // 引擎应重跑 mid 并以其新输出渲染 out，同时 in 的旧输出照常复用。
+  const { orch: orch1 } = makeOrch(async (node) => `old:${node.id}`);
+  const first = await orch1.run(chainGraph(), { runId: 'run_prune' });
+  assert.equal(first.status, 'success');
+
+  const calls = [];
+  const { orch: orch2 } = makeOrch(async (node) => {
+    calls.push(node.id);
+    return `new:${node.id}`;
+  });
+  const resumed = await orch2.run(chainGraph(), {
+    runId: 'run_prune_resume',
+    resume: {
+      runId: 'run_prune',
+      nodeStates: { in: first.nodeStates.in },
+      outputs: { in: first.outputs.in },
+      structuredOutputs: { in: first.structuredOutputs.in },
+    },
+  });
+  assert.equal(resumed.status, 'success');
+  assert.deepEqual(calls, ['mid']);
+  assert.equal(resumed.nodeStates.in.resumed, true);
+  assert.match(resumed.outputs.out, /new:mid/);
+});
+
+console.log(passed === 4 ? 'engine resume tests: ALL PASS' : 'engine resume tests: FAILED');

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
@@ -53,6 +53,11 @@ mkdirSync(workspaceA, { recursive: true });
 mkdirSync(workspaceB, { recursive: true });
 const original = process.env.DSH_HOME;
 process.env.DSH_HOME = dshHome;
+// 隔离包级 legacy 目录：开发机插件 data/ 里可能有真实历史运行，混入会按时间排序挤掉测试 seed（run_it_*）
+const packageLegacyDir = join(dshHome, 'package-legacy');
+mkdirSync(join(packageLegacyDir, 'state'), { recursive: true });
+process.env.WF1_LEGACY_DATA_DIR = packageLegacyDir;
+writeFileSync(join(packageLegacyDir, "state", "graph.json"), JSON.stringify({ nodes: [], edges: [] }));
 
 const legacyDataDir = join(dshHome, 'plugin-data', 'dsh-ccpg-orchestrator');
 const seedLegacy = () => {
@@ -279,14 +284,33 @@ try {
     outputs: { resume_input: 'hello' }, structuredOutputs: {}, nodeOrder: ['resume_input', 'resume_output'],
   }));
 
+  // 改的是未完成节点（resume_output）→ 不再拦截，success 节点照常复用
   const changedGraph = structuredClone(resumeGraph);
-  changedGraph.nodes[0].data.text = 'changed';
+  changedGraph.nodes[1].data.inputTemplate = 'changed';
   const changedResume = responseCapture();
   await route('/wf1/api/runs/resume')(request('POST', withSession('/wf1/api/runs/resume', 'session-b'), {
     runId: 'run_resume_seed', graph: changedGraph,
   }), changedResume);
-  assert.equal(changedResume.status, 409);
-  assert.equal(changedResume.json().code, 'workflow-graph-mismatch');
+  assert.equal(changedResume.status, 200);
+  assert.equal(changedResume.json().resumedNodes, 1);
+
+  // 改到 success 节点自身（resume_input）→ 无可复用节点，400 nothing-reusable
+  const brokenGraph = structuredClone(resumeGraph);
+  brokenGraph.nodes[0].data.text = 'changed';
+  const brokenResume = responseCapture();
+  await route('/wf1/api/runs/resume')(request('POST', withSession('/wf1/api/runs/resume', 'session-b'), {
+    runId: 'run_resume_seed', graph: brokenGraph,
+  }), brokenResume);
+  assert.equal(brokenResume.status, 400);
+  assert.equal(brokenResume.json().code, 'nothing-reusable');
+
+  // preview 模式：只返回复用/重跑明细，不启动运行
+  const previewResume = responseCapture();
+  await route('/wf1/api/runs/resume')(request('POST', withSession('/wf1/api/runs/resume', 'session-b'), {
+    runId: 'run_resume_seed', graph: brokenGraph, preview: true,
+  }), previewResume);
+  assert.equal(previewResume.status, 200);
+  assert.deepEqual(previewResume.json(), { reusableNodes: [], rerunNodes: ['输入'] });
 
   const matchingResume = responseCapture();
   await route('/wf1/api/runs/resume')(request('POST', withSession('/wf1/api/runs/resume', 'session-b'), {
@@ -295,9 +319,10 @@ try {
   assert.equal(matchingResume.status, 200);
   assert.equal(matchingResume.json().resumedFrom, 'run_resume_seed');
 
+  // 命名工作流场景：已保存版本改了 success 节点（resume_input）→ 无可复用节点拒绝
   const namedCreate = responseCapture();
   await route('/wf1/api/workflows')(request('POST', withSession('/wf1/api/workflows', 'session-b'), {
-    id: 'wf_resume_named', name: '命名续跑', graph: changedGraph,
+    id: 'wf_resume_named', name: '命名续跑', graph: brokenGraph,
   }), namedCreate);
   assert.equal(namedCreate.status, 200);
   writeFileSync(join(runsDirB, 'run_resume_named_seed.json'), JSON.stringify({
@@ -311,7 +336,8 @@ try {
   await route('/wf1/api/runs/resume')(request('POST', withSession('/wf1/api/runs/resume', 'session-b'), {
     runId: 'run_resume_named_seed', graph: resumeGraph,
   }), namedMismatch);
-  assert.equal(namedMismatch.status, 409);
+  assert.equal(namedMismatch.status, 400);
+  assert.equal(namedMismatch.json().code, 'nothing-reusable');
 
   const namedRestore = responseCapture();
   await route('/wf1/api/workflows')(request('POST', withSession('/wf1/api/workflows', 'session-b'), {

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
@@ -293,6 +293,10 @@ try {
   }), changedResume);
   assert.equal(changedResume.status, 200);
   assert.equal(changedResume.json().resumedNodes, 1);
+  // 响应明细：可复用/重跑节点 label 数组（RunHistory 弹窗直接展示）
+  assert.deepEqual(changedResume.json().reusableNodes, ['输入']);
+  assert.deepEqual(changedResume.json().rerunNodes, []);
+  assert.equal(changedResume.json().rerunCount, 0);
 
   // 改到 success 节点自身（resume_input）→ 无可复用节点，400 nothing-reusable
   const brokenGraph = structuredClone(resumeGraph);

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/variable-system.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/variable-system.test.mjs
@@ -5,7 +5,7 @@ import {
 } from '../lib/output-contract.js';
 import { renderTemplate, validateTemplate } from '../lib/template.js';
 import { buildVariableSchema } from '../lib/variable-schema.js';
-import { graphFingerprint, runMatchesGraphScope, selectScopedRun, summarizeNodeStates, summarizeOutputs, summarizeStructuredOutputs, upstreamGraphFingerprint } from '../lib/run-scope.js';
+import { graphFingerprint, resumeDiff, runMatchesGraphScope, selectScopedRun, subgraphFingerprint, summarizeNodeStates, summarizeOutputs, summarizeStructuredOutputs, upstreamGraphFingerprint } from '../lib/run-scope.js';
 import { resolveInside, safeFilename } from '../lib/safe-path.js';
 
 let passed = 0;
@@ -301,6 +301,82 @@ await test('目标模板可编辑但上游执行图变化会隔离最近运行',
   assert.equal(upstreamGraphFingerprint(runGraph, 'target'), upstreamGraphFingerprint(editedTarget, 'target'));
   assert.equal(runMatchesGraphScope(run, editedTarget, 'target'), true);
   assert.equal(runMatchesGraphScope(run, editedSource, 'target'), false);
+});
+
+await test('subgraphFingerprint 含目标节点自身：改目标或改上游均变，改无关下游不变', () => {
+  const runGraph = {
+    nodes: [
+      { id: 'source', type: 'http', data: { url: 'https://example.com/a' } },
+      { id: 'target', type: 'output', data: { inputTemplate: 'old' } },
+      { id: 'sink', type: 'output', data: { inputTemplate: 's' } },
+    ],
+    edges: [
+      { source: 'source', target: 'target' },
+      { source: 'target', target: 'sink' },
+    ],
+  };
+  const editedTarget = { ...runGraph, nodes: runGraph.nodes.map((node) => node.id === 'target'
+    ? { ...node, data: { ...node.data, inputTemplate: 'new' } } : node) };
+  const editedSource = { ...runGraph, nodes: runGraph.nodes.map((node) => node.id === 'source'
+    ? { ...node, data: { ...node.data, url: 'https://example.com/b' } } : node) };
+  const editedSink = { ...runGraph, nodes: runGraph.nodes.map((node) => node.id === 'sink'
+    ? { ...node, data: { ...node.data, inputTemplate: 's2' } } : node) };
+  assert.equal(subgraphFingerprint(runGraph, 'target'), subgraphFingerprint(editedSink, 'target'));
+  assert.notEqual(subgraphFingerprint(runGraph, 'target'), subgraphFingerprint(editedTarget, 'target'));
+  assert.notEqual(subgraphFingerprint(runGraph, 'target'), subgraphFingerprint(editedSource, 'target'));
+  // 快照图与当前图 position 差异不影响语义指纹
+  const movedTarget = { ...runGraph, nodes: runGraph.nodes.map((node) => ({ ...node, position: { x: 9, y: 9 } })) };
+  assert.equal(subgraphFingerprint(runGraph, 'target'), subgraphFingerprint(movedTarget, 'target'));
+});
+
+await test('resumeDiff：改失败节点/未跑下游可全量复用，改成功节点自身或其上游才失效', () => {
+  const prevGraph = {
+    nodes: [
+      { id: 'in', type: 'input', data: { label: '输入', text: 'hello' } },
+      { id: 'mid', type: 'agent', data: { label: '中转', prompt: 'p' } },
+      { id: 'out', type: 'output', data: { label: '汇总', inputTemplate: '{{$upstream}}' } },
+      { id: 'tail', type: 'output', data: { label: '尾部', inputTemplate: '{{$upstream}}' } },
+    ],
+    edges: [
+      { source: 'in', target: 'mid' },
+      { source: 'mid', target: 'out' },
+      { source: 'out', target: 'tail' },
+    ],
+  };
+  const states = {
+    in: { status: 'success' },
+    mid: { status: 'error' },
+    out: { status: 'skipped' },
+  }; // tail 从未执行
+  const edit = (id, data) => ({ ...prevGraph, nodes: prevGraph.nodes.map((node) => node.id === id
+    ? { ...node, data: { ...node.data, ...data } } : node) });
+
+  // 改卡住的 mid（error 节点）：全部 success 照常复用
+  assert.deepEqual(resumeDiff(prevGraph, edit('mid', { prompt: 'fixed' }), states),
+    { reusable: ['in'], rerun: [] });
+  // 改从未执行的 tail：同上
+  assert.deepEqual(resumeDiff(prevGraph, edit('tail', { inputTemplate: 'x' }), states),
+    { reusable: ['in'], rerun: [] });
+  // 删掉未执行的 tail（加新节点同理）：同上
+  const removedTail = {
+    nodes: prevGraph.nodes.filter((node) => node.id !== 'tail'),
+    edges: prevGraph.edges.filter((edge) => edge.source !== 'out' && edge.target !== 'tail'),
+  };
+  assert.deepEqual(resumeDiff(prevGraph, removedTail, states), { reusable: ['in'], rerun: [] });
+
+  // in 自身被改 → in 失效；success 下游（此处无）依赖其输出也失效
+  const states2 = { in: { status: 'success' }, mid: { status: 'success' }, out: { status: 'skipped' } };
+  assert.deepEqual(resumeDiff(prevGraph, edit('in', { text: 'changed' }), states2),
+    { reusable: [], rerun: ['in', 'mid'] });
+  // 改上游（in）导致 mid 失效；只改 mid 时仅 mid 失效、in 复用
+  assert.deepEqual(resumeDiff(prevGraph, edit('mid', { prompt: 'changed' }), states2),
+    { reusable: ['in'], rerun: ['mid'] });
+  // 图里消失的成功节点判失效
+  const removedMid = {
+    nodes: prevGraph.nodes.filter((node) => node.id !== 'mid'),
+    edges: prevGraph.edges.filter((edge) => edge.source !== 'mid' && edge.target !== 'mid'),
+  };
+  assert.deepEqual(resumeDiff(prevGraph, removedMid, states2), { reusable: ['in'], rerun: ['mid'] });
 });
 
 await test('完成运行不通过 SSE 全局快照恢复', () => {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -78,8 +78,8 @@ export default function App() {
   const [focusLark, setFocusLark] = useState(false); // 从 ⋯ 打开设置时聚焦授权区
   const [testNode, setTestNode] = useState(null); // 试运行弹窗目标节点
   const [nodeDetail, setNodeDetail] = useState(null); // 日志行点击 → { runId, nodeId }
-  // 断点续跑选择弹窗：待启动的图 + 可续跑的上次运行
-  const [resumeChoice, setResumeChoice] = useState(null); // { lastRun, startFresh, startResume }
+  // 断点续跑选择弹窗：待启动的图 + 可续跑的上次运行 + preview 返回的复用/重跑明细
+  const [resumeChoice, setResumeChoice] = useState(null); // { lastRun, plan, startFresh, startResume }
   const [feishuCreds, setFeishuCreds] = useState([]);
   const { screenToFlowPosition, fitView } = useReactFlow();
   const nodesRef = useRef(nodes);
@@ -701,23 +701,46 @@ export default function App() {
     } catch { /* 历史不可读不阻塞正常运行 */ }
     let runId;
     if (resumeCandidate) {
-      const choice = await new Promise((resolve) => {
-        setResumeChoice({
-          lastRun: resumeCandidate,
-          startFresh: () => resolve('fresh'),
-          startResume: () => resolve('resume'),
+      // 先问服务端这次能复用多少：明细随画布改动逐节点判定（不再要求全图一致）
+      let plan = null;
+      try {
+        const previewRes = await fetch(apiUrl('/runs/resume'), {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ runId: resumeCandidate.runId, canvasId: canvasIdRef.current, preview: true }),
         });
-      });
-      setResumeChoice(null);
-      if (choice === 'resume') {
-        // 保留画布上已完成节点的状态展示；只清未完成节点的错误残留
-        setNodes((nds) => nds.map((n) => (['error', 'canceled', 'running'].includes(n.data?.runStatus)
-          ? { ...n, data: { ...n.data, runStatus: 'idle', runError: null } }
-          : n)));
-        runId = await startResume();
-        if (runId) toast(`已续跑：复用上次 ${resumeCandidate.progress?.succeeded ?? '?'} 个已完成节点`, 'success');
-      } else {
+        if (previewRes.ok) plan = await previewRes.json();
+      } catch { /* preview 失败按无明细处理，不阻塞选择 */
+        plan = null;
+      }
+      if (plan && !plan.reusableNodes?.length) {
+        // 画布改动覆盖了全部已完成节点的上游：无从复用，直接全新运行
         runId = await startFresh();
+      } else {
+        const choice = await new Promise((resolve) => {
+          setResumeChoice({
+            lastRun: resumeCandidate,
+            plan,
+            startFresh: () => resolve('fresh'),
+            startResume: () => resolve('resume'),
+          });
+        });
+        setResumeChoice(null);
+        if (choice === 'resume') {
+          // 保留画布上已完成节点的状态展示；只清未完成节点的错误残留
+          setNodes((nds) => nds.map((n) => (['error', 'canceled', 'running'].includes(n.data?.runStatus)
+            ? { ...n, data: { ...n.data, runStatus: 'idle', runError: null } }
+            : n)));
+          runId = await startResume();
+          if (runId) {
+            const reused = plan?.reusableNodes?.length ?? resumeCandidate.progress?.succeeded ?? '?';
+            const rerunCount = plan?.rerunNodes?.length ?? 0;
+            toast(rerunCount
+              ? `已续跑：复用 ${reused} 个已完成节点，${rerunCount} 个因画布修改将重跑`
+              : `已续跑：复用上次 ${reused} 个已完成节点`, 'success');
+          }
+        } else {
+          runId = await startFresh();
+        }
       }
     } else {
       runId = await startFresh();
@@ -1470,16 +1493,32 @@ export default function App() {
             {resumeChoice.lastRun.status === 'interrupted' ? '异常中断' : resumeChoice.lastRun.status === 'error' ? '失败' : '被取消'}，
             已完成 <strong>{resumeChoice.lastRun.progress?.succeeded ?? '?'}/{resumeChoice.lastRun.progress?.total ?? '?'}</strong> 个节点。
           </p>
-          <p className="sec-hint">「从上次继续」复用已完成节点的输出，只补跑未完成部分（图未修改）。「重新运行」全部节点从头执行。</p>
+          {resumeChoice.plan ? (
+            <>
+              <p className="sec-hint">
+                「从上次继续」将复用 {resumeChoice.plan.reusableNodes.length} 个已完成节点的输出
+                {resumeChoice.plan.rerunNodes.length > 0 && (
+                  <>；<strong>{resumeChoice.plan.rerunNodes.length} 个因画布修改将重跑</strong>（{resumeChoice.plan.rerunNodes.join('、')}）</>
+                )}，其余未完成节点照常补跑。「重新运行」全部节点从头执行。
+              </p>
+              {resumeChoice.plan.reusableNodes.length > 0 && (
+                <p className="sec-hint">复用节点：{resumeChoice.plan.reusableNodes.join('、')}</p>
+              )}
+            </>
+          ) : (
+            <p className="sec-hint">「从上次继续」复用已完成节点的输出，只补跑未完成部分。「重新运行」全部节点从头执行。</p>
+          )}
         </Modal>
       )}
       {historyOpen && <RunHistory onClose={() => setHistoryOpen(false)}
-        onResume={(runId, resumedNodes) => {
+        onResume={(runId, resumedNodes, rerunNodes) => {
           activeRunIdRef.current = runId;
           runningRef.current = true;
           setInspectedRunId(runId);
           setRunStatus((current) => ({ ...current, running: true, runId }));
-          toast(`已从上次运行续跑（复用 ${resumedNodes} 个已完成节点）`, 'success');
+          toast(rerunNodes
+            ? `已从上次运行续跑（复用 ${resumedNodes} 个节点，${rerunNodes} 个因画布修改重跑）`
+            : `已从上次运行续跑（复用 ${resumedNodes} 个已完成节点）`, 'success');
         }}
         onSelect={(runId) => {
         setInspectedRunId(runId);

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -734,7 +734,7 @@ export default function App() {
           if (runId) {
             const reused = plan?.reusableNodes?.length ?? resumeCandidate.progress?.succeeded ?? '?';
             const rerunCount = plan?.rerunNodes?.length ?? 0;
-            toast(rerunCount
+            toast(rerunCount > 0
               ? `已续跑：复用 ${reused} 个已完成节点，${rerunCount} 个因画布修改将重跑`
               : `已续跑：复用上次 ${reused} 个已完成节点`, 'success');
           }
@@ -1516,8 +1516,9 @@ export default function App() {
           runningRef.current = true;
           setInspectedRunId(runId);
           setRunStatus((current) => ({ ...current, running: true, runId }));
-          toast(rerunNodes
-            ? `已从上次运行续跑（复用 ${resumedNodes} 个节点，${rerunNodes} 个因画布修改重跑）`
+          const rerunCount = rerunNodes?.length ?? 0;
+          toast(rerunCount > 0
+            ? `已从上次运行续跑（复用 ${resumedNodes} 个节点，${rerunCount} 个因画布修改重跑）`
             : `已从上次运行续跑（复用 ${resumedNodes} 个已完成节点）`, 'success');
         }}
         onSelect={(runId) => {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -284,6 +284,14 @@ export default function App() {
       if (!appliesToActiveRun(p)) return;
       setProgress((prev) => ({ ...prev, [p.nodeId]: p }));
       setNodes((nds) => nds.map((n) => (n.id === p.nodeId ? { ...n, data: { ...n.data, livePreview: p.preview, liveTurns: p.turns } } : n)));
+      // 过程 tab 实时过程：运行中节点的轮次 + 输出预览随 SSE 进入时间线
+      if (p.turns != null || p.preview) {
+        pushEntry({
+          kind: 'node', status: 'running', nodeId: p.nodeId, runId: p.runId,
+          nodeLabel: labelOf(nodesRef.current, p.nodeId).replace(/\(.*\)$/, ''),
+          turns: p.turns, preview: p.preview, live: true,
+        });
+      }
     });
     es.addEventListener('assistant-patch', (e) => {
       const p = JSON.parse(e.data);

--- a/web/src/ResultPanel.jsx
+++ b/web/src/ResultPanel.jsx
@@ -76,6 +76,12 @@ function ProcessView({ events, runId, onFocusNode, onOpenNodeDetail }) {
                 </div>
               )}
               {event.error && <p className="result-step-text">{event.error}</p>}
+              {event.status === 'running' && (event.turns != null || event.preview) && (
+                <div className="result-step-live">
+                  {event.turns != null && <span className="result-step-live-turns">第 {event.turns} 轮</span>}
+                  {event.preview && <pre className="result-step-live-preview">{event.preview}</pre>}
+                </div>
+              )}
               {canOpenDetail && <span className="result-detail-link">查看节点详情 <ChevronRight size={12} /></span>}
             </div>
           </li>

--- a/web/src/RunHistory.jsx
+++ b/web/src/RunHistory.jsx
@@ -30,7 +30,7 @@ export function RunHistory({ onClose, onSelect, onResume }) {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error || '续跑失败');
-      onResume?.(data.runId, data.resumedNodes);
+      onResume?.(data.runId, data.resumedNodes, data.rerunNodes);
       onClose();
     } catch (e) {
       alert(`无法续跑：${e.message}`);
@@ -61,7 +61,7 @@ export function RunHistory({ onClose, onSelect, onResume }) {
             </button>
             {r.resumable && (
               <button className="btn btn-sm rh-resume" disabled={resuming === r.runId}
-                title="从上次完成的节点之后继续运行（图未修改时可用）"
+                title="从上次完成的节点之后继续运行（改过卡住的节点也不影响，可复用的输出自动保留）"
                 onClick={() => resumeRun(r.runId)}>
                 {resuming === r.runId ? '启动中…' : `续跑 ${progressText(r)}`}
               </button>

--- a/web/src/result-adapter.js
+++ b/web/src/result-adapter.js
@@ -251,6 +251,10 @@ export function normalizeRunEvent(event, index = 0) {
     status,
     nodeId: first(value.nodeId, value.node?.id),
     nodeLabel: first(value.nodeLabel, value.label, value.node?.label),
+    turns: value.turns,
+    preview: textOf(value.preview) || undefined,
+    durationMs: value.durationMs,
+    startedAt: first(value.startedAt, value.startedat),
     text: textOf(first(value.text, value.message, value.error, value.detail, value.summary)),
     meta: first(value.meta, value.durationMs != null ? formatDuration(value.durationMs) : undefined),
     raw: event,
@@ -318,9 +322,21 @@ export function adaptRunResults(payload, context = {}) {
   const sourceTimeline = asArray(source.nodeTimeline).length
     ? source.nodeTimeline.map((row) => normalizeResultRow(row, nodes, runDetail)).filter(isRuntimeNode)
     : fallback;
+  const liveNodesSeen = new Set();
   const nodeTimeline = sourceTimeline.map((row) => {
     const live = liveByNode.get(row.nodeId);
-    const merged = live ? { ...row, status: live.status || row.status, error: live.text || row.error } : row;
+    if (live) liveNodesSeen.add(row.nodeId);
+    // live 事件是此刻真实状态（detail 是启动快照/竞态残影），status/轮次/预览以 live 为准
+    const merged = live
+      ? {
+        ...row,
+        status: live.status || row.status,
+        error: live.text || row.error,
+        turns: live.turns ?? row.turns,
+        preview: live.preview ?? row.preview,
+        durationMs: live.status === 'running' ? undefined : first(live.durationMs, row.durationMs),
+      }
+      : row;
     return {
       ...merged,
       id: `node:${row.nodeId}`,
@@ -329,6 +345,24 @@ export function adaptRunResults(payload, context = {}) {
       meta: merged.durationMs != null ? formatDuration(merged.durationMs) : undefined,
     };
   });
+  // run-results/detail 尚未就绪时（live 运行），时间线骨架可能缺失该节点：用 live 事件补行
+  for (const [nodeId, live] of liveByNode) {
+    if (liveNodesSeen.has(nodeId)) continue;
+    if (live.status === 'queued' || live.status === 'pending') continue;
+    nodeTimeline.push({
+      id: `node:${nodeId}`,
+      kind: 'node',
+      nodeId,
+      nodeLabel: live.nodeLabel || nodeId,
+      nodeType: nodes.get(nodeId)?.type,
+      status: live.status || 'running',
+      error: live.text,
+      turns: live.turns,
+      preview: live.preview,
+      startedAt: live.startedAt,
+      text: timelineText({ status: live.status || 'running', error: live.text }),
+    });
+  }
   const runEvents = [
     ...asArray(context.events), ...asArray(source.events), ...asArray(source.process),
     ...asArray(result.events), ...asArray(result.process),

--- a/web/src/result-adapter.test.mjs
+++ b/web/src/result-adapter.test.mjs
@@ -86,6 +86,32 @@ const partialEvents = adaptRunResults({}, {
 assert.equal(partialEvents.nodeTimeline.length, 3, '不完整 SSE 不能覆盖完整流程节点');
 assert.equal(partialEvents.nodeTimeline.find((row) => row.nodeId === 'agent').status, 'running');
 
+// live 运行：agent-progress 事件带轮次与流式输出预览，运行中节点在时间线上可见实时过程
+const liveRun = adaptRunResults({}, {
+  runDetail: { runId: 'run-live', workflowName: '直播', graph: runDetail.graph, nodeStates: { input: { status: 'success', durationMs: 10 } } },
+  events: [{ nodeId: 'agent', status: 'running', turns: 3, preview: '正在起草报告…' }],
+});
+const liveAgentRow = liveRun.nodeTimeline.find((row) => row.nodeId === 'agent');
+assert.equal(liveAgentRow.status, 'running');
+assert.equal(liveAgentRow.turns, 3, '运行中节点合并 live 轮次');
+assert.equal(liveAgentRow.preview, '正在起草报告…', '运行中节点合并 live 输出预览');
+// 终态 live 事件（node-status success/error）覆盖启动快照里的旧状态与旧耗时
+const terminalLive = adaptRunResults({}, {
+  runDetail: { runId: 'run-t', workflowName: '终态', graph: runDetail.graph, nodeStates: { agent: { status: 'running' } } },
+  events: [{ nodeId: 'agent', status: 'success', durationMs: 1200 }],
+});
+const terminalRow = terminalLive.nodeTimeline.find((row) => row.nodeId === 'agent');
+assert.equal(terminalRow.status, 'success', 'live 终态事件覆盖快照状态');
+assert.equal(terminalRow.meta, '1.2 秒');
+// detail 尚未 fetch 到（runDetail 空）：live 事件补出时间线行
+const earlyLive = adaptRunResults({}, {
+  runDetail: { runId: 'run-early' },
+  events: [{ nodeId: 'agent', nodeLabel: '报告', status: 'running', turns: 1, preview: 'p' }],
+});
+assert.equal(earlyLive.nodeTimeline.length, 1, '无骨架时 live 事件补行');
+assert.equal(earlyLive.nodeTimeline[0].nodeId, 'agent');
+assert.equal(earlyLive.nodeTimeline[0].preview, 'p');
+
 const backendShape = adaptRunResults({
   runId: 'run-backend',
   status: 'success',
@@ -146,6 +172,7 @@ assert.equal(withFailure.issues[0].message, '模型超时');
 
 assert.deepEqual(normalizeRunEvent({ type: 'node-status', node: { id: 'n1', label: '节点一' }, state: 'success', timestamp: 123 }), {
   id: '123-0', time: 123, kind: 'node-status', status: 'success', nodeId: 'n1', nodeLabel: '节点一', text: '', meta: undefined,
+  turns: undefined, preview: undefined, durationMs: undefined, startedAt: undefined,
   raw: { type: 'node-status', node: { id: 'n1', label: '节点一' }, state: 'success', timestamp: 123 },
 });
 

--- a/web/src/result-panel.css
+++ b/web/src/result-panel.css
@@ -159,6 +159,10 @@
 .result-step-meta span { display: inline-flex; align-items: center; gap: 3px; }
 .result-step-text { margin: 5px 0 0; color: var(--fg-muted); font-size: 11px; line-height: 1.5; overflow-wrap: anywhere; }
 .result-step-danger .result-step-text { color: var(--danger); }
+/* 运行中节点的实时过程：轮次徽标 + 流式输出预览（风格对齐画布节点 live 气泡） */
+.result-step-live { display: flex; flex-direction: column; gap: 4px; margin-top: 6px; }
+.result-step-live-turns { align-self: flex-start; font-size: 10px; font-weight: 600; padding: 1px 7px; border-radius: 999px; color: var(--accent); border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border-strong)); background: color-mix(in srgb, var(--accent) 10%, transparent); }
+.result-step-live-preview { margin: 0; max-height: 96px; overflow: hidden; font-family: var(--font-mono); font-size: 10.5px; line-height: 1.5; color: var(--fg-muted); background: var(--bg-raised); border: 1px solid var(--border); border-radius: 6px; padding: 5px 8px; white-space: pre-wrap; overflow-wrap: anywhere; mask-image: linear-gradient(to bottom, #000 72%, transparent); }
 .result-node-link { border: 0; padding: 0; background: none; color: var(--fg); font: inherit; font-size: 12px; font-weight: 600; cursor: pointer; }
 .result-node-link:hover { color: var(--accent); text-decoration: underline; }
 .result-issue-title button { border: 0; padding: 0; background: none; color: var(--accent); font: inherit; cursor: pointer; }


### PR DESCRIPTION
## 背景

断点续跑原以全图 fingerprint 比对拦截：画布任何一处改动（哪怕改的是没跑过的下游节点）都 409 拒绝续跑。节点卡住后改配置重试只能从头跑，长链路工作流成本极高。

## 方案

核心洞察：复用一个已完成节点的输出，只要求"产出这个输出的子图"没变（自身配置 + 全部上游）。

- `run-scope.js` 新增 `subgraphFingerprint`（自身+祖先子图指纹，复用既有 `upstreamScope` 遍历）与 `resumeDiff`（逐节点判定 reusable/rerun）
- resume 端点：删全图比对，改为按 `resumeDiff` 裁剪 resume 种子到可复用节点后交给引擎——失效的 success 节点与其余未完成节点一并重新执行。**engine.js 零改动**（搬运逻辑天然跳过不在种子里的节点）
- 新增 `preview: true` 模式：返回 `reusableNodes`/`rerunNodes`（带节点 label），前端续跑前弹窗展示明细
- 无可复用节点时 400 `nothing-reusable`（原 409 `workflow-graph-mismatch`）
- 前端：续跑弹窗列明将复用/将重跑的节点；preview 判定无可复用时跳过弹窗直接全新运行

## 行为矩阵

| 改动 | 旧行为 | 新行为 |
|---|---|---|
| 改卡住（error）的节点 | 409 拒绝 | ✅ 放行，全部 success 复用 |
| 改未执行的下游节点 / 增删无关节点 | 409 拒绝 | ✅ 放行，全部 success 复用 |
| 改成功节点自身或其上游 | 409 拒绝 | 该节点+依赖它的成功节点重跑，其余复用 |
| 改动覆盖全部成功节点上游 | 409 拒绝 | 400 提示直接重新运行 |

## 顺手修

集成测试环境敏感问题：开发机插件 `data/` 里的真实历史运行会被当 legacy 导入临时工作区、按时间排序挤掉测试 seed（`run_it_*` 找不到即崩，与本次改动无关、stash 验证为存量问题）。新增 `WF1_LEGACY_DATA_DIR` env（惰性读取，避开 ESM import 早于测试 env 赋值的时序）让测试指向隔离目录。

## 验证

- orchestrator 14 套单测全过（variable-system +2 用例：subgraphFingerprint/resumeDiff 各场景；engine-resume +1 用例：种子裁剪后失效节点照常重跑；集成测试 resume 段改写为新契约）
- web 10 套单测全过；`build-web.sh` 双构建通过