### PR TITLE
feat(web): 过程 tab 展示总运行时长与运行中节点的实时已运行时长

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -265,6 +265,7 @@ export default function App() {
         pushEntry({
           kind: 'node', status: p.status, nodeId: p.nodeId, runId: p.runId,
           nodeLabel: labelOf(nodesRef.current, p.nodeId).replace(/\(.*\)$/, ''),
+          startedAt: p.startedAt,
           text: p.error ? p.error : undefined,
           meta: p.retrying ? `第 ${p.attempt} 次尝试` : p.toleratedError ? '失败后继续' : undefined,
           chars: p.chars, durationMs: p.durationMs,
@@ -284,14 +285,6 @@ export default function App() {
       if (!appliesToActiveRun(p)) return;
       setProgress((prev) => ({ ...prev, [p.nodeId]: p }));
       setNodes((nds) => nds.map((n) => (n.id === p.nodeId ? { ...n, data: { ...n.data, livePreview: p.preview, liveTurns: p.turns } } : n)));
-      // 过程 tab 实时过程：运行中节点的轮次 + 输出预览随 SSE 进入时间线
-      if (p.turns != null || p.preview) {
-        pushEntry({
-          kind: 'node', status: 'running', nodeId: p.nodeId, runId: p.runId,
-          nodeLabel: labelOf(nodesRef.current, p.nodeId).replace(/\(.*\)$/, ''),
-          turns: p.turns, preview: p.preview, live: true,
-        });
-      }
     });
     es.addEventListener('assistant-patch', (e) => {
       const p = JSON.parse(e.data);

--- a/web/src/ResultPanel.jsx
+++ b/web/src/ResultPanel.jsx
@@ -37,56 +37,80 @@ function stepStatusMeta(status) {
   return STEP_STATUS_META[status] || { label: status || '未知', tone: 'pending' };
 }
 
-function ProcessView({ events, runId, onFocusNode, onOpenNodeDetail }) {
+function useElapsedClock(startedAt, active) {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (!active) return undefined;
+    const timer = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(timer);
+  }, [active]);
+  if (!startedAt) return '';
+  if (!active) return '';
+  const sec = Math.max(0, Math.floor((now - new Date(startedAt).getTime()) / 1000));
+  const mm = Math.floor(sec / 60);
+  const ss = String(sec % 60).padStart(2, '0');
+  return mm ? `${mm}:${ss}` : `0:${ss}`;
+}
+
+function ProcessStep({ event, index, runId, onFocusNode, onOpenNodeDetail }) {
+  const meta = stepStatusMeta(event.status);
+  const canOpenDetail = Boolean(event.nodeId && runId && !['running', 'queued', 'pending'].includes(event.status));
+  const openDetail = canOpenDetail ? () => onOpenNodeDetail?.(runId, event.nodeId) : undefined;
+  const startClock = formatClock(event.startedAt);
+  const liveElapsed = useElapsedClock(event.startedAt, event.status === 'running');
+  const duration = event.status === 'running' ? liveElapsed : formatDuration(event.durationMs);
+  return (
+    <li
+      className={`result-step result-step-${meta.tone}${canOpenDetail ? ' result-step-clickable' : ''}`}
+      key={event.id}
+      onClick={openDetail}
+      onKeyDown={openDetail ? (e) => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetail(); }
+      } : undefined}
+      tabIndex={openDetail ? 0 : undefined}
+      role={openDetail ? 'button' : undefined}
+    >
+      <span className="result-step-num" aria-hidden="true">
+        {event.status === 'running' ? <LoaderCircle size={13} className="result-spin" /> : index + 1}
+      </span>
+      <div className="result-step-card">
+        <div className="result-step-head">
+          <button className="result-node-link" onClick={(e) => { e.stopPropagation(); onFocusNode?.(event.nodeId); }}>
+            {event.nodeLabel || event.nodeId}
+          </button>
+          <span className={`result-step-pill result-step-pill-${meta.tone}`}>{meta.label}</span>
+        </div>
+        {(startClock || duration) && (
+          <div className="result-step-meta">
+            {startClock && <span><Clock3 size={11} />开始 {startClock}</span>}
+            {duration && <span className={event.status === 'running' ? 'result-step-elapsed' : ''}><Timer size={11} />{event.status === 'running' ? `已运行 ${duration}` : `耗时 ${duration}`}</span>}
+          </div>
+        )}
+        {event.error && <p className="result-step-text">{event.error}</p>}
+        {canOpenDetail && <span className="result-detail-link">查看节点详情 <ChevronRight size={12} /></span>}
+      </div>
+    </li>
+  );
+}
+
+function ProcessView({ events, runId, onFocusNode, onOpenNodeDetail, runStartedAt, runDurationMs, running }) {
+  const elapsed = useElapsedClock(runStartedAt, Boolean(running));
   if (!events.length) return <p className="result-empty">暂无过程记录。</p>;
   return (
     <ol className="result-steps">
-      {events.map((event, index) => {
-        const meta = stepStatusMeta(event.status);
-        const canOpenDetail = Boolean(event.nodeId && runId && !['running', 'queued', 'pending'].includes(event.status));
-        const openDetail = canOpenDetail ? () => onOpenNodeDetail?.(runId, event.nodeId) : undefined;
-        const startClock = formatClock(event.startedAt);
-        const duration = event.status === 'running' ? '' : formatDuration(event.durationMs);
-        return (
-          <li
-            className={`result-step result-step-${meta.tone}${canOpenDetail ? ' result-step-clickable' : ''}`}
-            key={event.id}
-            onClick={openDetail}
-            onKeyDown={openDetail ? (e) => {
-              if (e.target !== e.currentTarget) return;
-              if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openDetail(); }
-            } : undefined}
-            tabIndex={openDetail ? 0 : undefined}
-            role={openDetail ? 'button' : undefined}
-          >
-            <span className="result-step-num" aria-hidden="true">
-              {event.status === 'running' ? <LoaderCircle size={13} className="result-spin" /> : index + 1}
-            </span>
-            <div className="result-step-card">
-              <div className="result-step-head">
-                <button className="result-node-link" onClick={(e) => { e.stopPropagation(); onFocusNode?.(event.nodeId); }}>
-                  {event.nodeLabel || event.nodeId}
-                </button>
-                <span className={`result-step-pill result-step-pill-${meta.tone}`}>{meta.label}</span>
-              </div>
-              {(startClock || duration) && (
-                <div className="result-step-meta">
-                  {startClock && <span><Clock3 size={11} />开始 {startClock}</span>}
-                  {duration && <span><Timer size={11} />耗时 {duration}</span>}
-                </div>
-              )}
-              {event.error && <p className="result-step-text">{event.error}</p>}
-              {event.status === 'running' && (event.turns != null || event.preview) && (
-                <div className="result-step-live">
-                  {event.turns != null && <span className="result-step-live-turns">第 {event.turns} 轮</span>}
-                  {event.preview && <pre className="result-step-live-preview">{event.preview}</pre>}
-                </div>
-              )}
-              {canOpenDetail && <span className="result-detail-link">查看节点详情 <ChevronRight size={12} /></span>}
-            </div>
-          </li>
-        );
-      })}
+      {(elapsed || runDurationMs != null) && (
+        <li className="result-step result-step-total" aria-label="总运行时长">
+          <span className="result-step-num result-total-num"><Timer size={12} /></span>
+          <div className="result-step-card result-total-card">
+            <span className="result-total-label">总运行时长</span>
+            <span className="result-total-time">{elapsed || formatDuration(runDurationMs)}</span>
+          </div>
+        </li>
+      )}
+      {events.map((event, index) => (
+        <ProcessStep key={event.id} event={event} index={index} runId={runId} onFocusNode={onFocusNode} onOpenNodeDetail={onOpenNodeDetail} />
+      ))}
     </ol>
   );
 }
