### PR TITLE
feat(web): 工作流画布跟随 dsh 主界面主题

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -5,6 +5,7 @@
 //（ctx.inject(['betterSidebar'],…)）：未安装 better-sidebar 时按钮保持不可用。
 // 画布 ↔ 宿主经 postMessage 桥接：
 //   宿主 → 画布：{type:'wf1-session', sessionId}（画布据此绑 AI 助手工具作用域）
+//               {type:'wf1-theme', theme:'dark'|'light'}（画布跟随主界面主题）
 //   画布 → 宿主：{type:'wf1-ready'}
 //
 // ⚠ 本文件是源文件（src/client.js），真正的插件 bundle 是构建产物 lib/client.js；
@@ -22,6 +23,51 @@ window.__ModuleLoader__.load({
     var WORKFLOW_TAB_TYPE = "ccpg:workflow";
     var LEGACY_CHAT_TAB_TYPE = "ccpg:chat";
     var WORKFLOW_TAB_ORDER = 5; // better-sidebar + 菜单升序，内置最小 explorer=10 → 排第一
+
+    // ---- 主题桥：官方 UI 的 dark/light → 画布 data-theme ----
+    // 官方 UI 把当前主题记在 body[data-ds-dark-theme]（brand 插件同款锚点）；
+    // MutationObserver 监听该属性 + body class 变化，变化即向画布 iframe 发
+    // wf1-theme。独立标签页打开画布（无宿主）时画布保持自身默认主题。
+    function currentHostTheme() {
+      var body = document.body;
+      if (!body) return "dark";
+      if (body.hasAttribute("data-ds-dark-theme")) return "dark";
+      // 官方浅色：属性移除。历史版本曾用 class 携带主题名，一并识别。
+      var m = /(?:^|\s)(dark|light)(?:\s|$)/.exec(body.className || "");
+      return m ? m[1] : "light";
+    }
+    var themeBridge = { notifyReload: null };
+    function notifyThemeReload() {
+      if (themeBridge.notifyReload) themeBridge.notifyReload();
+    }
+    function startThemeBridge(getFrame) {
+      var lastTheme = null;
+      var send = function () {
+        var theme = currentHostTheme();
+        if (theme === lastTheme) return;
+        lastTheme = theme;
+        var frame = getFrame();
+        if (!frame) return;
+        try {
+          frame.contentWindow.postMessage(
+            { type: "wf1-theme", theme: theme },
+            window.location.origin,
+          );
+        } catch (e) { /* 画布未就绪 */ }
+      };
+      send();
+      // 画布 reload 后 lastTheme 仍等于旧值 → 重置让 send() 立即重发
+      themeBridge.notifyReload = function () { lastTheme = null; send(); };
+      var observer = new MutationObserver(send);
+      observer.observe(document.body, {
+        attributes: true,
+        attributeFilter: ["data-ds-dark-theme", "class"],
+      });
+      return function () {
+        themeBridge.notifyReload = null;
+        observer.disconnect();
+      };
+    }
 
     function currentDshSessionId(fallback) {
       try {
@@ -713,9 +759,24 @@ window.__ModuleLoader__.load({
         if (mountRef.current) mountRef.current.appendChild(host);
         frameRef.current = host.querySelector("iframe");
         setReady(canvasReady);
+        var stopThemeBridge = startThemeBridge(function () { return frameRef.current; });
         return function () {
+          stopThemeBridge();
           // 移回 detached 状态，React 不碰它，切 tab 再回来内容原样
           if (host.parentNode) host.parentNode.removeChild(host);
+        };
+      }, []);
+
+      // 画布 reload（wf1-ready）后主题桥的 lastTheme 防重标记仍指旧实例，
+      // 重置它让下一次 wf1-ready 时立即重发当前主题（与 sessionId 同款处理）。
+      react.useEffect(function () {
+        function resetThemeOnReady(ev) {
+          if (ev.source !== frameRef.current?.contentWindow) return;
+          if (ev.data && ev.data.type === "wf1-ready") notifyThemeReload();
+        }
+        window.addEventListener("message", resetThemeOnReady);
+        return function () {
+          window.removeEventListener("message", resetThemeOnReady);
         };
       }, []);
 
@@ -959,6 +1020,8 @@ window.__ModuleLoader__.load({
       setBetterSidebarService: setBetterSidebarService,
       sidebarAllTabs: sidebarAllTabs,
       subscribeSidebarService: subscribeSidebarService,
+      currentHostTheme: currentHostTheme,
+      startThemeBridge: startThemeBridge,
       toolText: toolText,
       runIdFromText: runIdFromText,
       runIdFromArgs: runIdFromArgs,

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -436,4 +436,70 @@ cardClient.__test.WorkflowRunCard({
   assert.ok(!String(metaText).startsWith("{"), "run_status 卡不应把结果 JSON 塞进 meta");
 }
 
+// ---- 主题桥：宿主 dark/light 检测 + wf1-theme 推送 ----
+// 在自定义 vm 上下文里重载 bundle，逐例换 document.body 断言 currentHostTheme
+function loadClientInContext(overrides) {
+  let scoped;
+  const ctx = {
+    document: {
+      createElement: () => ({}),
+      getElementById: () => null,
+      head: { appendChild() {} },
+      ...overrides.document,
+    },
+    window: {
+      location: { origin: "https://dsh.local" },
+      localStorage: { getItem: () => null },
+      __ModuleLoader__: {
+        load({ factory }) {
+          scoped = factory(() => ({ createElement() {}, useRef() {}, useState() {}, useEffect() {} }));
+        },
+      },
+    },
+    console,
+    ...overrides.globals,
+  };
+  vm.runInNewContext(bundle, ctx, { filename: "canvasui-scoped.js" });
+  return scoped;
+}
+
+for (const [body, expected] of [
+  [{ hasAttribute: (k) => k === "data-ds-dark-theme", className: "" }, "dark"],
+  [{ hasAttribute: () => false, className: "" }, "light"],
+  [{ hasAttribute: () => false, className: "theme-light other" }, "light"],
+  [{ hasAttribute: () => false, className: "xyz dark" }, "dark"],
+]) {
+  const scoped = loadClientInContext({ document: { body } });
+  assert.equal(scoped.__test.currentHostTheme(), expected);
+}
+
+// startThemeBridge：主题变化 → 向画布 iframe 发 wf1-theme
+{
+  const observers = [];
+  const body = { hasAttribute: () => true, className: "" };
+  const scoped = loadClientInContext({
+    document: { body },
+    globals: {
+      MutationObserver: class {
+        constructor(cb) { observers.push(cb); }
+        observe() {}
+        disconnect() {}
+      },
+    },
+  });
+  const sent = [];
+  const frame = { contentWindow: { postMessage: (msg, origin) => sent.push({ msg, origin }) } };
+  const stop = scoped.__test.startThemeBridge(() => frame);
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].msg.type, "wf1-theme");
+  assert.equal(sent[0].msg.theme, "dark");
+  assert.equal(sent[0].origin, "https://dsh.local");
+  // 切浅色（属性移除）→ observer 回调 → 重发 light
+  body.hasAttribute = () => false;
+  observers.forEach((cb) => cb());
+  assert.equal(sent.length, 2);
+  assert.equal(sent[1].msg.theme, "light");
+  stop();
+}
+
 console.log("canvasui client tests: passed");

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -18,6 +18,7 @@ import {
   stripCanvasRuntimeNodeData,
 } from './workflow-serialization.js';
 import { eventBelongsToCanvas, eventBelongsToRun } from './run-event-routing.js';
+import { useThemePalette } from './theme.js';
 import { useToast, PromptModal, ConfirmModal, Modal } from './ui.jsx';
 
 const STATUS_CN = { running: '运行中', success: '成功', error: '失败', canceled: '已取消', interrupted: '异常中断', skipped: '跳过', waiting: '等待审批' };
@@ -38,6 +39,7 @@ import { TEMPLATES, TemplateModal } from './templates.jsx';
 
 export default function App() {
   const toast = useToast();
+  const palette = useThemePalette();
   const [nodes, setNodes, onNodesChange] = useNodesState([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState([]);
   const [selectedId, setSelectedId] = useState(null);
@@ -1110,12 +1112,16 @@ export default function App() {
   }, [setNodes, setEdges, snapshot, markDirty, toast, fitView, reportCanvasState]);
   assistantOpsRef.current = applyAssistantOps;
 
-  // 宿主 postMessage：wf1-session（官方 UI 会话绑定）→ 绑定 + 拿 persona
+  // 宿主 postMessage：wf1-session（官方 UI 会话绑定）→ 绑定 + 拿 persona；
+  // wf1-theme（官方 UI 主题切换）→ 画布跟随切换 data-theme
   useEffect(() => {
     const onMessage = (ev) => {
       if (ev.origin !== window.location.origin) return;
       const d = ev.data;
       if (!d || typeof d !== 'object') return;
+      if (d.type === 'wf1-theme' && (d.theme === 'light' || d.theme === 'dark')) {
+        document.documentElement.dataset.theme = d.theme;
+      }
       if (d.type === 'wf1-session' && d.sessionId) {
         hostSessionRef.current = d.sessionId;
         setApiSessionId(d.sessionId);
@@ -1207,10 +1213,10 @@ export default function App() {
       const [id, st] = part.split(':');
       statusOf.set(id, st);
     }
-    const EDGE_COLOR = { success: '#10b981', running: '#f59e0b', error: '#ef4444', skipped: '#9ca3af', canceled: '#94a3b8' };
+    const EDGE_COLOR = { success: palette.edge.success, running: palette.edge.running, error: palette.edge.error, skipped: palette.edge.skipped, canceled: palette.edge.canceled };
     return edges.map((e) => {
       const src = statusOf.get(e.source) || 'idle';
-      const color = EDGE_COLOR[src] || '#94a3b8';
+      const color = EDGE_COLOR[src] || palette.edge.idle;
       const active = src === 'success' || src === 'running';
       const branch = e.branch || e.data?.branch;
       return {
@@ -1219,14 +1225,14 @@ export default function App() {
         // onInsert 直接注入边 data：styledEdges 随 [edges,statusKey] 重建，insertNodeOnEdge 引用稳定
         data: { onInsert: insertNodeOnEdge, branch },
         label: branch ? (branch === 'true' ? '是' : '否') : undefined,
-        labelStyle: { fill: '#A8A29E', fontSize: 11 },
-        labelBgStyle: { fill: '#1D1A16' },
+        labelStyle: { fill: palette.labelFill, fontSize: 11 },
+        labelBgStyle: { fill: palette.labelBg },
         animated: src === 'running',
         style: { stroke: color, strokeWidth: active ? 2.5 : 1.5, strokeDasharray: branch === 'false' ? '6 3' : undefined },
         markerEnd: { type: MarkerType.ArrowClosed, color },
       };
     });
-  }, [edges, edgeStatusKey, insertNodeOnEdge]);
+  }, [edges, edgeStatusKey, insertNodeOnEdge, palette]);
 
   const upstreamNodes = useMemo(() => {
     if (!selectedNode) return [];
@@ -1367,15 +1373,15 @@ export default function App() {
             fitView
             minZoom={0.15}
             maxZoom={2.5}
-            connectionLineStyle={{ stroke: '#94a3b8', strokeWidth: 2 }}
+            connectionLineStyle={{ stroke: palette.edge.idle, strokeWidth: 2 }}
           >
-            <Background variant="dots" gap={22} size={1.4} color="#3A352E" />
+            <Background variant="dots" gap={22} size={1.4} color={palette.canvasDot} />
             <Controls />
             <MiniMap
               pannable
               zoomable
-              nodeColor={(n) => ({ agent: '#8B5CF6', input: '#38BDF8', script: '#F97316', condition: '#F59E0B', http: '#34D399', output: '#A3E635', note: '#78716C' })[n.data?.nodeType] || '#57534E'}
-              maskColor="rgba(20,18,15,0.7)"
+              nodeColor={(n) => palette.minimapNode[n.data?.nodeType] || palette.minimapNode.unknown}
+              maskColor={palette.minimapMask}
             />
           </ReactFlow>
           {lint?.issues?.length > 0 && (

--- a/web/src/FlowNode.jsx
+++ b/web/src/FlowNode.jsx
@@ -5,15 +5,17 @@ import { useEffect, useState } from 'react';
 import { Handle, Position } from '@xyflow/react';
 import { NODE_REGISTRY, kindOf } from './registry.jsx';
 
+// 状态边框走 CSS 变量（跟随主题）：borderColor 由 CSS 类/内联 var() 决定，
+// 这里只给结构（粗细/线型/透明度）与光晕强度。
 const STATUS_STYLE = {
   idle: {},
-  queued: { border: '2px solid #94a3b8' },
-  running: { border: '2px solid #f59e0b', boxShadow: '0 0 12px rgba(245,158,11,.6)' },
-  waiting: { border: '2px dashed #db2777', boxShadow: '0 0 12px rgba(219,39,119,.4)' },
-  success: { border: '2px solid #10b981' },
-  error: { border: '2px solid #ef4444' },
-  skipped: { border: '2px dashed #9ca3af', opacity: 0.6 },
-  canceled: { border: '2px dotted #94a3b8', opacity: 0.7 },
+  queued: { border: '2px solid var(--canceled)' },
+  running: { border: '2px solid var(--edge-running)', boxShadow: '0 0 12px rgba(245,158,11,.6)' },
+  waiting: { border: '2px dashed var(--pink)', boxShadow: '0 0 12px rgba(219,39,119,.4)' },
+  success: { border: '2px solid var(--edge-success)' },
+  error: { border: '2px solid var(--edge-error)' },
+  skipped: { border: '2px dashed var(--edge-skipped)', opacity: 0.6 },
+  canceled: { border: '2px dotted var(--canceled)', opacity: 0.7 },
 };
 
 /** 运行中节点的实时计时：mm:ss，每秒自跳（节点结束即停，开销一个 interval） */

--- a/web/src/ScriptCodeEditor.jsx
+++ b/web/src/ScriptCodeEditor.jsx
@@ -24,20 +24,20 @@ import { tags } from '@lezer/highlight';
 
 const externalSync = Annotation.define();
 
-// 暗色高亮，对齐画布设计令牌（紫 #8B5CF6 / 青 #06B6D4）
+// JS 高亮配色经 CSS 变量取值（theme.js 调色板跟随主题切换）
 const scriptHighlight = HighlightStyle.define([
-  { tag: [tags.keyword, tags.modifier, tags.controlKeyword], color: '#C4B5FD' },
-  { tag: [tags.string, tags.special(tags.string)], color: '#6EE7B7' },
-  { tag: [tags.number, tags.bool, tags.null, tags.atom], color: '#FBBF24' },
-  { tag: [tags.function(tags.variableName), tags.function(tags.propertyName)], color: '#67E8F9' },
-  { tag: tags.propertyName, color: '#93C5FD' },
-  { tag: [tags.variableName, tags.self], color: '#E7E2D9' },
-  { tag: [tags.definition(tags.variableName), tags.local(tags.variableName)], color: '#E7E2D9' },
-  { tag: [tags.comment, tags.blockComment], color: '#8A857C', fontStyle: 'italic' },
-  { tag: [tags.operator, tags.punctuation, tags.separator], color: '#B8B2A7' },
-  { tag: [tags.typeName, tags.className, tags.standard(tags.variableName)], color: '#FCA5A5' },
-  { tag: tags.regexp, color: '#F0ABFC' },
-  { tag: tags.invalid, color: '#F87171' },
+  { tag: [tags.keyword, tags.modifier, tags.controlKeyword], color: 'var(--cm-keyword)' },
+  { tag: [tags.string, tags.special(tags.string)], color: 'var(--cm-string)' },
+  { tag: [tags.number, tags.bool, tags.null, tags.atom], color: 'var(--cm-number)' },
+  { tag: [tags.function(tags.variableName), tags.function(tags.propertyName)], color: 'var(--cm-function)' },
+  { tag: tags.propertyName, color: 'var(--cm-property)' },
+  { tag: [tags.variableName, tags.self], color: 'var(--cm-variable)' },
+  { tag: [tags.definition(tags.variableName), tags.local(tags.variableName)], color: 'var(--cm-variable)' },
+  { tag: [tags.comment, tags.blockComment], color: 'var(--cm-comment)', fontStyle: 'italic' },
+  { tag: [tags.operator, tags.punctuation, tags.separator], color: 'var(--cm-operator)' },
+  { tag: [tags.typeName, tags.className, tags.standard(tags.variableName)], color: 'var(--cm-type)' },
+  { tag: tags.regexp, color: 'var(--cm-regexp)' },
+  { tag: tags.invalid, color: 'var(--danger-fg)' },
 ]);
 
 const scriptTheme = EditorView.theme(
@@ -67,6 +67,7 @@ const scriptTheme = EditorView.theme(
   },
   { dark: true },
 );
+// ponytail: dark 标记恒为 true——cm-editor 底色是透明 var(--bg-raised)，实际明暗由 CSS 变量决定
 
 export function ScriptCodeEditor({ value, onChange, minHeight = '310px', readOnly = false }) {
   const hostRef = useRef(null);

--- a/web/src/result-panel.css
+++ b/web/src/result-panel.css
@@ -19,10 +19,10 @@
 .result-title-wrap { min-width: 0; display: flex; flex-wrap: wrap; align-items: center; gap: 6px 8px; }
 .result-title-wrap strong { min-width: 0; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 13px; }
 .result-status { padding: 2px 7px; border: 1px solid var(--border); border-radius: 999px; color: var(--fg-muted); font-size: 10px; font-weight: 700; }
-.result-status-success { color: #34D399; border-color: rgba(16,185,129,.32); background: rgba(16,185,129,.1); }
-.result-status-running { color: #FBBF24; border-color: rgba(245,158,11,.32); background: rgba(245,158,11,.1); }
-.result-status-danger { color: #F87171; border-color: rgba(239,68,68,.32); background: rgba(239,68,68,.1); }
-.result-status-waiting { color: #F9A8D4; border-color: rgba(236,72,153,.32); background: rgba(236,72,153,.1); }
+.result-status-success { color: var(--success-fg); border-color: rgba(16,185,129,.32); background: rgba(16,185,129,.1); }
+.result-status-running { color: var(--warn-fg); border-color: rgba(245,158,11,.32); background: rgba(245,158,11,.1); }
+.result-status-danger { color: var(--danger-fg); border-color: rgba(239,68,68,.32); background: rgba(239,68,68,.1); }
+.result-status-waiting { color: var(--pink); border-color: rgba(236,72,153,.32); background: rgba(236,72,153,.1); }
 .result-run-time { display: inline-flex; align-items: center; gap: 4px; width: 100%; color: var(--fg-faint); font-size: 10px; }
 .result-head-actions { display: flex; align-items: center; flex: none; }
 .result-head-actions a { text-decoration: none; }
@@ -44,7 +44,7 @@
 .result-loading { display: flex; align-items: center; justify-content: center; gap: 7px; min-height: 120px; color: var(--fg-muted); font-size: 12px; }
 .result-spin { animation: result-spin .8s linear infinite; }
 @keyframes result-spin { to { transform: rotate(360deg); } }
-.result-load-error { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; margin-bottom: 10px; padding: 8px 10px; border-left: 2px solid var(--danger); background: rgba(239,68,68,.08); color: #F87171; font-size: 11px; }
+.result-load-error { display: flex; align-items: flex-start; justify-content: space-between; gap: 8px; margin-bottom: 10px; padding: 8px 10px; border-left: 2px solid var(--danger); background: rgba(239,68,68,.08); color: var(--danger-fg); font-size: 11px; }
 .result-load-error button { border: 0; background: none; color: inherit; font: inherit; cursor: pointer; text-decoration: underline; }
 .result-summary { margin: 0 0 10px; padding: 9px 10px; border-left: 2px solid var(--accent); background: rgba(6,182,212,.07); color: var(--fg-muted); font-size: 12px; line-height: 1.55; }
 .result-save-area { display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: center; gap: 7px 10px; margin-bottom: 14px; padding-bottom: 12px; border-bottom: 1px solid var(--border); }
@@ -62,7 +62,7 @@
 .result-output-selector { display: flex; gap: 4px; margin-bottom: 10px; overflow-x: auto; }
 .result-output-selector button { min-height: 28px; flex: none; padding: 0 9px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-raised); color: var(--fg-muted); font: 600 11px/1 var(--font-ui); cursor: pointer; }
 .result-output-selector button.result-output-on { border-color: var(--accent); color: var(--fg); background: var(--bg-hover); }
-.result-partial { width: 100%; margin-bottom: 10px; padding: 7px 9px; border: 1px solid rgba(245,158,11,.3); border-radius: 6px; background: rgba(245,158,11,.08); color: #FBBF24; font: 11px/1.4 var(--font-ui); cursor: pointer; text-align: left; }
+.result-partial { width: 100%; margin-bottom: 10px; padding: 7px 9px; border: 1px solid rgba(245,158,11,.3); border-radius: 6px; background: rgba(245,158,11,.08); color: var(--warn-fg); font: 11px/1.4 var(--font-ui); cursor: pointer; text-align: left; }
 .result-legacy-badge { color: var(--warn); font-size: 9px; }
 .result-expand-btn { margin-left: auto; }
 .result-final-empty { padding: 12px; border: 1px dashed var(--border-strong); border-radius: 7px; background: var(--bg); }
@@ -180,7 +180,7 @@
 .result-issue-title { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--fg); font-size: 11px; font-weight: 650; }
 .result-issue-title button { font-size: 10px; font-weight: 400; }
 .result-issue p { margin: 5px 0; color: var(--fg-muted); font-size: 11px; line-height: 1.55; white-space: pre-wrap; overflow-wrap: anywhere; }
-.result-ok-state { display: flex; align-items: center; justify-content: center; gap: 7px; min-height: 110px; color: #34D399; font-size: 12px; }
+.result-ok-state { display: flex; align-items: center; justify-content: center; gap: 7px; min-height: 110px; color: var(--success-fg); font-size: 12px; }
 
 @media (max-width: 900px) {
   .result-panel { width: 340px; min-width: 310px; max-width: 45vw; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -341,7 +341,7 @@ body {
   border-color: transparent; color: var(--primary-fg); font-weight: 600;
 }
 .btn-primary:hover { filter: brightness(1.1); }
-.btn-danger { background: var(--danger); border-color: transparent; color: var(--danger-fg); }
+.btn-danger { background: var(--danger); border-color: transparent; color: var(--primary-fg); }
 .btn-danger:hover { filter: brightness(1.08); }
 .btn-sm { padding: 4px 9px; font-size: 12px; border-radius: 7px; }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -5,7 +5,21 @@
    ============================================================ */
 
 :root {
-  /* 色板 */
+  /* 字体 */
+  --font-ui: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', sans-serif;
+  --font-mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, monospace;
+
+  /* 尺寸/圆角/阴影节奏 */
+  --radius: 10px;
+  --radius-lg: 14px;
+  --dur: 160ms;
+  --ease: cubic-bezier(.25,.8,.35,1);
+}
+
+/* ============ 主题调色板（跟随 dsh 主界面；dark 为默认） ============ */
+/* 语义令牌 → 组件层。所有颜色经 --var 引用，禁止裸 hex。
+   dark 即 v2 的 OLED 深底；light 为跟随 dsh 浅色主题的浅底映射。 */
+html[data-theme='dark'], :root {
   --bg: #14120F;            /* 画布底（近黑暖灰） */
   --bg-panel: #1D1A16;      /* 面板/工具栏面 */
   --bg-raised: #26221D;     /* 卡片/输入面 */
@@ -20,9 +34,23 @@
   --primary-fg: #FFFFFF;
   --accent: #06B6D4;        /* 青（运行/链接强调） */
   --success: #10B981;
+  --success-fg: #34D399;
   --warn: #F59E0B;
+  --warn-fg: #FBBF24;
   --danger: #EF4444;
-  --danger-fg: #FFFFFF;
+  --danger-fg: #F87171;
+  --danger-muted: #FCA5A5;
+  --pink: #F9A8D4;
+  --primary-soft: #C4B5FD;  /* 紫上浅紫文字（浅色主题换深紫） */
+  --success-soft: #A7F3D0;
+  --accent-soft: #67E8F9;
+  --link-node: #7DD3FC;     /* 日志节点链接 */
+  --canceled: #94A3B8;
+  --type-input-fg: #60A5FA;      /* 品牌蓝亮字（暗底） */
+  --type-condition-fg: #422006;  /* 暖黄底深棕字 */
+  --type-http-fg: #062a30;
+  --type-script-fg: #2B1104;
+  --type-note-fg: #F5F5F4;
 
   /* 类型色（节点/工具栏一致性；灯亮度适配暗底） */
   --type-input: #3B82F6;
@@ -34,18 +62,98 @@
   --type-note: #78716C;
   --type-unknown: #78716C;
 
-  /* 字体 */
-  --font-ui: 'Plus Jakarta Sans', -apple-system, BlinkMacSystemFont, 'PingFang SC', 'Microsoft YaHei', sans-serif;
-  --font-mono: ui-monospace, 'SF Mono', SFMono-Regular, Menlo, monospace;
-
-  /* 尺寸/圆角/阴影节奏 */
-  --radius: 10px;
-  --radius-lg: 14px;
+  /* 阴影 */
   --shadow-1: 0 1px 3px rgba(0,0,0,.4);
   --shadow-2: 0 8px 24px rgba(0,0,0,.45);
   --shadow-glow: 0 0 0 3px rgba(139,92,246,.22);
-  --dur: 160ms;
-  --ease: cubic-bezier(.25,.8,.35,1);
+
+  /* SVG 专用（React Flow marker/迷你图/背景点不走 CSS 级联，需真实色值） */
+  --canvas-dot: #3A352E;
+  --minimap-mask: rgba(20,18,15,.7);
+  --edge-idle: #94a3b8;
+  --edge-success: #10b981;
+  --edge-running: #f59e0b;
+  --edge-error: #ef4444;
+  --edge-skipped: #9ca3af;
+
+  /* CodeMirror JS 高亮（暗色配色；light 主题下换浅色配色） */
+  --cm-keyword: #C4B5FD;
+  --cm-string: #6EE7B7;
+  --cm-number: #FBBF24;
+  --cm-function: #67E8F9;
+  --cm-property: #93C5FD;
+  --cm-variable: #E7E2D9;
+  --cm-comment: #8A857C;
+  --cm-operator: #B8B2A7;
+  --cm-type: #FCA5A5;
+  --cm-regexp: #F0ABFC;
+}
+
+html[data-theme='light'] {
+  --bg: #F7F5F2;            /* 画布底（暖白） */
+  --bg-panel: #FFFFFF;
+  --bg-raised: #F1EDE7;
+  --bg-hover: #E7E1D9;
+  --border: rgba(20,18,15,0.09);
+  --border-strong: rgba(20,18,15,0.16);
+  --fg: #26221D;
+  --fg-muted: #6F6A64;
+  --fg-faint: #A8A29E;
+  --primary: #7C3AED;
+  --primary-strong: #6D28D9;
+  --primary-fg: #FFFFFF;
+  --accent: #0891B2;
+  --success: #059669;
+  --success-fg: #047857;
+  --warn: #D97706;
+  --warn-fg: #B45309;
+  --danger: #DC2626;
+  --danger-fg: #B91C1C;
+  --danger-muted: #B91C1C;
+  --pink: #DB2777;
+  --primary-soft: #6D28D9;
+  --success-soft: #047857;
+  --accent-soft: #0E7490;
+  --link-node: #0369A1;
+  --canceled: #64748B;
+  --type-input-fg: #2563EB;
+  --type-condition-fg: #422006;
+  --type-http-fg: #062a30;
+  --type-script-fg: #2B1104;
+  --type-note-fg: #F5F5F4;
+
+  /* 类型色（深一档，浅底上可辨） */
+  --type-input: #2563EB;
+  --type-agent: #7C3AED;
+  --type-condition: #D97706;
+  --type-http: #0891B2;
+  --type-script: #EA580C;
+  --type-output: #059669;
+  --type-note: #78716C;
+  --type-unknown: #78716C;
+
+  --shadow-1: 0 1px 3px rgba(20,18,15,.12);
+  --shadow-2: 0 8px 24px rgba(20,18,15,.14);
+  --shadow-glow: 0 0 0 3px rgba(124,58,237,.2);
+
+  --canvas-dot: #D9D2C7;
+  --minimap-mask: rgba(247,245,242,.7);
+  --edge-idle: #A8A29E;
+  --edge-success: #059669;
+  --edge-running: #D97706;
+  --edge-error: #DC2626;
+  --edge-skipped: #C4BDB2;
+
+  --cm-keyword: #6D28D9;
+  --cm-string: #047857;
+  --cm-number: #B45309;
+  --cm-function: #0E7490;
+  --cm-property: #1D4ED8;
+  --cm-variable: #3F3A34;
+  --cm-comment: #8A857C;
+  --cm-operator: #6F6A64;
+  --cm-type: #B91C1C;
+  --cm-regexp: #A21CAF;
 }
 
 
@@ -121,8 +229,8 @@ body {
   border: 1px solid var(--border);
   white-space: nowrap;
 }
-.mode-glm { background: rgba(16,185,129,.14); color: #34D399; border-color: rgba(16,185,129,.3); }
-.mode-deepseek { background: rgba(59,130,246,.14); color: #60A5FA; border-color: rgba(59,130,246,.3); }
+.mode-glm { background: rgba(16,185,129,.14); color: var(--success-fg); border-color: rgba(16,185,129,.3); }
+.mode-deepseek { background: rgba(59,130,246,.14); color: var(--type-input-fg); border-color: rgba(59,130,246,.3); }
 .run-last { font-size: 12px; color: var(--fg-faint); white-space: nowrap; }
 
 /* ============ 工具栏下拉菜单（＋ 添加 / ⋯ 更多 / 双击画布） ============ */
@@ -163,7 +271,7 @@ body {
 .tb-menu-glyph { color: var(--fg-faint); font-size: 13px; }
 .tb-menu-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
 .tb-menu-sub { font-size: 11px; color: var(--fg-faint); font-weight: 400; }
-.tb-menu-danger:hover:not(:disabled) { background: rgba(239,68,68,.12); color: #F87171; }
+.tb-menu-danger:hover:not(:disabled) { background: rgba(239,68,68,.12); color: var(--danger-fg); }
 
 @media (max-width: 860px) {
   .toolbar { gap: 6px; padding: 8px 10px; }
@@ -309,12 +417,12 @@ body {
 .type-input { background: var(--type-input); }
 .type-agent { background: var(--type-agent); }
 .type-output { background: var(--type-output); }
-.type-condition { background: var(--type-condition); color: #422006; }
-.type-http { background: var(--type-http); color: #062a30; }
-.type-script { background: var(--type-script); color: #2B1104; }
-.type-note { background: var(--type-note); color: #F5F5F4; }
+.type-condition { background: var(--type-condition); color: var(--type-condition-fg); }
+.type-http { background: var(--type-http); color: var(--type-http-fg); }
+.type-script { background: var(--type-script); color: var(--type-script-fg); }
+.type-note { background: var(--type-note); color: var(--type-note-fg); }
 .badge-script { background: color-mix(in srgb, var(--type-script) 15%, transparent); color: var(--type-script); border-color: color-mix(in srgb, var(--type-script) 35%, transparent); }
-.badge-note { background: rgba(120,113,108,.15); color: #D6D3D1; border-color: rgba(120,113,108,.3); }
+.badge-note { background: rgba(120,113,108,.15); color: var(--fg-muted); border-color: rgba(120,113,108,.3); }
 .lint-item { background: none; border: none; padding: 0; cursor: pointer; font: inherit; text-align: left; }
 .lint-item:hover { text-decoration: underline; }
 .type-edge { background: var(--bg-raised); color: var(--fg-muted); border: 1px solid var(--border); }
@@ -337,7 +445,7 @@ body {
 .sec-title { font-size: 12px; font-weight: 600; letter-spacing: .4px; text-transform: uppercase; color: var(--fg-muted); }
 .sec-head:hover .sec-title { color: var(--fg); }
 .sec-count {
-  font-size: 10px; font-weight: 600; color: #C4B5FD;
+  font-size: 10px; font-weight: 600; color: var(--primary-soft);
   background: rgba(139,92,246,.18); border-radius: 999px; padding: 1px 7px; flex-shrink: 0;
 }
 .sec-body { padding: 2px 0 14px 17px; display: flex; flex-direction: column; gap: 10px; }
@@ -362,9 +470,9 @@ body {
 .script-param-head { display: grid; grid-template-columns: minmax(0, 1fr) auto 28px; gap: 6px; align-items: center; }
 .script-param-mode { display: inline-grid; grid-template-columns: 1fr 1fr; gap: 2px; padding: 2px; border: 1px solid var(--border); border-radius: 7px; background: var(--bg); }
 .script-param-mode button { border: 0; border-radius: 5px; padding: 5px 7px; background: transparent; color: var(--fg-faint); font: 11px var(--font-ui); cursor: pointer; }
-.script-param-mode .script-mode-on { background: var(--type-script); color: #2B1104; font-weight: 600; }
+.script-param-mode .script-mode-on { background: var(--type-script); color: var(--type-script-fg); font-weight: 600; }
 .script-param-remove { color: var(--danger); }
-.script-param-error { margin: 0; color: #F87171; font-size: 11px; }
+.script-param-error { margin: 0; color: var(--danger-fg); font-size: 11px; }
 .script-param-add { align-self: flex-start; }
 .script-json-input { font-family: var(--font-mono) !important; font-size: 12px !important; tab-size: 2; }
 /* 脚本代码编辑器：容器样式继承 .tpl-cm，这里只调代码特有项 */
@@ -388,10 +496,10 @@ body {
 .node-panel-scroll { overflow-y: auto; flex: 1; min-height: 0; }
 
 .panel-note { font-size: 12px; border-radius: 8px; padding: 8px 10px; margin: 0; }
-.note-ok { background: rgba(16,185,129,.1); color: #34D399; }
-.note-warn { background: rgba(245,158,11,.1); color: #FBBF24; }
+.note-ok { background: rgba(16,185,129,.1); color: var(--success-fg); }
+.note-warn { background: rgba(245,158,11,.1); color: var(--warn-fg); }
 .panel-error {
-  font-size: 12px; background: rgba(239,68,68,.12); color: #F87171;
+  font-size: 12px; background: rgba(239,68,68,.12); color: var(--danger-fg);
   border-radius: 8px; padding: 8px 10px; word-break: break-all;
 }
 .panel-output {
@@ -406,7 +514,7 @@ body {
 .result-title { font-size: 12px; font-weight: 600; color: var(--fg); letter-spacing: .4px; }
 .sec-result { padding-top: 12px; padding-bottom: 14px; display: flex; flex-direction: column; gap: 8px; }
 .panel-structured summary { cursor: pointer; color: var(--accent); font-size: 11px; }
-.panel-structured .panel-output { margin-top: 6px; color: #A7F3D0; }
+.panel-structured .panel-output { margin-top: 6px; color: var(--success-soft); }
 .attachment-row {
   display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--fg-muted);
   padding: 6px 8px; border: 1px solid var(--border); border-radius: 8px;
@@ -424,7 +532,7 @@ body {
 .chip:hover { border-color: var(--primary); color: var(--fg); }
 .chip:focus-visible { outline: none; box-shadow: var(--shadow-glow); }
 .chip-on {
-  background: rgba(139,92,246,.16); border-color: var(--primary); color: #C4B5FD; font-weight: 500;
+  background: rgba(139,92,246,.16); border-color: var(--primary); color: var(--primary-soft); font-weight: 500;
 }
 
 /* ============ 成果面板 ============ */
@@ -466,7 +574,7 @@ body {
 }
 .log-filter:hover:not(:disabled) { color: var(--fg); border-color: var(--border-strong); }
 .log-filter:disabled { opacity: .4; cursor: default; }
-.log-filter-on { background: rgba(139,92,246,.16); border-color: var(--primary); color: #C4B5FD; }
+.log-filter-on { background: rgba(139,92,246,.16); border-color: var(--primary); color: var(--primary-soft); }
 
 /* 结构化日志行 */
 .run-log {
@@ -483,19 +591,19 @@ body {
 .log-run-tag { color: var(--primary); flex-shrink: 0; }
 /* 状态点文字：色 + 文字双通道（不只靠颜色） */
 .log-status { font-size: 11px; flex-shrink: 0; border-radius: 4px; padding: 0 5px; }
-.dot-success { color: #34D399; background: rgba(16,185,129,.12); }
-.dot-error { color: #F87171; background: rgba(239,68,68,.14); }
-.dot-running { color: #FBBF24; background: rgba(245,158,11,.12); }
+.dot-success { color: var(--success-fg); background: rgba(16,185,129,.12); }
+.dot-error { color: var(--danger-fg); background: rgba(239,68,68,.14); }
+.dot-running { color: var(--warn-fg); background: rgba(245,158,11,.12); }
 .dot-skipped { color: var(--fg-faint); background: rgba(120,113,108,.14); }
-.dot-canceled { color: #94A3B8; background: rgba(148,163,184,.12); }
-.dot-waiting { color: #F9A8D4; background: rgba(236,72,153,.12); }
+.dot-canceled { color: var(--canceled); background: rgba(148,163,184,.12); }
+.dot-waiting { color: var(--pink); background: rgba(236,72,153,.12); }
 .lg-run.lg-st-start .log-text { color: var(--fg); }
-.lg-run.lg-st-success .log-text { color: #34D399; }
-.lg-run.lg-st-error .log-text, .lg-run.lg-st-canceled .log-text { color: #F87171; }
-.lg-sys .log-text { color: #F87171; word-break: break-all; }
+.lg-run.lg-st-success .log-text { color: var(--success-fg); }
+.lg-run.lg-st-error .log-text, .lg-run.lg-st-canceled .log-text { color: var(--danger-fg); }
+.lg-sys .log-text { color: var(--danger-fg); word-break: break-all; }
 .log-node {
   background: none; border: none; padding: 0; font: inherit; font-size: 12px;
-  color: #7DD3FC; cursor: pointer; text-decoration: none; flex-shrink: 0;
+  color: var(--link-node); cursor: pointer; text-decoration: none; flex-shrink: 0;
 }
 .log-node:hover { text-decoration: underline; }
 .log-text { color: var(--fg-muted); word-break: break-word; min-width: 0; }
@@ -528,7 +636,7 @@ body {
 .spinner {
   width: 10px; height: 10px; flex: none;
   border: 1.5px solid rgba(245, 158, 11, .3);
-  border-top-color: #f59e0b;
+  border-top-color: var(--warn);
   border-radius: 50%;
   animation: spin .8s linear infinite;
 }
@@ -552,12 +660,12 @@ body {
 .flow-node-elapsed {
   font-family: var(--font-mono); font-size: 11px; font-weight: 600;
   padding: 1px 6px; margin-right: 6px; border-radius: 999px;
-  background: rgba(245, 158, 11, .18); color: #b45309;
+  background: rgba(245, 158, 11, .18); color: var(--warn-fg);
 }
 .flow-node-body { padding: 9px 12px; }
 .flow-node-hint { margin: 0; font-size: 12px; color: var(--fg-muted); line-height: 1.45; }
 .flow-node-live {
-  margin: 6px 0 0; font-size: 11px; color: #FDE68A;
+  margin: 6px 0 0; font-size: 11px; color: var(--warn-fg);
   background: rgba(245,158,11,.1); border-radius: 6px; padding: 4px 7px;
   line-height: 1.4; font-family: var(--font-mono);
 }
@@ -572,11 +680,11 @@ body {
   display: inline-flex; align-items: center; gap: 3px;
 }
 .badge-model {
-  font-family: var(--font-mono); background: rgba(245,158,11,.1); color: #FBBF24; border-color: rgba(245,158,11,.25);
+  font-family: var(--font-mono); background: rgba(245,158,11,.1); color: var(--warn-fg); border-color: rgba(245,158,11,.25);
   max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
 }
-.badge-plan { background: rgba(236,72,153,.12); color: #F9A8D4; border-color: rgba(236,72,153,.25); }
-.badge-cond { background: rgba(245,158,11,.1); color: #FBBF24; border-color: rgba(245,158,11,.25); }
+.badge-plan { background: rgba(236,72,153,.12); color: var(--pink); border-color: rgba(236,72,153,.25); }
+.badge-cond { background: rgba(245,158,11,.1); color: var(--warn-fg); border-color: rgba(245,158,11,.25); }
 
 /* 连接桩 */
 .flow-handle {
@@ -633,8 +741,8 @@ body {
 /* 条件分支「是/否」标签（自定义边自绘） */
 .edge-branch-tag {
   position: absolute; z-index: 5; pointer-events: none;
-  font-size: 11px; font-weight: 600; color: #A8A29E;
-  background: #1D1A16; border: 1px solid var(--border);
+  font-size: 11px; font-weight: 600; color: var(--fg-muted);
+  background: var(--bg-panel); border: 1px solid var(--border);
   border-radius: 6px; padding: 1px 7px; line-height: 1.5;
 }
 .edge-addbtn {
@@ -676,7 +784,7 @@ body {
   background: var(--bg-panel) !important; border: 1px solid var(--border);
   border-radius: var(--radius) !important; overflow: hidden;
 }
-.react-flow__minimap-mask { fill: rgba(20,18,15,.7); }
+.react-flow__minimap-mask { fill: var(--minimap-mask); }
 .react-flow__edge-path { transition: stroke var(--dur) var(--ease); }
 .react-flow__attribution { display: none; }
 .react-flow__edge-text { fill: var(--fg-muted) !important; }
@@ -736,15 +844,15 @@ body {
   display: flex; flex-direction: column; gap: 3px; max-width: 340px;
   box-shadow: var(--shadow-2);
 }
-.lint-error { color: #F87171; }
-.lint-warn { color: #FBBF24; }
+.lint-error { color: var(--danger-fg); }
+.lint-warn { color: var(--warn-fg); }
 
 /* ============ Plan 过程 ============ */
 .plan-trace {
   margin: 12px 0 0; border: 1px solid var(--border);
   border-radius: var(--radius); padding: 8px 10px; background: var(--bg-raised);
 }
-.plan-trace summary { font-size: 12px; font-weight: 600; color: #F9A8D4; cursor: pointer; user-select: none; }
+.plan-trace summary { font-size: 12px; font-weight: 600; color: var(--pink); cursor: pointer; user-select: none; }
 .plan-trace .panel-output { margin-top: 4px; max-height: 200px; }
 .live-progress .live-out { max-height: 120px; overflow: auto; background: rgba(245,158,11,.07); }
 /* 面板置顶实时活动条：运行中节点点开第一眼可见 */
@@ -754,11 +862,11 @@ body {
   background: rgba(245, 158, 11, .1); border: 1px solid rgba(245, 158, 11, .35);
 }
 .live-strip-dot {
-  width: 8px; height: 8px; border-radius: 50%; background: #f59e0b;
+  width: 8px; height: 8px; border-radius: 50%; background: var(--warn);
   animation: log-pulse 1.2s ease-in-out infinite;
 }
-.live-strip-title { font-size: 13px; font-weight: 700; color: #b45309; }
-.live-strip-elapsed { font-family: var(--font-mono); font-size: 13px; font-weight: 600; color: #92400e; }
+.live-strip-title { font-size: 13px; font-weight: 700; color: var(--warn-fg); }
+.live-strip-elapsed { font-family: var(--font-mono); font-size: 13px; font-weight: 600; color: var(--warn-fg); }
 .live-strip-turns { font-size: 12px; color: var(--fg-muted); white-space: nowrap; }
 .live-strip-preview {
   grid-column: 1 / -1; margin: 0; padding: 8px 10px; max-height: 132px; overflow: auto;
@@ -990,7 +1098,7 @@ body {
 .cred-name-line strong { font-size: 13px; }
 .cred-default-tag {
   font-size: 10px; font-weight: 600; padding: 1px 7px; border-radius: 999px;
-  background: rgba(139,92,246,.18); color: #C4B5FD; border: 1px solid rgba(139,92,246,.35);
+  background: rgba(139,92,246,.18); color: var(--primary-soft); border: 1px solid rgba(139,92,246,.35);
 }
 .cred-id { font-size: 11px; color: var(--fg-faint); font-family: var(--font-mono); margin-top: 3px; display: block; }
 .cred-empty {
@@ -1040,10 +1148,10 @@ body {
 .tpl-cm .cm-tooltip-autocomplete > ul > li[aria-selected] { background: rgba(139,92,246,.2); color: var(--fg); }
 .tpl-cm .cm-completionLabel { font-size: 12px; }
 .tpl-cm .cm-completionDetail { color: var(--fg-faint); font-size: 10px; }
-.cm-template-token { color: #A7F3D0; background: rgba(16,185,129,.1); border-radius: 3px; }
-.cm-template-legacy { color: #FDE68A; background: rgba(245,158,11,.1); }
-.cm-template-error { text-decoration: underline wavy #F87171 1px; text-underline-offset: 3px; }
-.cm-template-warning { text-decoration: underline wavy #FBBF24 1px; text-underline-offset: 3px; }
+.cm-template-token { color: var(--success-soft); background: rgba(16,185,129,.1); border-radius: 3px; }
+.cm-template-legacy { color: var(--warn-fg); background: rgba(245,158,11,.1); }
+.cm-template-error { text-decoration: underline wavy var(--danger-fg) 1px; text-underline-offset: 3px; }
+.cm-template-warning { text-decoration: underline wavy var(--warn-fg) 1px; text-underline-offset: 3px; }
 .tpl-toolbar { display: flex; align-items: center; gap: 5px; min-width: 0; }
 .tpl-toolbar-spacer { flex: 1; min-width: 0; }
 .tpl-tool {
@@ -1056,17 +1164,17 @@ body {
 .tpl-tool:disabled { opacity: .45; cursor: default; }
 .tpl-health { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 10.5px; }
 .tpl-health-ok { color: var(--success); }
-.tpl-health-bad { color: #F87171; }
-.tpl-active-info code { min-width: 0; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--font-mono); font-size: 10px; color: #A7F3D0; }
+.tpl-health-bad { color: var(--danger-fg); }
+.tpl-active-info code { min-width: 0; max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--font-mono); font-size: 10px; color: var(--success-soft); }
 .tpl-active-label { color: var(--fg); font-weight: 600; }
 .tpl-rendered-error { border-color: rgba(239,68,68,.4); }
 .tpl-rendered > p { margin: 0; padding: 6px 10px; color: var(--warn); font-size: 11px; border-top: 1px solid var(--border); }
 
-.var-explorer { min-width: 0; max-width: 100%; border: 1px solid var(--border-strong); border-radius: 8px; background: rgba(20,18,15,.72); overflow: hidden; }
+.var-explorer { min-width: 0; max-width: 100%; border: 1px solid var(--border-strong); border-radius: 8px; background: var(--bg-panel); overflow: hidden; }
 .var-explorer-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 8px 9px; border-bottom: 1px solid var(--border); }
 .var-explorer-head > div { display: flex; align-items: center; gap: 7px; min-width: 0; }
 .var-explorer-head strong { font-size: 11px; color: var(--fg); }
-.var-fallback { flex-shrink: 0; padding: 1px 5px; border-radius: 4px; background: rgba(245,158,11,.12); color: #FBBF24; font-size: 9px; }
+.var-fallback { flex-shrink: 0; padding: 1px 5px; border-radius: 4px; background: rgba(245,158,11,.12); color: var(--warn-fg); font-size: 9px; }
 .var-search { display: flex !important; align-items: center; gap: 6px; margin: 7px 8px !important; padding: 0 8px; border: 1px solid var(--border); border-radius: 6px; background: var(--bg-raised); }
 .var-search svg { flex-shrink: 0; color: var(--fg-faint); }
 .var-search input { min-width: 0; padding: 6px 0 !important; border: 0 !important; background: transparent !important; box-shadow: none !important; font-size: 11px !important; }
@@ -1088,15 +1196,15 @@ body {
 .var-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
 .var-name-line { display: flex; align-items: center; gap: 5px; min-width: 0; }
 .var-name { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 11px; }
-.var-main code { display: block; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--font-mono); font-size: 9.5px; color: #A7F3D0; }
-.var-type { flex-shrink: 0; padding: 1px 4px; border-radius: 4px; background: rgba(6,182,212,.1); color: #67E8F9; font-size: 8.5px; line-height: 1.35; }
+.var-main code { display: block; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-family: var(--font-mono); font-size: 9.5px; color: var(--success-soft); }
+.var-type { flex-shrink: 0; padding: 1px 4px; border-radius: 4px; background: rgba(6,182,212,.1); color: var(--accent-soft); font-size: 8.5px; line-height: 1.35; }
 .var-preview, .var-no-value { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 9.5px; }
 .var-preview { color: var(--fg-faint); }
-.var-no-value { color: #A8A29E; font-style: italic; }
+.var-no-value { color: var(--fg-muted); font-style: italic; }
 .var-copy { margin-left: auto; flex-shrink: 0; }
 .var-empty { padding: 16px 8px; text-align: center; color: var(--fg-faint); font-size: 11px; }
 .var-explorer-foot { padding: 7px 9px; border-top: 1px solid var(--border); color: var(--fg-faint); font-size: 9.5px; line-height: 1.45; }
-.var-explorer-foot code { color: #A7F3D0; font-family: var(--font-mono); }
+.var-explorer-foot code { color: var(--success-soft); font-family: var(--font-mono); }
 
 .tpl-editor { display: flex; flex-direction: column; gap: 6px; }
 .tpl-editor h4 {
@@ -1127,12 +1235,12 @@ body {
 .tpl-wrap:focus-within .tpl-hl { box-shadow: var(--shadow-glow); }
 
 .tpl-var {
-  color: #C4B5FD; background: rgba(139,92,246,.13);
+  color: var(--primary-soft); background: rgba(139,92,246,.13);
   border-radius: 4px; padding: 0 2px;
 }
 .tpl-var-opt { border-bottom: 2px dotted rgba(139,92,246,.5); }
 .tpl-var-bad {
-  color: #FCA5A5; background: rgba(239,68,68,.12);
+  color: var(--danger-muted); background: rgba(239,68,68,.12);
   text-decoration: underline wavy rgba(239,68,68,.6);
   text-underline-offset: 3px;
 }
@@ -1150,7 +1258,7 @@ body {
 .tpl-status-note { color: var(--fg-faint); font-size: 11px; line-height: 1.35; }
 .tpl-status-actions { display: flex; align-items: center; justify-content: flex-end; gap: 6px; }
 .tpl-status-ok { color: var(--success); line-height: 1.4; }
-.tpl-status-bad { color: #F87171; line-height: 1.4; }
+.tpl-status-bad { color: var(--danger-fg); line-height: 1.4; }
 .tpl-jump { font-size: 11px; padding: 4px 8px; white-space: nowrap; }
 .tpl-render-btn { min-width: 72px; padding: 4px 9px; white-space: nowrap; }
 
@@ -1162,11 +1270,11 @@ body {
 }
 .tpl-chip {
   font-family: var(--font-mono); font-size: 11px;
-  color: #C4B5FD; background: rgba(139,92,246,.13); border-radius: 4px; padding: 1px 5px;
+  color: var(--primary-soft); background: rgba(139,92,246,.13); border-radius: 4px; padding: 1px 5px;
 }
 .tpl-tag-opt {
   font-size: 11px; padding: 1px 7px; border-radius: 999px;
-  background: rgba(245,158,11,.12); color: #FBBF24;
+  background: rgba(245,158,11,.12); color: var(--warn-fg);
 }
 .tpl-preview { width: 100%; }
 .tpl-preview summary { cursor: pointer; color: var(--accent); font-size: 12px; }
@@ -1236,20 +1344,20 @@ body {
   flex: 0 0 auto; max-height: 112px; overflow: auto; padding: 7px 10px;
   border-top: 1px solid rgba(239,68,68,.28); background: rgba(239,68,68,.06);
 }
-.variable-workbench-issues p { margin: 2px 0; color: #FCA5A5; font-size: 10.5px; line-height: 1.45; }
+.variable-workbench-issues p { margin: 2px 0; color: var(--danger-muted); font-size: 10.5px; line-height: 1.45; }
 .variable-preview-body { flex: 1; min-height: 0; overflow: auto; }
 .variable-preview-body pre {
   margin: 0; min-height: 100%; padding: 14px;
   white-space: pre-wrap; word-break: break-word;
   color: var(--fg); font-family: var(--font-mono); font-size: 12.5px; line-height: 1.65;
 }
-.variable-preview-error pre { color: #FCA5A5; }
+.variable-preview-error pre { color: var(--danger-muted); }
 .variable-preview-empty { padding: 18px 14px; color: var(--fg-faint); font-size: 12px; }
 .variable-preview-missing {
   flex: 0 0 auto; max-height: 150px; overflow: auto; display: flex; flex-direction: column; gap: 5px;
   padding: 9px 12px; border-top: 1px solid rgba(245,158,11,.3); background: rgba(245,158,11,.06);
 }
-.variable-preview-missing strong { color: #FBBF24; font-size: 10.5px; }
+.variable-preview-missing strong { color: var(--warn-fg); font-size: 10.5px; }
 .variable-preview-missing code { color: var(--fg-muted); font-size: 10px; word-break: break-all; }
 
 /* B 层变量按钮 + 预览卡 */
@@ -1273,7 +1381,7 @@ body {
 }
 .tpl-varbtn-wrap:hover { border-color: var(--primary); background: var(--bg-hover); }
 .tpl-varbtn {
-  flex: 1; min-width: 0; border: 0; background: transparent; color: #C4B5FD;
+  flex: 1; min-width: 0; border: 0; background: transparent; color: var(--primary-soft);
   padding: 5px 7px; cursor: pointer; text-align: left;
   font-family: var(--font-mono); font-size: 10.5px; line-height: 1.35;
   overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
@@ -1344,7 +1452,7 @@ body {
 }
 .test-input-head { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; cursor: pointer; }
 .test-input-head input { accent-color: var(--primary); }
-.test-input-name { font-family: var(--font-mono); font-size: 12px; color: #C4B5FD; }
+.test-input-name { font-family: var(--font-mono); font-size: 12px; color: var(--primary-soft); }
 .test-from { font-size: 11px; color: var(--fg-faint); }
 .test-input-off .test-input-name { text-decoration: line-through; opacity: .5; }
 .test-input-off textarea { opacity: .45; }
@@ -1354,10 +1462,10 @@ body {
   padding: 10px; font-size: 12px; font-family: var(--font-mono);
   white-space: pre-wrap; word-break: break-word; color: var(--fg-muted);
 }
-.test-result-err pre { border-color: rgba(239,68,68,.4); color: #FCA5A5; }
+.test-result-err pre { border-color: rgba(239,68,68,.4); color: var(--danger-muted); }
 .test-structured { margin-top: 9px; }
 .test-structured summary { cursor: pointer; color: var(--accent); font-size: 11px; margin-bottom: 5px; }
-.test-structured pre { max-height: 280px; color: #A7F3D0; }
+.test-structured pre { max-height: 280px; color: var(--success-soft); }
 .test-progress pre { background: rgba(245,158,11,.06); border-color: rgba(245,158,11,.25); }
 .test-hist-list { display: flex; flex-direction: column; gap: 8px; margin-top: 8px; }
 .test-hist-item { border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; }
@@ -1489,11 +1597,11 @@ body {
 .vc-variable-select:focus-visible { outline: none; box-shadow: inset var(--shadow-glow); border-radius: 7px; }
 .vc-variable-type {
   flex: 0 0 auto; min-width: 47px; padding: 3px 5px; border-radius: 5px;
-  background: rgba(6,182,212,.1); color: #67E8F9; font: 9px/1.35 var(--font-mono); text-align: center;
+  background: rgba(6,182,212,.1); color: var(--accent-soft); font: 9px/1.35 var(--font-mono); text-align: center;
 }
 .vc-variable-main { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 3px; }
 .vc-variable-main strong { overflow: hidden; font-size: 12px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
-.vc-variable-main code { overflow: hidden; color: #A7F3D0; font: 9.5px/1.4 var(--font-mono); text-overflow: ellipsis; white-space: nowrap; }
+.vc-variable-main code { overflow: hidden; color: var(--success-soft); font: 9.5px/1.4 var(--font-mono); text-overflow: ellipsis; white-space: nowrap; }
 .vc-required { flex: 0 0 auto; color: var(--warn); font-size: 9px; }
 .vc-copy { position: absolute; right: 24px; z-index: 1; width: 26px; height: 26px; padding: 0; color: var(--fg-faint); }
 .vc-copy:hover { color: var(--accent); }
@@ -1530,15 +1638,15 @@ body {
   display: flex; flex-direction: column; gap: 4px; background: var(--bg); overflow: hidden;
 }
 .vc-token-preview span { color: var(--fg-faint); font-size: 9px; text-transform: uppercase; letter-spacing: .5px; }
-.vc-token-preview code { overflow-wrap: anywhere; color: #A7F3D0; font: 10.5px/1.5 var(--font-mono); }
+.vc-token-preview code { overflow-wrap: anywhere; color: var(--success-soft); font: 10.5px/1.5 var(--font-mono); }
 .vc-form-error {
   margin-top: 10px; padding: 8px 9px; border: 1px solid rgba(239,68,68,.35); border-radius: 7px;
-  display: flex; align-items: flex-start; gap: 7px; background: rgba(239,68,68,.08); color: #FCA5A5; font-size: 11px; line-height: 1.45;
+  display: flex; align-items: flex-start; gap: 7px; background: rgba(239,68,68,.08); color: var(--danger-muted); font-size: 11px; line-height: 1.45;
 }
 .vc-form-error svg { flex: 0 0 auto; margin-top: 1px; }
 .vc-form-foot { min-height: 54px; padding: 9px 16px; border-top: 1px solid var(--border); display: flex; justify-content: flex-end; }
 .vc-delete { color: var(--fg-faint); }
-.vc-delete:hover { color: #FCA5A5; background: rgba(239,68,68,.1); }
+.vc-delete:hover { color: var(--danger-muted); background: rgba(239,68,68,.1); }
 .vc-confirm-modal { z-index: 970; }
 .vc-confirm-modal .modal-box { width: min(460px, 92vw); }
 

--- a/web/src/theme.js
+++ b/web/src/theme.js
@@ -1,0 +1,35 @@
+// 主题调色板：styles.css 的 CSS 变量是唯一事实源；React Flow 的 SVG 属性
+// （marker/迷你图节点/背景点）不走 CSS 级联、解析不了 var()，需要真实色值时
+// 经 getComputedStyle 现取。useThemePalette 监听 <html data-theme> 变化
+// （宿主 dsh 经 wf1-theme postMessage 驱动），切换时自动重算。
+import { useEffect, useMemo, useState } from 'react';
+
+const currentTheme = () => (document.documentElement.dataset.theme === 'light' ? 'light' : 'dark');
+
+export function useThemePalette() {
+  const [theme, setTheme] = useState(currentTheme);
+  useEffect(() => {
+    const observer = new MutationObserver(() => setTheme(currentTheme()));
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['data-theme'] });
+    return () => observer.disconnect();
+  }, []);
+  return useMemo(() => {
+    const styles = getComputedStyle(document.documentElement);
+    const token = (name) => styles.getPropertyValue(name).trim();
+    return {
+      canvasDot: token('--canvas-dot'),
+      minimapMask: token('--minimap-mask'),
+      labelFill: token('--fg-muted'),
+      labelBg: token('--bg-panel'),
+      edge: {
+        idle: token('--edge-idle'), success: token('--edge-success'), running: token('--edge-running'),
+        error: token('--edge-error'), skipped: token('--edge-skipped'), canceled: token('--edge-idle'),
+      },
+      minimapNode: {
+        agent: token('--type-agent'), input: token('--type-input'), script: token('--type-script'),
+        condition: token('--type-condition'), http: token('--type-http'), output: token('--type-output'),
+        note: token('--type-note'), unknown: token('--fg-faint'),
+      },
+    };
+  }, [theme]);
+}


### PR DESCRIPTION
## 背景

关闭 #20。

工作流画布（web/）此前只有一套 OLED 深色样式，硬编码在各组件里；dsh 主界面切浅色主题时画布仍全黑，视觉割裂。

## 方案

三层改造，全部走 CSS 变量令牌，主题切换零刷新：

- **web 令牌化**（8f44fe2）：`styles.css` 拆出深/浅两套 token（`html[data-theme='dark'], :root` 默认深色 / `html[data-theme='light']`），组件层全部改 var() 引用；新增 CodeMirror 语法色、React Flow SVG 专用 token（连线/迷你图/背景点）；`theme.js` 新增 `useThemePalette`——SVG 属性无法解析 var()，经 getComputedStyle 读 token，data-theme 变化时重算
- **canvasui 主题桥**（d29a45b）：宿主侧 MutationObserver 盯 `body[data-ds-dark-theme]`（官方 ThemePresenter 的落点，含「跟随系统」OS 明暗翻转），变化即向画布 iframe postMessage `wf1-theme`；画布收消息设 `documentElement.dataset.theme`，CSS 级联整体换肤；iframe 加载完成（wf1-ready）后补发一次，兜住初始竞态

## 验证

- 真实 dsh 实例（profile 软链指向本分支代码）+ Playwright 走设置页实测：
  - `ui-theme: light` → 画布 `data-theme=light`，`--bg=#F7F5F2` ✅
  - 改 `dark` 重载 → `data-theme=dark`，`--bg=#14120F` ✅
  - 运行中动态切换 body 属性 → 画布 600ms 内变肤，不刷新 ✅
- 「跟随系统」与手动切换走同一条 `data-ds-dark-theme` DOM 变更路径（官方 ThemeRuntime 监听 `prefers-color-scheme` → ThemePresenter 写属性），桥均覆盖
- `npm test` 全量通过（web 10 套 + canvasui 含新增主题桥用例）

🤖 Generated with [Claude Code](https://claude.com/claude-code)