### PR TITLE
fix(release): npm 聚合包改为 8 包发布，修复 registry 安装不可用

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 Node.js >= 20 且已安装 `@deepseek-ai/dsh`：
 
 ```sh
-dsh plugin --profile web add dsh-ccpg-one@0.2.0
+dsh plugin --profile web add dsh-ccpg-one@0.2.1
 dsh web
 ```
 
-Harness Desktop 用户在 **Open DSH Terminal** 中执行 `dsh plugin add dsh-ccpg-one@0.2.0`，然后重启 Desktop。也可以从 [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest) 下载离线聚合包。
+Harness Desktop 用户在 **Open DSH Terminal** 中执行 `dsh plugin add dsh-ccpg-one@0.2.1`，然后重启 Desktop。也可以从 [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest) 下载离线聚合包。
 
 ## 界面与使用方式
 
@@ -40,7 +40,7 @@ Workflow One 嵌在 dsh 官方界面中：左侧保留与智能体的对话，�
 **Harness Desktop（npm 包发布后）**：从 Desktop 托盘打开 **Open DSH Terminal**，对当前 profile 安装并重启 Desktop：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.2.0
+dsh plugin add dsh-ccpg-one@0.2.1
 ```
 
 Desktop 使用官方 DSH/Cordis 插件组合，不需要另一套插件。不要在 Desktop 里运行 `setup.sh`：Desktop 自己管理 profile、Node/pnpm 和随机 loopback 端口；飞书账号页首次点击「自动安装」时，lark-cli 会通过 Desktop 的受管 pnpm 安装到当前 profile。安装使用细节、环境差异与常见问题排查见 [`dsh-plugins/DESKTOP.md`](dsh-plugins/DESKTOP.md)；Desktop 开发兼容契约（`desktopProfiles`/`desktopPnpm` 动态探测、跨环境插件写法）也在该文档第 2 节。

--- a/dsh-plugins/DESKTOP.md
+++ b/dsh-plugins/DESKTOP.md
@@ -13,7 +13,7 @@ TL;DR：**Desktop 不需要任何专用安装脚本或专用插件分支**——
 从 Desktop 托盘菜单打开 **Open DSH Terminal**（该终端已绑定当前 profile），执行：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.2.0
+dsh plugin add dsh-ccpg-one@0.2.1
 ```
 
 聚合包自带 `dsh.bundle.patch`：`dsh plugin add` 一步完成「装依赖 + 进 bundles 层 + 挂载」7 个默认插件与 better-sidebar。安装完成后**重启 Desktop**（新 bundle 要在下一次 Loader 组合中生效）。

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -22,7 +22,7 @@
 从 Desktop 托盘打开 **Open DSH Terminal**；该终端已绑定当前 profile：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.2.0