@@ -312,7 +336,17 @@ export function ResultPanel({
             <ProcessArtifacts results={model.processResults} files={model.processFiles} artifacts={model.files} />
           </>
         )}
-        {model.runId && activeTab === 'process' && <ProcessView events={model.nodeTimeline} runId={model.runId} onFocusNode={onFocusNode} onOpenNodeDetail={onOpenNodeDetail} />}
+        {model.runId && activeTab === 'process' && (
+          <ProcessView
+            events={model.nodeTimeline}
+            runId={model.runId}
+            onFocusNode={onFocusNode}
+            onOpenNodeDetail={onOpenNodeDetail}
+            runStartedAt={viewState.isRunning ? model.startedAt : undefined}
+            runDurationMs={viewState.isRunning ? undefined : model.durationMs}
+            running={viewState.isRunning}
+          />
+        )}
         {model.runId && activeTab === 'issues' && <IssuesView issues={model.issues} runId={model.runId} onFocusNode={onFocusNode} onOpenNodeDetail={onOpenNodeDetail} />}
       </div>
     </aside>

--- a/web/src/result-adapter.js
+++ b/web/src/result-adapter.js
@@ -251,10 +251,8 @@ export function normalizeRunEvent(event, index = 0) {
     status,
     nodeId: first(value.nodeId, value.node?.id),
     nodeLabel: first(value.nodeLabel, value.label, value.node?.label),
-    turns: value.turns,
-    preview: textOf(value.preview) || undefined,
+    startedAt: value.startedAt,
     durationMs: value.durationMs,
-    startedAt: first(value.startedAt, value.startedat),
     text: textOf(first(value.text, value.message, value.error, value.detail, value.summary)),
     meta: first(value.meta, value.durationMs != null ? formatDuration(value.durationMs) : undefined),
     raw: event,
@@ -322,18 +320,15 @@ export function adaptRunResults(payload, context = {}) {
   const sourceTimeline = asArray(source.nodeTimeline).length
     ? source.nodeTimeline.map((row) => normalizeResultRow(row, nodes, runDetail)).filter(isRuntimeNode)
     : fallback;
-  const liveNodesSeen = new Set();
   const nodeTimeline = sourceTimeline.map((row) => {
     const live = liveByNode.get(row.nodeId);
-    if (live) liveNodesSeen.add(row.nodeId);
-    // live 事件是此刻真实状态（detail 是启动快照/竞态残影），status/轮次/预览以 live 为准
+    // live 事件是此刻真实状态（detail 是启动快照/竞态残影）；startedAt/durationMs 供过程 tab 显示开始时间与已运行时长
     const merged = live
       ? {
         ...row,
         status: live.status || row.status,
         error: live.text || row.error,
-        turns: live.turns ?? row.turns,
-        preview: live.preview ?? row.preview,
+        startedAt: live.startedAt || row.startedAt,
         durationMs: live.status === 'running' ? undefined : first(live.durationMs, row.durationMs),
       }
       : row;
@@ -345,24 +340,6 @@ export function adaptRunResults(payload, context = {}) {
       meta: merged.durationMs != null ? formatDuration(merged.durationMs) : undefined,
     };
   });
-  // run-results/detail 尚未就绪时（live 运行），时间线骨架可能缺失该节点：用 live 事件补行
-  for (const [nodeId, live] of liveByNode) {
-    if (liveNodesSeen.has(nodeId)) continue;
-    if (live.status === 'queued' || live.status === 'pending') continue;
-    nodeTimeline.push({
-      id: `node:${nodeId}`,
-      kind: 'node',
-      nodeId,
-      nodeLabel: live.nodeLabel || nodeId,
-      nodeType: nodes.get(nodeId)?.type,
-      status: live.status || 'running',
-      error: live.text,
-      turns: live.turns,
-      preview: live.preview,
-      startedAt: live.startedAt,
-      text: timelineText({ status: live.status || 'running', error: live.text }),
-    });
-  }
   const runEvents = [
     ...asArray(context.events), ...asArray(source.events), ...asArray(source.process),
     ...asArray(result.events), ...asArray(result.process),

--- a/web/src/result-adapter.test.mjs
+++ b/web/src/result-adapter.test.mjs
@@ -86,32 +86,6 @@ const partialEvents = adaptRunResults({}, {
 assert.equal(partialEvents.nodeTimeline.length, 3, '不完整 SSE 不能覆盖完整流程节点');
 assert.equal(partialEvents.nodeTimeline.find((row) => row.nodeId === 'agent').status, 'running');
 
-// live 运行：agent-progress 事件带轮次与流式输出预览，运行中节点在时间线上可见实时过程
-const liveRun = adaptRunResults({}, {
-  runDetail: { runId: 'run-live', workflowName: '直播', graph: runDetail.graph, nodeStates: { input: { status: 'success', durationMs: 10 } } },
-  events: [{ nodeId: 'agent', status: 'running', turns: 3, preview: '正在起草报告…' }],
-});
-const liveAgentRow = liveRun.nodeTimeline.find((row) => row.nodeId === 'agent');
-assert.equal(liveAgentRow.status, 'running');
-assert.equal(liveAgentRow.turns, 3, '运行中节点合并 live 轮次');
-assert.equal(liveAgentRow.preview, '正在起草报告…', '运行中节点合并 live 输出预览');
-// 终态 live 事件（node-status success/error）覆盖启动快照里的旧状态与旧耗时
-const terminalLive = adaptRunResults({}, {
-  runDetail: { runId: 'run-t', workflowName: '终态', graph: runDetail.graph, nodeStates: { agent: { status: 'running' } } },
-  events: [{ nodeId: 'agent', status: 'success', durationMs: 1200 }],
-});
-const terminalRow = terminalLive.nodeTimeline.find((row) => row.nodeId === 'agent');
-assert.equal(terminalRow.status, 'success', 'live 终态事件覆盖快照状态');
-assert.equal(terminalRow.meta, '1.2 秒');
-// detail 尚未 fetch 到（runDetail 空）：live 事件补出时间线行
-const earlyLive = adaptRunResults({}, {
-  runDetail: { runId: 'run-early' },
-  events: [{ nodeId: 'agent', nodeLabel: '报告', status: 'running', turns: 1, preview: 'p' }],
-});
-assert.equal(earlyLive.nodeTimeline.length, 1, '无骨架时 live 事件补行');
-assert.equal(earlyLive.nodeTimeline[0].nodeId, 'agent');
-assert.equal(earlyLive.nodeTimeline[0].preview, 'p');
-
 const backendShape = adaptRunResults({
   runId: 'run-backend',
   status: 'success',
@@ -172,7 +146,6 @@ assert.equal(withFailure.issues[0].message, '模型超时');
 
 assert.deepEqual(normalizeRunEvent({ type: 'node-status', node: { id: 'n1', label: '节点一' }, state: 'success', timestamp: 123 }), {
   id: '123-0', time: 123, kind: 'node-status', status: 'success', nodeId: 'n1', nodeLabel: '节点一', text: '', meta: undefined,
-  turns: undefined, preview: undefined, durationMs: undefined, startedAt: undefined,
   raw: { type: 'node-status', node: { id: 'n1', label: '节点一' }, state: 'success', timestamp: 123 },
 });
 

--- a/web/src/result-adapter.test.mjs
+++ b/web/src/result-adapter.test.mjs
@@ -146,8 +146,10 @@ assert.equal(withFailure.issues[0].message, '模型超时');
 
 assert.deepEqual(normalizeRunEvent({ type: 'node-status', node: { id: 'n1', label: '节点一' }, state: 'success', timestamp: 123 }), {
   id: '123-0', time: 123, kind: 'node-status', status: 'success', nodeId: 'n1', nodeLabel: '节点一', text: '', meta: undefined,
+  startedAt: undefined, durationMs: undefined,
   raw: { type: 'node-status', node: { id: 'n1', label: '节点一' }, state: 'success', timestamp: 123 },
 });
+assert.equal(normalizeRunEvent({ nodeId: 'n1', status: 'running', startedAt: '2026-08-24T12:00:00.000Z', durationMs: 2500 }).durationMs, 2500, 'live 事件携带时长/开始时间供过程行展示');
 
 assert.equal(artifactPreviewKind('report.md'), 'markdown');
 assert.equal(artifactPreviewKind('data.json'), 'json');

--- a/web/src/result-panel.css
+++ b/web/src/result-panel.css
@@ -159,10 +159,14 @@
 .result-step-meta span { display: inline-flex; align-items: center; gap: 3px; }
 .result-step-text { margin: 5px 0 0; color: var(--fg-muted); font-size: 11px; line-height: 1.5; overflow-wrap: anywhere; }
 .result-step-danger .result-step-text { color: var(--danger); }
-/* 运行中节点的实时过程：轮次徽标 + 流式输出预览（风格对齐画布节点 live 气泡） */
-.result-step-live { display: flex; flex-direction: column; gap: 4px; margin-top: 6px; }
-.result-step-live-turns { align-self: flex-start; font-size: 10px; font-weight: 600; padding: 1px 7px; border-radius: 999px; color: var(--accent); border: 1px solid color-mix(in srgb, var(--accent) 40%, var(--border-strong)); background: color-mix(in srgb, var(--accent) 10%, transparent); }
-.result-step-live-preview { margin: 0; max-height: 96px; overflow: hidden; font-family: var(--font-mono); font-size: 10.5px; line-height: 1.5; color: var(--fg-muted); background: var(--bg-raised); border: 1px solid var(--border); border-radius: 6px; padding: 5px 8px; white-space: pre-wrap; overflow-wrap: anywhere; mask-image: linear-gradient(to bottom, #000 72%, transparent); }
+/* 运行中节点已运行时长：等宽跳秒，与画布节点徽标同感 */
+.result-step-meta .result-step-elapsed { color: var(--accent); font-variant-numeric: tabular-nums; font-weight: 600; }
+/* 总运行时长行：顶部汇总，非节点步骤 */
+.result-step-total { margin-bottom: 2px; }
+.result-total-num { color: var(--fg-faint) !important; background: var(--bg-raised) !important; border-color: var(--border) !important; }
+.result-total-card { display: flex; align-items: center; justify-content: space-between; gap: 10px; background: var(--bg-raised); }
+.result-total-label { font-size: 11px; color: var(--fg-muted); font-weight: 600; }
+.result-total-time { font-family: var(--font-mono); font-size: 12px; color: var(--fg); font-variant-numeric: tabular-nums; }
 .result-node-link { border: 0; padding: 0; background: none; color: var(--fg); font: inherit; font-size: 12px; font-weight: 600; cursor: pointer; }
 .result-node-link:hover { color: var(--accent); text-decoration: underline; }
 .result-issue-title button { border: 0; padding: 0; background: none; color: var(--accent); font: inherit; cursor: pointer; }


### PR DESCRIPTION
## 背景

上一版（PR #17 内）"过程 tab 运行中节点实时轮次/预览"方案不合用户意图（运行过程应看节点详情，而非过程行内流式内容），本 PR 先还原该方案（断点续跑等其余改动保留），再按新需求补两项时长展示。

## 改动

- **还原**：App.jsx 的 agent-progress → pushEntry、result-adapter 的 turns/preview 合并与补行、ResultPanel 的 live 轮次/预览渲染、result-panel.css 的 result-step-live 样式、对应测试
- **新增**：
  - 过程 tab 顶部「总运行时长」行——运行中按 run startedAt 每秒跳秒，结束后固定为最终耗时
  - 运行中节点行显示「已运行 mm:ss」等宽跳秒（对齐画布节点徽标风格），结束后回落固定「耗时」
  - 数据链路：SSE node-status 的 startedAt 透传进 eventsByRunId，normalizeRunEvent/nodeTimeline 合并 startedAt/durationMs
  - ProcessStep 拆为独立组件（hook 不进 map 回调）

## 验证

- web 10 套 + 仓库全量聚合单测通过；build-web.sh 双构建通过
- 真实 dsh（4023）+ GLM agent 链路实测：运行中「诗人助手 · 执行中 · 已运行 0:18→0:22」与总时长 0:18→0:22 同步每秒跳；结束后总时长固定「56 秒」、各节点行固定耗时且可点详情