+dsh plugin add dsh-ccpg-one@0.2.1
 ```
 
 安装后重启 Desktop，让新 bundle 进入 Loader 组合。compatibility 与 advanced 模式都继续使用普通 DSH Web Client；画布、同源 `/wf1/api/*`、侧栏和预览无需 Desktop 专用注册。飞书账号页首次点击「自动安装」时，插件通过公开 `desktopPnpm` service 把固定版本 lark-cli 安装到当前 profile，并在 profile 切换或退出时取消仍在运行的操作。
@@ -109,7 +109,7 @@ sh start.sh dev
 聚合包和 7 个默认插件均为带 `dsh.bundle.patch` 的自描述包。推荐一条命令：
 
 ```sh
-dsh plugin --profile myprofile add dsh-ccpg-one@0.2.0
+dsh plugin --profile myprofile add dsh-ccpg-one@0.2.1
 ```
 
 需要 CCPG 品牌外观时，再显式安装独立插件：
@@ -133,7 +133,7 @@ dsh plugin --profile myprofile add dsh-ccpg-brand
 
 `pack.sh <tag>`：7 个默认插件 + 独立可选 brand 清单校验 → 画布双构建 → orchestrator 依赖 → canvasui bundle 重建并 `--check` → rsync 组装（清运行时数据）→ `dist-release/dsh-ccpg-plugins-<tag>.tar.gz`。通用发布归档仍携带 brand 源包供显式安装，但 `setup.sh` 和 `dsh-ccpg-one` 都不会自动安装它。CI（release.yml）同源执行并作为 release asset 上传。
 
-`sh publish-npm.sh --dry-run` 会构建并验证单一聚合包 `dsh-ccpg-one`：7 个默认插件作为 `bundleDependencies` 放进同一个 tarball，子插件和 brand 不单独发布。去掉 `--dry-run` 才上传官方 npm registry；tag 必须与聚合包版本一致。GitHub `release.yml` 先上传 release 资产，再使用仓库 Actions Secret `NPM_TOKEN` 发布聚合包，失败后可安全重跑（已存在版本会自动跳过）。
+`sh publish-npm.sh --dry-run` 会构建并验证 8 个 npm 包：7 个默认插件**独立发布为公共包**（loader 与 client-modules 都从 profile 根按包名解析 entry，嵌套 bundle 布局两处都解析不到），`dsh-ccpg-one` 作为聚合壳以普通依赖引用它们——用户一条 `dsh plugin add dsh-ccpg-one` 装齐全部。brand 不单独发布。安装冒烟会校验「无 @deepseek-ai SDK 泄漏」（peer 自动安装会遮蔽 dsh 全局版本导致官方 UI 400）。去掉 `--dry-run` 才上传官方 npm registry；tag 必须与聚合包版本一致。GitHub `release.yml` 先上传 release 资产，再使用仓库 Actions Secret `NPM_TOKEN` 按子包→聚合包顺序发布，失败后可安全重跑（已存在版本会自动跳过）。
 
 ## 已知边界
 

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/cordis.patch.yml
+++ b/dsh-plugins/dsh-ccpg-one/cordis.patch.yml
@@ -14,6 +14,8 @@
 #   export CCPG_NO_GUARD=1    → 不加载 llm-guard（空工具调用防护，不建议关）
 #   export CCPG_ONLY_CORE=1   → 只留核心五件（tools/orchestrator/web/canvasui 之上的全关）
 # 以下变量可写进工作区 .env（DSH_ 前缀被禁止，CCPG_ 前缀合法）。
+# 挂载名说明：loader 与 client-modules 都从 profile 根按包名解析 entry——
+# 子插件必须作为 registry 依赖装在 profile node_modules（publish-npm.sh 已发布为公共包）。
 - insert:
     # ---- 核心（不可关）：引擎 + 画布 + 官方 UI 集成 ----
     - id: dsh-ccpg-tools
@@ -34,6 +36,8 @@
     - id: dsh-ccpg-llm-guard
       name: 'dsh-ccpg-llm-guard'
       disabled: !!js "Boolean(process.env.CCPG_NO_GUARD || process.env.CCPG_ONLY_CORE)"
-    - id: better-sidebar
+    # id 不能用 better-sidebar：用户单独 add 过 dsh-better-sidebar 时其 bundle 层已 insert 同 id 行，
+    # 两层同 id insert 会 duplicate 报错。用独立 id + 防双挂载 disable（检测到别层已挂 sidebar 就关自己）。
+    - id: one-better-sidebar
       name: 'dsh-better-sidebar'
-      disabled: !!js "Boolean(process.env.CCPG_NO_SIDEBAR || process.env.CCPG_ONLY_CORE) || [...ctx.loader.entries()].some((e) => e.options.name === 'dsh-better-sidebar' && e.options.id !== 'better-sidebar' && !e.disabled)"
+      disabled: !!js "Boolean(process.env.CCPG_NO_SIDEBAR || process.env.CCPG_ONLY_CORE) || [...ctx.loader.entries()].some((e) => e.options.name === 'dsh-better-sidebar' && e.options.id !== 'one-better-sidebar' && !e.disabled)"

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-one",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -42,23 +42,14 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.15.2",
-    "dsh-ccpg-canvasui": "0.2.0",
-    "dsh-ccpg-document-preview": "0.2.0",
-    "dsh-ccpg-larkauth": "0.2.0",
-    "dsh-ccpg-llm-guard": "0.2.0",
-    "dsh-ccpg-orchestrator": "0.2.0",
-    "dsh-ccpg-tools": "0.2.0",
-    "dsh-ccpg-web": "0.2.0"
+    "dsh-ccpg-canvasui": "0.2.1",
+    "dsh-ccpg-document-preview": "0.2.1",
+    "dsh-ccpg-larkauth": "0.2.1",
+    "dsh-ccpg-llm-guard": "0.2.1",
+    "dsh-ccpg-orchestrator": "0.2.1",
+    "dsh-ccpg-tools": "0.2.1",
+    "dsh-ccpg-web": "0.2.1"
   },
-  "bundleDependencies": [
-    "dsh-ccpg-canvasui",
-    "dsh-ccpg-document-preview",
-    "dsh-ccpg-larkauth",
-    "dsh-ccpg-llm-guard",
-    "dsh-ccpg-orchestrator",
-    "dsh-ccpg-tools",
-    "dsh-ccpg-web"
-  ],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/publish-npm.sh
+++ b/dsh-plugins/publish-npm.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
-# 只发布 dsh-ccpg-one；七个内部插件作为 bundleDependencies 装进同一个 npm 包。
+# 发布 dsh-ccpg-one + 七个子插件共 8 个包到 npm。
+# 子插件必须是 registry 公共包：loader 与 client-modules 都从 profile 根按包名解析 entry，
+# bundleDependencies 嵌套布局两处都解析不到（loader ERR_MODULE_NOT_FOUND / client 静默不注册）。
 set -e
 HERE=$(cd "$(dirname "$0")" && pwd)
 REPO_ROOT=$(cd "$HERE/.." && pwd)
@@ -13,6 +15,14 @@ VERSION=$(node -e "console.log(require(process.argv[1]).version)" "$HERE/dsh-ccp
 [ -z "${GITHUB_REF_NAME:-}" ] || [ "$GITHUB_REF_NAME" = "v$VERSION" ] \
   || { echo "✗ tag $GITHUB_REF_NAME 与聚合包版本 v$VERSION 不一致"; exit 1; }
 
+# 聚合包声明的子插件依赖版本必须与子插件实际版本一致（npm 安装按声明解析）。
+version_of() { node -e "console.log(require(process.argv[1]).version)" "$HERE/$1/package.json"; }
+for pkg in $PACKAGES; do
+  DECLARED=$(node -e "console.log(require(process.argv[1]).dependencies['$pkg'] || '')" "$HERE/dsh-ccpg-one/package.json")
+  ACTUAL=$(version_of "$pkg")
+  [ "$DECLARED" = "$ACTUAL" ] || { echo "✗ $pkg 依赖声明 $DECLARED 与实际版本 $ACTUAL 不一致"; exit 1; }
+done
+
 if [ "${SKIP_BUILD:-}" != "1" ]; then
   sh "$HERE/build-web.sh"
   node "$REPO_ROOT/scripts/verify-plugin-packages.mjs"
@@ -20,42 +30,53 @@ fi
 
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT INT TERM
-STAGE="$TMP/dsh-ccpg-one"
-mkdir -p "$STAGE/node_modules" "$TMP/packages" "$PACK_DIR"
-cp "$HERE/dsh-ccpg-one/package.json" "$HERE/dsh-ccpg-one/cordis.patch.yml" "$STAGE/"
-cp -R "$HERE/dsh-ccpg-one/lib" "$STAGE/lib"
-[ ! -f "$HERE/dsh-ccpg-one/LICENSE" ] || cp "$HERE/dsh-ccpg-one/LICENSE" "$STAGE/LICENSE"
+mkdir -p "$PACK_DIR"
 
-for pkg in $PACKAGES; do
-  (cd "$HERE/$pkg" && npm pack --silent --ignore-scripts --pack-destination "$TMP/packages" >/dev/null)
-  mkdir -p "$STAGE/node_modules/$pkg"
-  tar -xzf "$TMP/packages/$pkg-$VERSION.tgz" --strip-components=1 -C "$STAGE/node_modules/$pkg"
+# 逐包 npm pack（files 字段裁剪内容；构建产物已在 build 步生成）
+for pkg in $PACKAGES dsh-ccpg-one; do
+  (cd "$HERE/$pkg" && npm pack --silent --ignore-scripts --pack-destination "$PACK_DIR" >/dev/null)
 done
-
-(cd "$STAGE" && npm pack --silent --ignore-scripts --pack-destination "$PACK_DIR" >/dev/null)
 TARBALL="$PACK_DIR/dsh-ccpg-one-$VERSION.tgz"
 for pkg in $PACKAGES; do
-  tar -tzf "$TARBALL" "package/node_modules/$pkg/package.json" >/dev/null
+  tar -tzf "$TARBALL" package/cordis.patch.yml >/dev/null
+  PV=$(version_of "$pkg")
+  [ -f "$PACK_DIR/$pkg-$PV.tgz" ] || { echo "✗ 缺 $pkg-$PV.tgz"; exit 1; }
 done
-tar -tzf "$TARBALL" package/node_modules/dsh-ccpg-web/web-dist/index.html >/dev/null
-tar -tzf "$TARBALL" package/node_modules/dsh-ccpg-canvasui/lib/client.js >/dev/null
-echo "✓ 聚合 npm 包已校验: $TARBALL ($(du -h "$TARBALL" | cut -f1))"
+tar -tzf "$PACK_DIR/dsh-ccpg-web-$VERSION.tgz" package/web-dist/index.html >/dev/null
+tar -tzf "$PACK_DIR/dsh-ccpg-canvasui-$VERSION.tgz" package/lib/client.js >/dev/null
+echo "✓ 8 个 npm 包已打包至 $PACK_DIR"
 
+# 安装冒烟：本地 registry 模拟（file: tgz 直装聚合包——npm 会连同 7 个 registry 依赖从
+# NPM_REGISTRY 解析；dry-run 阶段子插件尚未发布，逐包 file: 预装后再装聚合包对齐 registry 语义）。
 mkdir -p "$TMP/install-smoke"
-npm install --prefix "$TMP/install-smoke" "$TARBALL" --ignore-scripts --no-audit --no-fund --registry "$NPM_REGISTRY" >/dev/null
 for pkg in $PACKAGES; do
-  [ -f "$TMP/install-smoke/node_modules/dsh-ccpg-one/node_modules/$pkg/package.json" ] \
-    || [ -f "$TMP/install-smoke/node_modules/$pkg/package.json" ] \
-    || { echo "✗ npm 安装后缺少 bundled dependency: $pkg"; exit 1; }
+  PV=$(version_of "$pkg")
+  npm install --prefix "$TMP/install-smoke" "$PACK_DIR/$pkg-$PV.tgz" \
+    --ignore-scripts --no-audit --no-fund --legacy-peer-deps --registry "$NPM_REGISTRY" >/dev/null
 done
-echo "✓ 聚合 npm 包全新安装 smoke 通过"
+npm install --prefix "$TMP/install-smoke" "$TARBALL" \
+  --ignore-scripts --no-audit --no-fund --legacy-peer-deps --registry "$NPM_REGISTRY" >/dev/null
+for pkg in $PACKAGES dsh-better-sidebar; do
+  [ -f "$TMP/install-smoke/node_modules/$pkg/package.json" ] \
+    || { echo "✗ npm 安装后缺少顶层依赖: $pkg"; exit 1; }
+done
+ls "$TMP/install-smoke/node_modules/@deepseek-ai/dsh-host-webserver" >/dev/null 2>&1 \
+  && { echo "✗ 安装引入了 @deepseek-ai SDK 拷贝（peer 泄漏，会遮蔽 dsh 全局版本）"; exit 1; }
+echo "✓ 全新安装 smoke 通过（无 SDK 泄漏）"
 
-if npm view "dsh-ccpg-one@$VERSION" version --registry "$NPM_REGISTRY" >/dev/null 2>&1; then
-  echo "✓ dsh-ccpg-one@$VERSION 已发布，跳过重复 publish"
-  exit 0
-fi
-if [ "$MODE" != "--dry-run" ] && [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-  echo "✗ 缺少 NODE_AUTH_TOKEN（GitHub Actions 中配置 NPM_TOKEN secret）"
-  exit 1
-fi
-npm publish "$TARBALL" --registry "$NPM_REGISTRY" --access public $MODE
+publish_one() {
+  npm view "$1@$2" version --registry "$NPM_REGISTRY" >/dev/null 2>&1 && {
+    echo "✓ $1@$2 已发布，跳过"
+    return 0
+  }
+  if [ "$MODE" != "--dry-run" ] && [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+    echo "✗ 缺少 NODE_AUTH_TOKEN（GitHub Actions 中配置 NPM_TOKEN secret）"
+    exit 1
+  fi
+  npm publish "$PACK_DIR/$1-$2.tgz" --registry "$NPM_REGISTRY" --access public $MODE
+}
+
+for pkg in $PACKAGES; do
+  publish_one "$pkg" "$(version_of "$pkg")"
+done
+publish_one dsh-ccpg-one "$VERSION"


### PR DESCRIPTION
## 背景

0.2.0 的 npm 安装路径完全不可用：`dsh plugin add dsh-ccpg-one@0.2.0` 后 boot 直接失败（`Cannot find package 'dsh-ccpg-tools'`）。

## 根因（三层）

1. **bundleDependencies 嵌套布局 vs 双端裸名解析**：loader import 与 client-modules 包元数据扫描都从 profile 根按包名解析 entry；子插件嵌在 `dsh-ccpg-one/node_modules/` 里两处都解析不到（后者甚至静默——官方 UI boot graph 直接缺失我们的插件）
2. **npm≥7 自动装 peer**：sidebar 的 `@deepseek-ai/*` peer 被自动装到 profile 顶层，遮蔽 dsh 全局安装的 SDK → 双份 webserver → 官方 UI 全站 400（`renderIndex is not a function`）
3. **sidebar 同 id 双挂载**：用户单独装过 better-sidebar 时，聚合 patch 与其 bundle 层 insert 同 id → duplicate loader entry id

## 方案

对齐 better-sidebar 既有生态模式：**7 个子插件独立发布为 npm 公共包**，聚合壳改普通依赖引用（去 bundleDependencies），patch 保持裸包名；sidebar insert 改独立 id + 防双挂载 disable；publish-npm.sh 重写为 8 包流水线（含版本一致性校验 + SDK 泄漏冒烟断言）。

## 验证（本地 verdaccio 模拟 registry）

| 场景 | 结果 |
|---|---|
| web 全新 profile：`dsh plugin add dsh-ccpg-one` 一条命令 | UI 200 / 画布 200 / boot graph 全插件 |
| 引擎 input→script→output | success（quickjs 沙箱正常） |
| 续跑 resumeDiff | 复用「输入」、重跑「脚本,输出」✅ |
| Harness Desktop 2.0.2 同命令安装+重启 | 同上全绿 ✅ |
| npm/pnpm 双渠道 / tarball --one boot-smoke / 全量单测 | 全部通过 |
| 曾单独装过 sidebar 的 profile | 不再 duplicate id ✅ |

用户视角：**web 版和 Desktop 版都是一条命令，零额外操作**。

合并后打 tag `v0.2.1`，CI 自动发布 8 个包到 npm。