### PR TITLE
refactor(orchestrator): 工作流与运行记录迁移到 SQLite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24.15
           cache: npm
           cache-dependency-path: |
             package-lock.json
@@ -46,7 +46,7 @@ jobs:
       - name: build
         run: sh dsh-plugins/build-web.sh
         env:
-          DSH_NODE: node # 构建链认 DSH_NODE 指向 ≥20 的 node；CI 里就是 node 本身
+          DSH_NODE: node # Workflow One 用 node:sqlite，要求 ≥24.15；CI 里就是 node 本身
 
       - name: verify npm packages
         run: node scripts/verify-plugin-packages.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24
+          node-version: 24.15
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## 环境前提
 
-- Node ≥ 20。系统自带 Node 版本不够时，用 `DSH_NODE` 环境变量指向任意 ≥ 20 的 node 可执行文件（setup/start/pack 脚本都认它）
+- Node ≥ 24.15（Workflow One 使用内置 `node:sqlite`）。系统自带 Node 版本不够时，用 `DSH_NODE` 环境变量指向任意 ≥ 24.15 的 node 可执行文件（setup/start/pack 脚本都认它）
 - dsh 全局安装：`npm i -g @deepseek-ai/dsh`
 - LLM key 一律经环境变量注入：变量名由 dsh profile 的 provider 配置（`cordis.patch.yml` 的 `apiKeyEnv`）声明，配什么 provider 就用什么变量，文档与代码里不要写死某个 key 名；插件与仓库**不存任何 key**
 - 构建脚本为 POSIX sh：macOS / Linux 原生可用，Windows 走 WSL 或 Git Bash
@@ -55,7 +55,7 @@
 ### 常用命令
 
 ```sh
-npm test                                   # 全量单测聚合（scripts/run-tests.sh：web 10 套 + orchestrator 13 套 + llm-guard + canvasui + document-preview）
+npm test                                   # 全量单测聚合（scripts/run-tests.sh：web 10 套 + orchestrator 14 套 + llm-guard + canvasui + document-preview）
 sh dsh-plugins/build-web.sh                 # 画布双构建（/wf1/ base + 根 base），改前端后必跑（产物不入库，仅落工作区）
 sh dsh-plugins/setup.sh [profile] [端口]    # 安装（默认 dsh-ccpg / 4021）
 sh dsh-plugins/start.sh <profile>           # 启动
@@ -63,7 +63,7 @@ sh dsh-plugins/pack.sh <tag>                # 打包 release（CI 同源）
 
 # 分套运行（改哪跑哪）
 cd web && npm test                          # 前端 10 套
-cd dsh-plugins/dsh-ccpg-orchestrator && for t in test/*.test.mjs; do node "$t"; done  # 引擎 13 套
+cd dsh-plugins/dsh-ccpg-orchestrator && for t in test/*.test.mjs; do node "$t"; done  # 引擎 14 套
 node dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs         # canvasui 客户端
 node dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs  # 4 例
 ```
@@ -75,7 +75,7 @@ CI：`.github/workflows/ci.yml` 在 PR 与 main push 上跑 `npm test` + `build-
 1. **双端节点注册表**：新增节点类型必须两处注册——引擎 `orchestrator/lib/engine.js` 的 `registerKind({execute, lint, edgeTaken, wantsSink})` + 前端 `web/src/registry.jsx`（icon/色/preset/summary/badges）。AI 助手侧同步 `lib/assistant.js`（NODE_TYPES + persona 契约）与 `lib/variable-schema.js`（变量树）。两处注册即得调度/审批/超时/重试/UI 全部能力，不要另起旁路。
 2. **canvasui bundle 是构建产物**：`lib/client.js` 由 `src/client.js` 生成（gitignore 不入库），直接改会被覆盖；改后重跑 `build-canvasui.sh`（`--check` 逐字比对防漂移）。
 3. **4020 Express 回退能力冻结**：新功能只做插件路径（`/wf1/api/*`）；`server/` 仅修 bug。同语义端点双入口实现时以插件端为准。
-4. **工作区本地存储**：每实体一 JSON 文件，统一位于当前 dsh 会话工作目录的 `.workflow-one/`（state/workflows/runs/attachments/runtime），节点 agent 以工作区根为 cwd、成果只收集各节点 runtime 输出目录；`.workflow-one/` 必须 gitignore，**绝不提交**。飞书凭据仍是 dsh 用户级数据，不迁入工作区。
+4. **工作区本地存储**：工作流与运行记录位于当前 dsh 会话工作目录的 `.workflow-one/workflow-one.sqlite`；state/attachments/runtime 继续使用同目录下文件。节点 agent 以工作区根为 cwd、成果只收集各节点 runtime 输出目录；`.workflow-one/` 必须 gitignore，**绝不提交**。飞书凭据仍是 dsh 用户级数据，不迁入工作区。
 5. **构建产物一律不入库**（`web-dist/`、`canvasui lib/client.js`、`document-preview/dist/`、`web/dist/` 全部 gitignore）：分发包「拿到即装」由 `pack.sh` 现场重跑构建保证；源码安装先 `build-web.sh` 再 `setup.sh`（setup 已前置校验）。绝不为省一步构建把产物提交进仓库。
 
 ### 前端坑
@@ -88,5 +88,5 @@ CI：`.github/workflows/ci.yml` 在 PR 与 main push 上跑 `npm test` + `build-
 ### 测试与验证
 
 - 单测全部是零依赖 node 断言脚本（`node:assert` + 自写 runner），直接 `node <file>` 运行；新插件照此约定写测试
-- 改引擎跑 orchestrator 13 套；改前端跑 web 10 套；改 canvasui 跑其 client 测试并重建 bundle；改预览跑 document-preview 4 例
+- 改引擎跑 orchestrator 14 套；改前端跑 web 10 套；改 canvasui 跑其 client 测试并重建 bundle；改预览跑 document-preview 4 例
 - E2E 用 CDP（chrome-devtools）跑真实浏览器验证；dsh 官方 UI 首载慢，等待时间放宽（画布就绪 3.5s→6s），wait text 偶超时先多等几秒再判失败

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## 立即安装
 
-Node.js >= 20 且已安装 `@deepseek-ai/dsh`：
+Node.js >= 24.15 且已安装 `@deepseek-ai/dsh`：
 
 ```sh
 dsh plugin --profile web add dsh-ccpg-one@0.2.1
@@ -48,7 +48,7 @@ Desktop 使用官方 DSH/Cordis 插件组合，不需要另一套插件。不要
 **普通用户（release 包，无需本仓库源码）**：
 
 ```sh
-# 前提：node>=20、npm i -g @deepseek-ai/dsh
+# 前提：node>=24.15、npm i -g @deepseek-ai/dsh
 curl -LO https://github.com/chumingjun/harness-one/releases/download/<tag>/dsh-ccpg-plugins-<tag>.tar.gz
 tar -xzf dsh-ccpg-plugins-<tag>.tar.gz && cd dsh-plugins
 sh setup.sh --one wf1 4021               # 一键安装（自带全部构建产物）
@@ -158,7 +158,7 @@ dsh-plugins/
 ## 测试
 
 ```sh
-cd dsh-plugins/dsh-ccpg-orchestrator && for t in test/*.test.mjs; do node "$t"; done  # 13 套
+cd dsh-plugins/dsh-ccpg-orchestrator && for t in test/*.test.mjs; do node "$t"; done  # 14 套
 node dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs                               # canvasui 客户端
 node dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs                        # 4/4
 cd web && npm test                                                                    # 10 套
@@ -167,7 +167,7 @@ cd web && npm test                                                              
 ## 已知限制
 
 - 飞书写回为追加段落块，不保留富文本格式
-- 存储 = 每实体一 JSON 文件（多人编辑需求出现再迁 SQLite）
+- 工作流与运行记录按工作区存入 `.workflow-one/workflow-one.sqlite`；state、附件与运行产物仍为本地文件
 
 ## 反馈
 

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -15,7 +15,7 @@
 
 ## 安装与使用
 
-普通 dsh 有 release/源码两种路径，前提是 **Node ≥ 20**、`npm i -g @deepseek-ai/dsh`。Harness Desktop 自带运行时，走下面的原生插件命令。
+普通 dsh 有 release/源码两种路径，前提是 **Node ≥ 24.15**、`npm i -g @deepseek-ai/dsh`。Harness Desktop 自带运行时，走下面的原生插件命令。
 
 ### Harness Desktop
 
@@ -123,7 +123,7 @@ dsh plugin --profile myprofile add dsh-ccpg-brand
 ## 数据位置
 
 - 技能目录：dsh 原生 `~/.dsh/skills` / `~/.agents/skills`（`ctx.skills` 发现；feishu-cli 技能由 larkauth 启动时自动种子到 `~/.dsh/skills`）
-- Workflow One 数据：当前 dsh 会话工作目录下的 `.workflow-one/`（state/workflows/attachments/runs/runtime，gitignore）
+- Workflow One 数据：当前 dsh 会话工作目录下的 `.workflow-one/`；工作流与运行记录存于 `workflow-one.sqlite`，state/attachments/runtime 继续使用文件系统（整体 gitignore）
 - 节点执行：agent 以真实工作区根为 cwd，可读取项目文件；交付物写入 `.workflow-one/runtime/<workflow>/<run>/nodes/<node>/workspace/`，成果快照只扫描该节点目录
 - 旧版 `~/.dsh/plugin-data/dsh-ccpg-orchestrator` 与插件包 `data/`：首次进入工作区时只导入一次，之后不再写入
 - agent 会话：`~/.dsh/sessions/`（dsh 持久化，zstd JSONL）

--- a/dsh-plugins/boot-smoke.sh
+++ b/dsh-plugins/boot-smoke.sh
@@ -7,7 +7,7 @@
 #
 # 用法：sh boot-smoke.sh <tarball> [端口]
 # 环境隔离：DSH_HOME / HOME 之外的全局态不触碰；profile 与临时目录用完即删。
-# 依赖：node>=20、npm i -g @deepseek-ai/dsh、curl；模型不需要 key
+# 依赖：node>=24.15、npm i -g @deepseek-ai/dsh、curl；模型不需要 key
 #（smoke 只验证插件挂载与页面可服务，不发真实 LLM 请求）。
 set -e
 

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -28,7 +28,7 @@
     "cordis"
   ],
   "engines": {
-    "node": ">=20"
+    "node": ">=24.15"
   },
   "type": "module",
   "private": false,

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -7,7 +7,7 @@
 //     · maxRounds: 轮询 session events 的 turn 计数，超限 agent.cancel
 //     · 取消: 运行 cancel → agent.cancel({kind:'user'}) + handle.dispose()
 //     · 流式进度: agent-progress 事件（turn 序号 / assistant 文本预览）
-//   - 运行历史持久化 data/runs/<runId>.json + 刷新恢复（SSE 快照）
+//   - 工作区 SQLite 运行历史 + 刷新恢复（SSE 快照）
 //   - webhook 触发（/wf1/api/hooks/* prefix 路由）+ 定时触发（wf1:schedule.* 定时键）
 //   - 节点工作区 data/workspaces/<节点名>/；产物下载 /wf1/api/artifact
 //
@@ -54,6 +54,7 @@ import { Orchestrator, lintGraph, getKind } from './engine.js';
 import { createWorkflowExportManifest, importWorkflowDocument, normalizeWorkflowDocument } from './workflow-document.js';
 import { saveArtifactsToWorkspace } from './artifact-save.js';
 import { createStoragePaths } from './storage-paths.js';
+import { WorkflowSqliteStore } from './sqlite-store.js';
 import {
   canvasAssistantPersona, checkPatchResult, summarizeGraphForAI, validateGraphOps,
 } from './assistant.js';
@@ -130,17 +131,18 @@ export function apply(ctx, config) {
   const copyLegacyTree = (source, target) => {
     if (!existsSync(source)) return;
     mkdirSync(dirname(target), { recursive: true, mode: 0o700 });
-    cpSync(source, target, { recursive: true, force: true, errorOnExist: false });
+    cpSync(source, target, { recursive: true, force: false, errorOnExist: false });
   };
   const initializeStore = (workspaceRoot) => {
     const paths = createStoragePaths({ workspaceRoot, legacyRoot: legacyDataDir() });
-    const rootExisted = existsSync(paths.root);
     const marker = join(paths.state, 'legacy-import.json');
-    for (const dir of [paths.root, paths.state, paths.workflows, paths.attachments, paths.runs, paths.runtime, join(paths.state, 'tombstones', 'workflows')]) {
+    const workflowTombstoneDir = join(paths.state, 'tombstones', 'workflows');
+    for (const dir of [paths.root, paths.state, paths.workflows, paths.attachments, paths.runs, paths.runtime, workflowTombstoneDir]) {
       mkdirSync(dir, { recursive: true, mode: 0o700 });
     }
-    if (!legacyClaimedWorkspace && !rootExisted) {
-      for (const legacy of [paths.packageLegacy, paths.pluginDataLegacy]) {
+    if (!legacyClaimedWorkspace && !existsSync(marker)) {
+      // 用户级 plugin-data 优先于包内种子；已有工作区文件两者都不得覆盖。
+      for (const legacy of [paths.pluginDataLegacy, paths.packageLegacy]) {
         copyLegacyTree(legacy.workflows, paths.workflows);
         copyLegacyTree(legacy.attachments, paths.attachments);
         copyLegacyTree(legacy.runs, paths.runs);
@@ -159,9 +161,15 @@ export function apply(ctx, config) {
       graphFile: join(paths.state, 'graph.json'),
       triggersFile: join(paths.state, 'triggers.json'),
       globalVariablesFile: join(paths.state, 'global-variables.json'),
-      workflowTombstoneDir: join(paths.state, 'tombstones', 'workflows'),
-      runHistory: [],
-      historyHydrated: false,
+      workflowTombstoneDir,
+      database: new WorkflowSqliteStore({
+        databaseFile: paths.database,
+        workflowsDir: paths.workflows,
+        runsDir: paths.runs,
+        workflowTombstoneDir,
+        migrationErrorFile: join(paths.state, 'sqlite-migration-errors.json'),
+        logger: ctx.logger,
+      }),
       globalVariableStore: new GlobalVariableStore(join(paths.state, 'global-variables.json')),
       hooks: new Map(),
       schedulers: new Map(),
@@ -182,14 +190,6 @@ export function apply(ctx, config) {
     return store;
   };
   const STORAGE = new Proxy({}, { get(_target, key) { return currentStore().paths[key]; } });
-  const runHistory = new Proxy([], {
-    get(_target, key) {
-      const rows = currentStore().runHistory;
-      const value = rows[key];
-      return typeof value === 'function' ? value.bind(rows) : value;
-    },
-    set(_target, key, value) { currentStore().runHistory[key] = value; return true; },
-  });
   const globalVariableStore = new Proxy({}, {
     get(_target, key) {
       const store = currentStore().globalVariableStore;
@@ -198,10 +198,14 @@ export function apply(ctx, config) {
     },
   });
   const currentPaths = () => currentStore().paths;
-  const currentRunHistory = () => currentStore().runHistory;
+  const currentDatabase = () => currentStore().database;
   const currentHooks = () => currentStore().hooks;
   const currentSchedulers = () => currentStore().schedulers;
   const currentSchedulerMeta = () => currentStore().schedulerMeta;
+  ctx.effect?.(() => () => {
+    for (const store of stores.values()) store.database.close();
+    stores.clear();
+  }, 'workflow-one sqlite stores');
   const registeredWorkspaceRoots = () => {
     try {
       const registry = ctx.workspaceRegistry || ctx.get?.('workspaceRegistry');
@@ -256,30 +260,38 @@ export function apply(ctx, config) {
     return sessionStore(sessionId);
   };
   let ensureTriggers = () => {};
+  const internalRouteError = (res, error) => {
+    if (res.writableEnded) return undefined;
+    if (error instanceof RequestBodyError) {
+      return json(res, Number(error.status) || 500, {
+        error: String(error.message || error),
+        code: error.code || 'request-failed',
+      });
+    }
+    ctx.logger?.error?.(`Workflow One 请求失败：${error.stack || error.message || error}`);
+    return json(res, 500, { error: 'Workflow One 内部错误', code: 'internal-error' });
+  };
   const register = (route, { scoped = true } = {}) => {
     const handler = route.handler;
     ctx.webServer.register({
       ...route,
       handler(req, res) {
         if (!scoped) return handler(req, res);
+        let store;
+        try { store = requestStore(req); }
+        catch (error) {
+          return json(res, 409, { error: String(error.message || error), code: 'workspace-session-required' });
+        }
         try {
-          const result = workspaceContext.run(requestStore(req), () => {
-            hydrateHistory();
+          const result = workspaceContext.run(store, () => {
             ensureTriggers();
             return handler(req, res);
           });
           return result && typeof result.catch === 'function'
-            ? result.catch((error) => {
-                if (!(error instanceof RequestBodyError)) throw error;
-                if (res.writableEnded) return undefined;
-                return json(res, Number(error?.status) || 500, {
-                  error: String(error?.message || error),
-                  code: error?.code || 'request-failed',
-                });
-              })
+            ? result.catch((error) => internalRouteError(res, error))
             : result;
         } catch (error) {
-          return json(res, 409, { error: String(error.message || error), code: 'workspace-session-required' });
+          return internalRouteError(res, error);
         }
       },
     });
@@ -428,7 +440,7 @@ export function apply(ctx, config) {
             outputs: summarizeOutputs(run.outputs, run.structuredOutputs),
           });
         }
-        const hist = runHistory.find((r) => r.runId === args.runId);
+        const hist = readRun(args.runId);
         if (!hist) return `运行 "${args.runId}" 不存在`;
         return JSON.stringify({
           status: hist.status,
@@ -463,10 +475,7 @@ export function apply(ctx, config) {
         const canvasId = resolveCanvasId(exec);
         if (!sid || !canvasId) return '此工具只在绑定了工作流画布的会话里可用（在画布「工作流」标签页发起对话）。';
         try {
-          return await workspaceContext.run(sessionStore(String(sid)), () => {
-            hydrateHistory();
-            return def.execute(args, { ...exec, canvasId });
-          });
+          return await workspaceContext.run(sessionStore(String(sid)), () => def.execute(args, { ...exec, canvasId }));
         } catch (error) {
           return `工作区不可用：${String(error.message || error)}`;
         }
@@ -497,30 +506,6 @@ export function apply(ctx, config) {
       ...(recoveredStatus === 'interrupted' ? { error: run.error || '运行进程异常终止' } : {}),
     });
   };
-  const hydrateHistory = () => {
-    const store = currentStore();
-    if (store.historyHydrated) return;
-    store.historyHydrated = true;
-    const byId = new Map();
-    for (const dir of [store.paths.runs]) {
-      try {
-        for (const file of readdirSync(dir).filter((name) => name.endsWith('.json'))) {
-          try {
-            const runFile = join(dir, file);
-            let run = normalizeRunDocument(JSON.parse(readFileSync(runFile, 'utf8')));
-            if (run.status === 'running') {
-              const interruptedAt = statSync(runFile).mtime.toISOString();
-              run = recoverInterruptedRun(run, interruptedAt);
-              atomicJson(runFile, run);
-            }
-            if (!byId.has(run.runId)) byId.set(run.runId, run);
-          } catch { /* 单条损坏不阻塞其他历史 */ }
-        }
-      } catch { /* 目录空 */ }
-    }
-    const rows = [...byId.values()].sort((a, b) => (b.startedAt || '').localeCompare(a.startedAt || ''));
-    store.runHistory.push(...rows.slice(0, 50));
-  };
   const persistRun = (run, graph, workflowName, workflowId) => {
     try {
       const light = { ...run, _resolved: true };
@@ -547,12 +532,7 @@ export function apply(ctx, config) {
         artifactIndex: snapshot.artifacts,
         issues: [...(Array.isArray(base.issues) ? base.issues : []), ...snapshot.issues],
       });
-      atomicJson(join(currentPaths().runs, `${safeFileId(run.runId, 'invalid')}.json`), document);
-      const historyRun = { ...document, graph: graphSnapshot };
-      const history = currentRunHistory();
-      const idx = history.findIndex((r) => r.runId === run.runId);
-      if (idx >= 0) history[idx] = historyRun;
-      else history.unshift(historyRun);
+      currentDatabase().putRun(document);
       pruneRuns();
       broadcast('run-results-ready', {
         runId: document.runId,
@@ -567,24 +547,19 @@ export function apply(ctx, config) {
       return null;
     }
   };
-  // 保留策略：超过 RUNS_KEEP 的旧运行文件删除（内存列表同步裁剪）
+  // 保留策略：SQLite 提交删除后，再清理对应运行产物目录。
   const pruneRuns = () => {
     try {
-      const runsDir = currentPaths().runs;
-      const history = currentRunHistory();
-      const files = readdirSync(runsDir)
-        .filter((f) => f.endsWith('.json'))
-        .map((f) => ({ f, t: statSync(join(runsDir, f)).mtimeMs }))
-        .sort((a, b) => b.t - a.t);
-      for (const { f } of files.slice(RUNS_KEEP)) {
+      for (const run of currentDatabase().pruneRuns(RUNS_KEEP)) {
         try {
-          const run = normalizeRunDocument(JSON.parse(readFileSync(join(runsDir, f), 'utf8')));
           rmSync(STORAGE.runRoot({ workflowId: run.workflowId || 'draft', runId: run.runId }), { recursive: true, force: true });
-        } catch { /* 单条记录损坏或并发删除 */ }
-        try { unlinkSync(join(runsDir, f)); } catch { /* 并发删除 */ }
+        } catch (error) {
+          ctx.logger?.warn?.(`运行 ${run.runId} 已过期，但 runtime 清理失败：${error.message}`);
+        }
       }
-      if (history.length > RUNS_KEEP) history.length = RUNS_KEEP;
-    } catch { /* 目录不可读 */ }
+    } catch (error) {
+      ctx.logger?.warn?.(`运行记录清理失败：${error.message}`);
+    }
   };
   let orch;
   const readRun = (runId) => {
@@ -597,29 +572,22 @@ export function apply(ctx, config) {
       };
       return normalizeRunDocument({ ...run, graph });
     }
-    const filename = `${safeFileId(runId, 'invalid')}.json`;
-    for (const dir of [currentPaths().runs]) {
-      try {
-        const runFile = join(dir, filename);
-        let run = normalizeRunDocument(JSON.parse(readFileSync(runFile, 'utf8')));
-        if (run.status === 'running' && !pendingRunIds.has(runId)) {
-          run = recoverInterruptedRun(run, statSync(runFile).mtime.toISOString());
-          writeRun(run);
-        }
-        return run;
-      } catch { /* 回退下一位置 */ }
+    const record = currentDatabase().getRunRecord(runId);
+    if (!record) return null;
+    let run = record.document;
+    if (run.status === 'running' && !pendingRunIds.has(runId)) {
+      run = recoverInterruptedRun(run, record.updatedAt || new Date().toISOString());
+      writeRun(run);
     }
-    return null;
+    return run;
   };
   const writeRun = (run) => {
     const document = normalizeRunDocument(run);
-    atomicJson(join(currentPaths().runs, `${safeFileId(document.runId, 'invalid')}.json`), document);
-    const history = currentRunHistory();
-    const idx = history.findIndex((row) => row.runId === document.runId);
-    if (idx >= 0) history[idx] = document;
-    else history.unshift(document);
-    return document;
+    return currentDatabase().putRun(document);
   };
+  const recentRuns = (limit = 50) => currentDatabase().listRuns(limit).map((run) => (
+    run.status === 'running' && !pendingRunIds.has(run.runId) ? (readRun(run.runId) || run) : run
+  ));
   const checkpointRun = (runId) => {
     const live = orch?.runs.get(runId);
     if (!live || live.run.workspaceRoot !== currentStore().workspaceRoot) return;
@@ -639,20 +607,17 @@ export function apply(ctx, config) {
   };
 
   // ---- 工作流库 ----
-  const wfFile = (id, dir = currentPaths().workflows) => join(dir, `${safeFileId(id, 'invalid')}.json`);
   const wfTombstone = (id) => join(currentStore().workflowTombstoneDir, safeFileId(id, 'invalid'));
-  const readWf = (id) => {
-    if (existsSync(wfTombstone(id))) return null;
-    for (const dir of [currentPaths().workflows]) {
-      try { return normalizeWorkflowDocument(JSON.parse(readFileSync(wfFile(id, dir), 'utf8'))); } catch { /* 回退下一位置 */ }
-    }
-    return null;
-  };
+  const readWf = (id) => currentDatabase().getWorkflow(id);
   const writeWf = (wf) => {
-    const document = normalizeWorkflowDocument(wf);
-    atomicJson(wfFile(document.id), document);
+    const document = currentDatabase().putWorkflow(wf);
     try { unlinkSync(wfTombstone(document.id)); } catch { /* 未删除过 */ }
     return document;
+  };
+  const deleteWf = (id) => {
+    if (!currentDatabase().deleteWorkflow(id)) return false;
+    atomicWrite(wfTombstone(id), new Date().toISOString());
+    return true;
   };
 
   const resolveAttachmentFile = (attachment) => {
@@ -1050,7 +1015,7 @@ export function apply(ctx, config) {
     let runInputs; try { runInputs = assertSafeContextObject(body?.runInputs ?? body?.inputs, 'runInputs'); } catch (error) { return routeError(res, error); }
     const url = new URL(req.url, 'http://x');
     const runId = url.searchParams.get('run') || body?.runId;
-    const selected = selectScopedRun({ runId, workflowId: body?.workflowId, graph: body?.graph }, { readRun, runs: runHistory });
+    const selected = selectScopedRun({ runId, workflowId: body?.workflowId, graph: body?.graph }, { readRun, runs: recentRuns(50) });
     const hasInlineValues = body?.outputs || body?.structuredOutputs || body?.triggerInput !== undefined;
     if (selected.error && !hasInlineValues) return json(res, selected.status || 404, { ok: false, error: selected.error });
     const selectedRun = selected.run || {};
@@ -1121,7 +1086,7 @@ export function apply(ctx, config) {
     let inlineRunInputs; try { inlineRunInputs = assertSafeContextObject(body?.runInputs ?? body?.inputs, 'runInputs'); } catch (error) { return routeError(res, error); }
     const graph = body?.graph || persistedWorkflow?.graph || { nodes: body?.nodes || [], edges: body?.edges || [] };
     const targetNodeId = body?.targetNodeId || body?.nodeId;
-    const selected = selectScopedRun({ runId: body?.runId, workflowId: body?.workflowId, graph: body?.graph }, { readRun, runs: runHistory });
+    const selected = selectScopedRun({ runId: body?.runId, workflowId: body?.workflowId, graph: body?.graph }, { readRun, runs: recentRuns(50) });
     const hasInlineValues = body?.outputs || body?.structuredOutputs || body?.triggerInput !== undefined;
     if (selected.error && !hasInlineValues) return json(res, selected.status || 404, { error: selected.error });
     const selectedRun = selected.run || {};
@@ -1159,21 +1124,7 @@ export function apply(ctx, config) {
   // ---- 工作流库 ----
   register({ kind: 'exact', path: '/wf1/api/workflows', async handler(req, res) {
     if (req.method === 'GET') {
-      const ids = new Set();
-      for (const dir of [currentPaths().workflows]) {
-        try { for (const file of readdirSync(dir).filter((name) => name.endsWith('.json'))) ids.add(file.replace(/\.json$/, '')); }
-        catch { /* 目录空 */ }
-      }
-      const list = [...ids].map((id) => {
-        const wf = readWf(id);
-        if (!wf) return null;
-        return {
-          id: wf.id, name: wf.name, updatedAt: wf.updatedAt,
-          nodeCount: wf.graph?.nodes?.length ?? 0,
-          agentCount: wf.graph?.nodes?.filter((n) => n.type === 'agent').length ?? 0,
-        };
-      }).filter(Boolean).sort((a, b) => (b.updatedAt || '').localeCompare(a.updatedAt || ''));
-      return json(res, 200, { workflows: list });
+      return json(res, 200, { workflows: currentDatabase().listWorkflows() });
     }
     if (req.method === 'POST') {
       const body = await readBody(req);
@@ -1235,8 +1186,7 @@ export function apply(ctx, config) {
     }
     if (req.method === 'DELETE') {
       if (!readWf(id)) return json(res, 404, { error: '工作流不存在' });
-      try { unlinkSync(wfFile(id)); } catch { /* 可能仅存在旧目录 */ }
-      atomicWrite(wfTombstone(id), new Date().toISOString());
+      deleteWf(id);
       return json(res, 200, { ok: true });
     }
     if (req.method === 'PATCH') {
@@ -1460,9 +1410,7 @@ export function apply(ctx, config) {
       && Object.values(r.nodeStates || {}).some((st) => st?.status === 'success')
       && r.graph.nodes.some((node) => !['success', 'skipped'].includes(r.nodeStates?.[node.id]?.status));
     json(res, 200, {
-      runs: runHistory.slice(0, 20).map((row) => (
-        row.status === 'running' && !live.includes(row.runId) ? (readRun(row.runId) || row) : row
-      )).map((r) => {
+      runs: recentRuns(20).map((r) => {
         const { structuredOutputs, graph, ...summary } = r;
         const isLive = live.includes(r.runId);
         return {
@@ -1582,7 +1530,7 @@ export function apply(ctx, config) {
     const runId = url.searchParams.get('run') || '';
     const nodeId = url.searchParams.get('node') || '';
     if (!runId || !nodeId) return json(res, 400, { error: '缺少 run 和 node' });
-    const run = readRun(runId) || runHistory.find((r) => r.runId === runId);
+    const run = readRun(runId);
     if (!run) return json(res, 404, { error: '运行记录不存在' });
     const state = run.nodeStates?.[nodeId];
     const label = (run.graph?.nodes || []).find((n) => n.id === nodeId)?.data?.label || nodeId;
@@ -1736,7 +1684,7 @@ export function apply(ctx, config) {
   // 刷新恢复快照：进行中运行的最新状态（供页面加载时补齐 SSE 错过的事件）
   register({ kind: 'exact', path: '/wf1/api/state', handler(_req, res) {
     const runningIds = [...orch.runs.values()].filter((entry) => entry.run.workspaceRoot === currentStore().workspaceRoot).map((entry) => entry.run.runId);
-    const latest = runHistory[0];
+    const latest = recentRuns(1)[0];
     const lastRun = latest ? (() => {
       const { structuredOutputs, graph, ...summary } = latest;
       return { ...summary, outputs: summarizeOutputs(summary.outputs, structuredOutputs), nodeStates: summarizeNodeStates(summary.nodeStates), structuredOutputSummary: summarizeStructuredOutputs(structuredOutputs) };
@@ -2161,7 +2109,6 @@ export function apply(ctx, config) {
   for (const workspaceRoot of registeredWorkspaceRoots()) {
     const store = storeForWorkspace(workspaceRoot);
     workspaceContext.run(store, () => {
-      hydrateHistory();
       ensureTriggers();
     });
   }

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/sqlite-store.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/sqlite-store.js
@@ -124,6 +124,10 @@ export class WorkflowSqliteStore {
       }
     }
 
+    if (migrationErrorFile && errors.length) {
+      atomicJson(migrationErrorFile, { version: 1, migratedAt: new Date().toISOString(), errors });
+    }
+
     this.db.exec('BEGIN IMMEDIATE');
     try {
       this.db.exec(SCHEMA);
@@ -151,12 +155,11 @@ export class WorkflowSqliteStore {
       throw error;
     }
 
-    if (migrationErrorFile) {
+    if (migrationErrorFile && !errors.length) {
       try {
-        if (errors.length) atomicJson(migrationErrorFile, { version: 1, migratedAt: new Date().toISOString(), errors });
-        else unlinkSync(migrationErrorFile);
+        unlinkSync(migrationErrorFile);
       } catch (error) {
-        if (errors.length || error?.code !== 'ENOENT') this.logger?.warn?.(`SQLite 迁移报告写入失败：${error.message}`);
+        if (error?.code !== 'ENOENT') this.logger?.warn?.(`SQLite 迁移报告清理失败：${error.message}`);
       }
     }
     for (const error of errors) this.logger?.warn?.(`SQLite 跳过损坏的 ${error.kind} JSON：${error.file}（${error.error}）`);

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/sqlite-store.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/sqlite-store.js
@@ -1,0 +1,286 @@
+import { DatabaseSync } from 'node:sqlite';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { normalizeRunDocument } from './run-results.js';
+import { normalizeWorkflowDocument } from './workflow-document.js';
+
+const SCHEMA_VERSION = 1;
+
+const SCHEMA = `
+  CREATE TABLE IF NOT EXISTS workflows (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    node_count INTEGER NOT NULL,
+    agent_count INTEGER NOT NULL,
+    document_json TEXT NOT NULL CHECK (json_valid(document_json))
+  ) STRICT;
+  CREATE INDEX IF NOT EXISTS workflows_updated_at ON workflows(updated_at DESC);
+
+  CREATE TABLE IF NOT EXISTS runs (
+    run_id TEXT PRIMARY KEY,
+    workflow_id TEXT,
+    status TEXT NOT NULL,
+    started_at TEXT,
+    finished_at TEXT,
+    updated_at TEXT NOT NULL,
+    document_json TEXT NOT NULL CHECK (json_valid(document_json))
+  ) STRICT;
+  CREATE INDEX IF NOT EXISTS runs_started_at ON runs(started_at DESC);
+  CREATE INDEX IF NOT EXISTS runs_workflow_started_at ON runs(workflow_id, started_at DESC);
+`;
+
+const jsonFiles = (dir) => {
+  try { return readdirSync(dir).filter((name) => name.endsWith('.json')).sort(); }
+  catch { return []; }
+};
+
+const atomicJson = (file, value) => {
+  mkdirSync(dirname(file), { recursive: true, mode: 0o700 });
+  const tmp = `${file}.tmp-${process.pid}-${Date.now().toString(36)}`;
+  writeFileSync(tmp, JSON.stringify(value, null, 2), { mode: 0o600 });
+  renameSync(tmp, file);
+};
+
+const parseDocument = (row, normalize) => normalize(JSON.parse(row.document_json));
+
+export class WorkflowSqliteStore {
+  constructor({ databaseFile, workflowsDir, runsDir, workflowTombstoneDir, migrationErrorFile, logger } = {}) {
+    if (!databaseFile) throw new Error('缺少 SQLite 数据库路径');
+    mkdirSync(dirname(databaseFile), { recursive: true, mode: 0o700 });
+    chmodSync(dirname(databaseFile), 0o700);
+    this.databaseFile = databaseFile;
+    this.logger = logger;
+    this.db = new DatabaseSync(databaseFile);
+    this.closed = false;
+    try {
+      chmodSync(databaseFile, 0o600);
+      this.db.exec('PRAGMA busy_timeout = 5000; PRAGMA synchronous = FULL; PRAGMA auto_vacuum = INCREMENTAL;');
+      this.#configureJournal();
+      this.#migrate({ workflowsDir, runsDir, workflowTombstoneDir, migrationErrorFile });
+      this.#prepare();
+    } catch (error) {
+      try { this.db.close(); } catch { /* initialization failed before close */ }
+      this.closed = true;
+      throw error;
+    }
+  }
+
+  #configureJournal() {
+    try {
+      const mode = String(this.db.prepare('PRAGMA journal_mode = WAL').get()?.journal_mode || '').toLowerCase();
+      if (mode === 'wal') return;
+      this.logger?.warn?.(`Workflow One SQLite 未启用 WAL（实际为 ${mode || 'unknown'}），回退 DELETE journal`);
+    } catch (error) {
+      this.logger?.warn?.(`Workflow One SQLite 启用 WAL 失败，回退 DELETE journal：${error.message}`);
+    }
+    this.db.exec('PRAGMA journal_mode = DELETE');
+  }
+
+  #migrate({ workflowsDir, runsDir, workflowTombstoneDir, migrationErrorFile }) {
+    const version = Number(this.db.prepare('PRAGMA user_version').get()?.user_version || 0);
+    if (version > SCHEMA_VERSION) throw new Error(`不支持的 Workflow One SQLite schema：${version}`);
+    if (version === SCHEMA_VERSION) return;
+
+    const workflows = [];
+    const runs = [];
+    const errors = [];
+    for (const name of jsonFiles(workflowsDir)) {
+      const file = join(workflowsDir, name);
+      const id = basename(name, '.json');
+      if (workflowTombstoneDir && existsSync(join(workflowTombstoneDir, id))) continue;
+      try {
+        const raw = JSON.parse(readFileSync(file, 'utf8'));
+        if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('工作流文档必须是对象');
+        const updatedAt = raw.updatedAt || statSync(file).mtime.toISOString();
+        const document = normalizeWorkflowDocument({ ...raw, id: raw.id || id, name: raw.name || id, updatedAt });
+        if (!document.id || !document.name || !document.updatedAt) throw new Error('缺少 id、name 或 updatedAt');
+        workflows.push(document);
+      } catch (error) {
+        errors.push({ kind: 'workflow', file, error: String(error.message || error) });
+      }
+    }
+    for (const name of jsonFiles(runsDir)) {
+      const file = join(runsDir, name);
+      const runId = basename(name, '.json');
+      try {
+        const raw = JSON.parse(readFileSync(file, 'utf8'));
+        if (!raw || typeof raw !== 'object' || Array.isArray(raw)) throw new Error('运行文档必须是对象');
+        const document = normalizeRunDocument({ ...raw, runId: raw.runId || runId });
+        if (!document.runId || !document.status) throw new Error('缺少 runId 或 status');
+        runs.push({ document, updatedAt: statSync(file).mtime.toISOString() });
+      } catch (error) {
+        errors.push({ kind: 'run', file, error: String(error.message || error) });
+      }
+    }
+
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      this.db.exec(SCHEMA);
+      const putWorkflow = this.db.prepare(`
+        INSERT INTO workflows (id, name, updated_at, node_count, agent_count, document_json)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          name=excluded.name, updated_at=excluded.updated_at,
+          node_count=excluded.node_count, agent_count=excluded.agent_count,
+          document_json=excluded.document_json
+      `);
+      const putRun = this.db.prepare(`
+        INSERT INTO runs (run_id, workflow_id, status, started_at, finished_at, updated_at, document_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(run_id) DO UPDATE SET
+          workflow_id=excluded.workflow_id, status=excluded.status,
+          started_at=excluded.started_at, finished_at=excluded.finished_at,
+          updated_at=excluded.updated_at, document_json=excluded.document_json
+      `);
+      for (const document of workflows) this.#runWorkflowStatement(putWorkflow, document);
+      for (const row of runs) this.#runRunStatement(putRun, row.document, row.updatedAt);
+      this.db.exec(`PRAGMA user_version = ${SCHEMA_VERSION}; COMMIT;`);
+    } catch (error) {
+      try { this.db.exec('ROLLBACK'); } catch { /* transaction already closed */ }
+      throw error;
+    }
+
+    if (migrationErrorFile) {
+      try {
+        if (errors.length) atomicJson(migrationErrorFile, { version: 1, migratedAt: new Date().toISOString(), errors });
+        else unlinkSync(migrationErrorFile);
+      } catch (error) {
+        if (errors.length || error?.code !== 'ENOENT') this.logger?.warn?.(`SQLite 迁移报告写入失败：${error.message}`);
+      }
+    }
+    for (const error of errors) this.logger?.warn?.(`SQLite 跳过损坏的 ${error.kind} JSON：${error.file}（${error.error}）`);
+  }
+
+  #prepare() {
+    this.statements = {
+      getWorkflow: this.db.prepare('SELECT document_json FROM workflows WHERE id = ?'),
+      listWorkflows: this.db.prepare('SELECT id, name, updated_at, node_count, agent_count FROM workflows ORDER BY updated_at DESC, id ASC'),
+      putWorkflow: this.db.prepare(`
+        INSERT INTO workflows (id, name, updated_at, node_count, agent_count, document_json)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          name=excluded.name, updated_at=excluded.updated_at,
+          node_count=excluded.node_count, agent_count=excluded.agent_count,
+          document_json=excluded.document_json
+      `),
+      deleteWorkflow: this.db.prepare('DELETE FROM workflows WHERE id = ?'),
+      getRun: this.db.prepare('SELECT updated_at, document_json FROM runs WHERE run_id = ?'),
+      listRuns: this.db.prepare('SELECT document_json FROM runs ORDER BY started_at DESC, run_id DESC LIMIT ?'),
+      putRun: this.db.prepare(`
+        INSERT INTO runs (run_id, workflow_id, status, started_at, finished_at, updated_at, document_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(run_id) DO UPDATE SET
+          workflow_id=excluded.workflow_id, status=excluded.status,
+          started_at=excluded.started_at, finished_at=excluded.finished_at,
+          updated_at=excluded.updated_at, document_json=excluded.document_json
+      `),
+      staleRuns: this.db.prepare('SELECT run_id, workflow_id FROM runs ORDER BY started_at DESC, run_id DESC LIMIT -1 OFFSET ?'),
+      deleteRun: this.db.prepare('DELETE FROM runs WHERE run_id = ?'),
+    };
+  }
+
+  #runWorkflowStatement(statement, value) {
+    const document = normalizeWorkflowDocument(value);
+    if (!document.id || !document.name || !document.updatedAt) throw new Error('工作流缺少 id、name 或 updatedAt');
+    const nodes = Array.isArray(document.graph?.nodes) ? document.graph.nodes : [];
+    statement.run(
+      document.id,
+      document.name,
+      document.updatedAt,
+      nodes.length,
+      nodes.filter((node) => node.type === 'agent').length,
+      JSON.stringify(document),
+    );
+    return document;
+  }
+
+  #runRunStatement(statement, value, updatedAt = new Date().toISOString()) {
+    const document = normalizeRunDocument(value);
+    if (!document.runId || !document.status) throw new Error('运行记录缺少 runId 或 status');
+    statement.run(
+      document.runId,
+      document.workflowId || null,
+      document.status,
+      document.startedAt,
+      document.finishedAt,
+      updatedAt,
+      JSON.stringify(document),
+    );
+    return document;
+  }
+
+  getWorkflow(id) {
+    const row = this.statements.getWorkflow.get(String(id));
+    return row ? parseDocument(row, normalizeWorkflowDocument) : null;
+  }
+
+  listWorkflows() {
+    return this.statements.listWorkflows.all().map((row) => ({
+      id: row.id,
+      name: row.name,
+      updatedAt: row.updated_at,
+      nodeCount: row.node_count,
+      agentCount: row.agent_count,
+    }));
+  }
+
+  putWorkflow(value) {
+    return this.#runWorkflowStatement(this.statements.putWorkflow, value);
+  }
+
+  deleteWorkflow(id) {
+    return Number(this.statements.deleteWorkflow.run(String(id)).changes) > 0;
+  }
+
+  getRun(id) {
+    return this.getRunRecord(id)?.document || null;
+  }
+
+  getRunRecord(id) {
+    const row = this.statements.getRun.get(String(id));
+    return row ? { document: parseDocument(row, normalizeRunDocument), updatedAt: row.updated_at } : null;
+  }
+
+  listRuns(limit = 50) {
+    const count = Math.max(0, Math.floor(Number(limit) || 0));
+    return this.statements.listRuns.all(count).map((row) => parseDocument(row, normalizeRunDocument));
+  }
+
+  putRun(value) {
+    return this.#runRunStatement(this.statements.putRun, value);
+  }
+
+  pruneRuns(keep) {
+    const count = Math.max(0, Math.floor(Number(keep) || 0));
+    const stale = this.statements.staleRuns.all(count).map((row) => ({ runId: row.run_id, workflowId: row.workflow_id }));
+    if (!stale.length) return stale;
+    this.db.exec('BEGIN IMMEDIATE');
+    try {
+      for (const row of stale) this.statements.deleteRun.run(row.runId);
+      this.db.exec('COMMIT');
+    } catch (error) {
+      try { this.db.exec('ROLLBACK'); } catch { /* transaction already closed */ }
+      throw error;
+    }
+    try { this.db.exec('PRAGMA incremental_vacuum(1000)'); } catch { /* 回收失败不影响已提交删除 */ }
+    return stale;
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    try { this.db.exec('PRAGMA wal_checkpoint(TRUNCATE)'); } catch { /* DELETE journal 或已关闭 */ }
+    this.db.close();
+  }
+}

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/storage-paths.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/storage-paths.js
@@ -55,6 +55,7 @@ export function createStoragePaths({
   const attachments = join(root, 'attachments');
   const runs = join(root, 'runs');
   const runtime = join(root, 'runtime');
+  const database = join(root, 'workflow-one.sqlite');
   const resolvedDshHome = absoluteDirectory(dshHome, 'dshHome');
   const pluginDataLegacy = legacyLayout(join(resolvedDshHome, 'plugin-data', PLUGIN_NAME), 'plugin-data');
   const packageLegacy = legacyLayout(absoluteDirectory(legacyRoot, 'legacyRoot'), 'package-data');
@@ -81,6 +82,8 @@ export function createStoragePaths({
     attachmentsDir: attachments,
     runs,
     runsDir: runs,
+    database,
+    databaseFile: database,
     runtime,
     runtimeDir: runtime,
     artifactRoot: runtime,

--- a/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
@@ -14,7 +14,7 @@
         "quickjs-emscripten": "0.32.0"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=24.15"
       },
       "peerDependencies": {
         "@deepseek-ai/dsh-llm": "*",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -12,7 +12,7 @@
     "directory": "dsh-plugins/dsh-ccpg-orchestrator"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=24.15"
   },
   "peerDependencies": {
     "@deepseek-ai/dsh-llm": "*",

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/plugin-storage.integration.test.mjs
@@ -1,8 +1,9 @@
 import assert from 'node:assert/strict';
 import { EventEmitter } from 'node:events';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
 import { apply } from '../lib/index.js';
 import { graphFingerprint } from '../lib/run-scope.js';
 
@@ -45,6 +46,34 @@ function request(method, url, body, splitAt) {
 }
 
 const withSession = (url, sessionId) => `${url}${url.includes('?') ? '&' : '?'}sessionId=${sessionId}`;
+const databaseFile = (workspace) => join(workspace, '.workflow-one', 'workflow-one.sqlite');
+const readStoredDocument = (workspace, table, key, id) => {
+  if (!existsSync(databaseFile(workspace))) return null;
+  const db = new DatabaseSync(databaseFile(workspace), { readOnly: true });
+  try {
+    const row = db.prepare(`SELECT document_json FROM ${table} WHERE ${key} = ?`).get(id);
+    return row ? JSON.parse(row.document_json) : null;
+  } finally {
+    db.close();
+  }
+};
+const readStoredRun = (workspace, runId) => readStoredDocument(workspace, 'runs', 'run_id', runId);
+const readStoredWorkflow = (workspace, workflowId) => readStoredDocument(workspace, 'workflows', 'id', workflowId);
+const seedStoredRun = (workspace, value, updatedAt = new Date().toISOString()) => {
+  const db = new DatabaseSync(databaseFile(workspace));
+  try {
+    db.prepare(`
+      INSERT INTO runs (run_id, workflow_id, status, started_at, finished_at, updated_at, document_json)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+      ON CONFLICT(run_id) DO UPDATE SET
+        workflow_id=excluded.workflow_id, status=excluded.status,
+        started_at=excluded.started_at, finished_at=excluded.finished_at,
+        updated_at=excluded.updated_at, document_json=excluded.document_json
+    `).run(value.runId, value.workflowId || null, value.status, value.startedAt || null, value.finishedAt || null, updatedAt, JSON.stringify(value));
+  } finally {
+    db.close();
+  }
+};
 const dshHome = mkdtempSync(join(tmpdir(), 'wf1-plugin-home-'));
 const workspacesRoot = mkdtempSync(join(tmpdir(), 'wf1-workspaces-'));
 const workspaceA = join(workspacesRoot, 'workspace-a');
@@ -94,6 +123,7 @@ const seedLegacy = () => {
   writeFileSync(join(legacyDataDir, 'state', 'graph.json'), JSON.stringify({ nodes: [], edges: [] }));
 };
 seedLegacy();
+const disposers = [];
 
 try {
   const routes = [];
@@ -114,6 +144,7 @@ try {
     llm: { listProviders() { return []; }, async listModels() { return []; } },
     agentPresets: { async mount() {} },
     logger: { info() {}, warn() {}, error() {} },
+    effect(setup) { const dispose = setup(); if (dispose) disposers.push(dispose); },
   };
   apply(ctx, {});
   const route = (path) => routes.find((entry) => entry.kind === 'exact' && entry.path === path)?.handler;
@@ -147,8 +178,9 @@ try {
     id: 'wf_only_a', name: '仅 A', graph: { nodes: [], edges: [] },
   }), createA);
   assert.equal(createA.status, 200);
-  assert.equal(existsSync(join(workspaceA, '.workflow-one', 'workflows', 'wf_only_a.json')), true);
-  assert.equal(existsSync(join(workspaceB, '.workflow-one', 'workflows', 'wf_only_a.json')), false);
+  assert.equal(readStoredWorkflow(workspaceA, 'wf_only_a')?.name, '仅 A');
+  assert.equal(readStoredWorkflow(workspaceB, 'wf_only_a'), null);
+  assert.equal(existsSync(join(workspaceA, '.workflow-one', 'workflows', 'wf_only_a.json')), false, '新工作流不得双写 JSON');
 
   const utf8Workflow = {
     id: 'wf_utf8', name: '中文分块',
@@ -159,8 +191,14 @@ try {
   const utf8Create = responseCapture();
   await route('/wf1/api/workflows')(request('POST', withSession('/wf1/api/workflows', 'session-b'), utf8Workflow, utf8Split), utf8Create);
   assert.equal(utf8Create.status, 200);
-  const utf8Saved = JSON.parse(readFileSync(join(workspaceB, '.workflow-one', 'workflows', 'wf_utf8.json'), 'utf8'));
+  const utf8Saved = readStoredWorkflow(workspaceB, 'wf_utf8');
   assert.equal(utf8Saved.graph.nodes[0].data.text, '审核对象');
+
+  const deleteUtf8 = responseCapture();
+  await route('/wf1/api/workflows/detail')(request('DELETE', withSession('/wf1/api/workflows/detail?id=wf_utf8', 'session-b')), deleteUtf8);
+  assert.equal(deleteUtf8.status, 200);
+  assert.equal(readStoredWorkflow(workspaceB, 'wf_utf8'), null);
+  assert.equal(existsSync(join(workspaceB, '.workflow-one', 'state', 'tombstones', 'workflows', 'wf_utf8')), true);
 
   const runRes = responseCapture();
   await route('/wf1/api/run')(request('POST', withSession('/wf1/api/run', 'session-b'), {
@@ -173,17 +211,16 @@ try {
   assert.equal(runRes.status, 200);
   const newRunId = runRes.json().runId;
   let storedRun;
-  const runsDirB = join(workspaceB, '.workflow-one', 'runs');
-  // startRun 即落盘 running 快照（成果面板运行中可读），这里等运行完结状态（success/error/canceled）
+  // startRun 即写入 running 快照（成果面板运行中可读），这里等运行完结状态（success/error/canceled）
   for (let attempt = 0; attempt < 30; attempt += 1) {
-    const files = existsSync(runsDirB) ? readdirSync(runsDirB).filter((file) => file.endsWith('.json')) : [];
-    storedRun = files.map((file) => JSON.parse(readFileSync(join(runsDirB, file), 'utf8'))).find((run) => run.runId === newRunId);
+    storedRun = readStoredRun(workspaceB, newRunId);
     if (storedRun && storedRun.status !== 'running') break;
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
   assert.equal(storedRun?.status, 'success');
   assert.equal(storedRun?.workspaceRoot, undefined);
-  assert.equal(existsSync(join(workspaceA, '.workflow-one', 'runs', `${newRunId}.json`)), false);
+  assert.equal(readStoredRun(workspaceA, newRunId), null);
+  assert.equal(existsSync(join(workspaceB, '.workflow-one', 'runs', `${newRunId}.json`)), false, '新运行不得双写 JSON');
   assert.equal(existsSync(join(dshHome, 'plugin-data', 'dsh-ccpg-orchestrator', 'runs', `${newRunId}.json`)), false);
 
   const originalFetch = globalThis.fetch;
@@ -226,7 +263,7 @@ try {
     assert.equal(liveDetail.nodeStates.live_output, undefined);
     assert.equal(liveDetail.workspaceRoot, undefined);
 
-    const liveCheckpoint = JSON.parse(readFileSync(join(runsDirB, `${liveRunId}.json`), 'utf8'));
+    const liveCheckpoint = readStoredRun(workspaceB, liveRunId);
     assert.equal(liveCheckpoint.status, 'running');
     assert.equal(liveCheckpoint.nodeStates.live_input.status, 'success');
     assert.equal(liveCheckpoint.outputs.live_input, 'hello');
@@ -242,13 +279,13 @@ try {
 
   let finishedLiveRun;
   for (let attempt = 0; attempt < 30; attempt += 1) {
-    finishedLiveRun = JSON.parse(readFileSync(join(runsDirB, `${liveRunId}.json`), 'utf8'));
+    finishedLiveRun = readStoredRun(workspaceB, liveRunId);
     if (finishedLiveRun.status !== 'running') break;
     await new Promise((resolve) => setTimeout(resolve, 10));
   }
   assert.equal(finishedLiveRun.status, 'success');
 
-  writeFileSync(join(runsDirB, 'run_late_orphan.json'), JSON.stringify({
+  seedStoredRun(workspaceB, {
     runId: 'run_late_orphan', schemaVersion: 3, status: 'running',
     startedAt: '2026-08-24T00:00:00.000Z', triggerInput: '', runInputs: {},
     graph: {
@@ -260,7 +297,7 @@ try {
     },
     nodeStates: { orphan_done: { status: 'success' } }, outputs: { orphan_done: 'done' },
     structuredOutputs: {}, nodeOrder: ['orphan_done'],
-  }));
+  });
   const orphanDetail = responseCapture();
   await route('/wf1/api/runs/detail')(request('GET', withSession('/wf1/api/runs/detail?id=run_late_orphan', 'session-b')), orphanDetail);
   assert.equal(orphanDetail.status, 200);
@@ -276,13 +313,13 @@ try {
     ],
     edges: [{ source: 'resume_input', target: 'resume_output' }],
   };
-  writeFileSync(join(runsDirB, 'run_resume_seed.json'), JSON.stringify({
+  seedStoredRun(workspaceB, {
     runId: 'run_resume_seed', schemaVersion: 3, status: 'error',
     startedAt: '2026-08-24T00:00:00.000Z', finishedAt: '2026-08-24T00:00:01.000Z', durationMs: 1000,
     triggerInput: '', runInputs: {}, graph: resumeGraph, graphFingerprint: 'legacy-fingerprint',
     nodeStates: { resume_input: { status: 'success' }, resume_output: { status: 'error', error: '模拟失败' } },
     outputs: { resume_input: 'hello' }, structuredOutputs: {}, nodeOrder: ['resume_input', 'resume_output'],
-  }));
+  });
 
   // 改的是未完成节点（resume_output）→ 不再拦截，success 节点照常复用
   const changedGraph = structuredClone(resumeGraph);
@@ -329,13 +366,13 @@ try {
     id: 'wf_resume_named', name: '命名续跑', graph: brokenGraph,
   }), namedCreate);
   assert.equal(namedCreate.status, 200);
-  writeFileSync(join(runsDirB, 'run_resume_named_seed.json'), JSON.stringify({
+  seedStoredRun(workspaceB, {
     runId: 'run_resume_named_seed', schemaVersion: 3, status: 'interrupted', workflowId: 'wf_resume_named',
     startedAt: '2026-08-24T00:00:00.000Z', finishedAt: '2026-08-24T00:00:01.000Z', durationMs: 1000,
     triggerInput: '', runInputs: {}, graph: resumeGraph, graphFingerprint: graphFingerprint(resumeGraph),
     nodeStates: { resume_input: { status: 'success' }, resume_output: { status: 'running' } },
     outputs: { resume_input: 'hello' }, structuredOutputs: {}, nodeOrder: ['resume_input', 'resume_output'],
-  }));
+  });
   const namedMismatch = responseCapture();
   await route('/wf1/api/runs/resume')(request('POST', withSession('/wf1/api/runs/resume', 'session-b'), {
     runId: 'run_resume_named_seed', graph: resumeGraph,
@@ -380,9 +417,7 @@ try {
   const artifactRunId = artifactRunRes.json().runId;
   let artifactRunDoc;
   for (let attempt = 0; attempt < 30; attempt += 1) {
-    artifactRunDoc = readdirSync(runsDirB)
-      .map((file) => JSON.parse(readFileSync(join(runsDirB, file), 'utf8')))
-      .find((run) => run.runId === artifactRunId);
+    artifactRunDoc = readStoredRun(workspaceB, artifactRunId);
     if (artifactRunDoc && artifactRunDoc.status !== 'running') break;
     await new Promise((resolve) => setTimeout(resolve, 25));
   }
@@ -411,6 +446,7 @@ try {
 
   console.log('plugin storage integration tests: ALL PASS');
 } finally {
+  for (const dispose of disposers.reverse()) await dispose();
   if (original === undefined) delete process.env.DSH_HOME;
   else process.env.DSH_HOME = original;
   rmSync(dshHome, { recursive: true, force: true });

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/sqlite-store.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/sqlite-store.test.mjs
@@ -142,4 +142,28 @@ test('rolls back schema migration when the database is incompatible', () => {
   }
 });
 
+test('does not complete migration when the bad-file report cannot be written', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wf1-sqlite-report-'));
+  try {
+    const databaseFile = join(root, 'workflow-one.sqlite');
+    const workflowsDir = join(root, 'workflows');
+    const reportPath = join(root, 'state');
+    mkdirSync(workflowsDir, { recursive: true });
+    mkdirSync(reportPath);
+    writeFileSync(join(workflowsDir, 'wf_bad.json'), '{');
+
+    assert.throws(() => new WorkflowSqliteStore({
+      databaseFile,
+      workflowsDir,
+      runsDir: join(root, 'runs'),
+      migrationErrorFile: reportPath,
+    }));
+    const check = new DatabaseSync(databaseFile);
+    assert.equal(check.prepare('PRAGMA user_version').get().user_version, 0);
+    check.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 console.log(`\n${passed} tests passed`);

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/sqlite-store.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/sqlite-store.test.mjs
@@ -1,0 +1,145 @@
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { WorkflowSqliteStore } from '../lib/sqlite-store.js';
+
+let passed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+    console.log(`  ✓ ${name}`);
+  } catch (error) {
+    console.error(`  ✗ ${name}\n    ${error.stack || error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+const workflow = (id, updatedAt, nodes = []) => ({
+  id,
+  name: id,
+  updatedAt,
+  graph: { nodes, edges: [] },
+});
+const run = (runId, startedAt, status = 'success', workflowId = null) => ({
+  runId,
+  workflowId,
+  status,
+  startedAt,
+  finishedAt: startedAt,
+  nodeStates: {},
+  outputs: {},
+  structuredOutputs: {},
+});
+
+console.log('sqlite store tests:');
+
+test('migrates valid JSON, reports bad files, and becomes the only write source', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wf1-sqlite-'));
+  try {
+    const workflowsDir = join(root, 'workflows');
+    const runsDir = join(root, 'runs');
+    const tombstones = join(root, 'state', 'tombstones', 'workflows');
+    const errorFile = join(root, 'state', 'sqlite-migration-errors.json');
+    const databaseFile = join(root, 'workflow-one.sqlite');
+    chmodSync(root, 0o755);
+    mkdirSync(workflowsDir, { recursive: true });
+    mkdirSync(runsDir, { recursive: true });
+    mkdirSync(tombstones, { recursive: true });
+    writeFileSync(join(workflowsDir, 'wf_old.json'), JSON.stringify(workflow('wf_old', '2026-08-01T00:00:00.000Z', [
+      { id: 'a', type: 'agent', data: {} },
+      { id: 'o', type: 'output', data: {} },
+    ])));
+    writeFileSync(join(workflowsDir, 'wf_deleted.json'), JSON.stringify(workflow('wf_deleted', '2026-08-01T00:00:00.000Z')));
+    writeFileSync(join(tombstones, 'wf_deleted'), 'deleted');
+    writeFileSync(join(workflowsDir, 'wf_array.json'), '[]');
+    writeFileSync(join(workflowsDir, 'wf_bad.json'), '{');
+    writeFileSync(join(runsDir, 'run_old.json'), JSON.stringify(run('run_old', '2026-08-01T00:00:00.000Z', 'success', 'wf_old')));
+
+    const warnings = [];
+    const store = new WorkflowSqliteStore({
+      databaseFile,
+      workflowsDir,
+      runsDir,
+      workflowTombstoneDir: tombstones,
+      migrationErrorFile: errorFile,
+      logger: { warn(message) { warnings.push(message); } },
+    });
+    assert.equal(statSync(root).mode & 0o777, 0o700);
+    assert.equal(statSync(databaseFile).mode & 0o777, 0o600);
+    assert.deepEqual(store.listWorkflows(), [{
+      id: 'wf_old', name: 'wf_old', updatedAt: '2026-08-01T00:00:00.000Z', nodeCount: 2, agentCount: 1,
+    }]);
+    assert.equal(store.getRun('run_old').workflowId, 'wf_old');
+    const migrationErrors = JSON.parse(readFileSync(errorFile, 'utf8')).errors;
+    assert.equal(migrationErrors.every((error) => error.kind === 'workflow'), true);
+    assert.equal(migrationErrors.some((error) => error.error.includes('必须是对象')), true);
+    assert.equal(warnings.some((message) => message.includes('wf_bad.json')), true);
+
+    store.putWorkflow(workflow('wf_new', '2026-08-02T00:00:00.000Z'));
+    store.putRun(run('run_new', '2026-08-02T00:00:00.000Z', 'success', 'wf_new'));
+    assert.equal(existsSync(join(workflowsDir, 'wf_new.json')), false);
+    assert.equal(existsSync(join(runsDir, 'run_new.json')), false);
+    assert.deepEqual(store.listRuns(2).map((row) => row.runId), ['run_new', 'run_old']);
+    assert.equal(store.deleteWorkflow('wf_new'), true);
+    assert.equal(store.getWorkflow('wf_new'), null);
+    assert.equal(store.getRun('run_new').workflowId, 'wf_new', '删除工作流不得级联删除历史运行');
+    store.close();
+    store.close();
+    const settings = new DatabaseSync(databaseFile);
+    assert.equal(settings.prepare('PRAGMA user_version').get().user_version, 1);
+    assert.equal(settings.prepare('PRAGMA auto_vacuum').get().auto_vacuum, 2);
+    settings.close();
+
+    writeFileSync(join(workflowsDir, 'wf_late.json'), JSON.stringify(workflow('wf_late', '2026-08-03T00:00:00.000Z')));
+    const reopened = new WorkflowSqliteStore({ databaseFile, workflowsDir, runsDir, workflowTombstoneDir: tombstones, migrationErrorFile: errorFile });
+    assert.equal(reopened.getWorkflow('wf_late'), null, '完成迁移后不得继续读取 JSON 备份');
+    reopened.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('prunes runs by startedAt and keeps the newest rows', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wf1-sqlite-prune-'));
+  try {
+    const store = new WorkflowSqliteStore({
+      databaseFile: join(root, 'workflow-one.sqlite'),
+      workflowsDir: join(root, 'workflows'),
+      runsDir: join(root, 'runs'),
+    });
+    store.putRun(run('run_1', '2026-08-01T00:00:00.000Z'));
+    store.putRun(run('run_3', '2026-08-03T00:00:00.000Z'));
+    store.putRun(run('run_2', '2026-08-02T00:00:00.000Z'));
+    assert.deepEqual(store.pruneRuns(2), [{ runId: 'run_1', workflowId: null }]);
+    assert.deepEqual(store.listRuns(10).map((row) => row.runId), ['run_3', 'run_2']);
+    store.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('rolls back schema migration when the database is incompatible', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wf1-sqlite-rollback-'));
+  try {
+    const databaseFile = join(root, 'workflow-one.sqlite');
+    const workflowsDir = join(root, 'workflows');
+    mkdirSync(workflowsDir, { recursive: true });
+    writeFileSync(join(workflowsDir, 'wf_seed.json'), JSON.stringify(workflow('wf_seed', '2026-08-01T00:00:00.000Z')));
+    const broken = new DatabaseSync(databaseFile);
+    broken.exec('CREATE TABLE workflows (id TEXT PRIMARY KEY) STRICT');
+    broken.close();
+
+    assert.throws(() => new WorkflowSqliteStore({ databaseFile, workflowsDir, runsDir: join(root, 'runs') }));
+    const check = new DatabaseSync(databaseFile);
+    assert.equal(check.prepare('PRAGMA user_version').get().user_version, 0);
+    assert.equal(check.prepare("SELECT count(*) count FROM sqlite_master WHERE type='table' AND name='runs'").get().count, 0);
+    check.close();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+console.log(`\n${passed} tests passed`);

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/storage-paths.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/storage-paths.test.mjs
@@ -38,6 +38,7 @@ test('uses the workspace hidden directory and exposes read-only legacy layouts',
     assert.equal(paths.attachments, join(pluginRoot, 'attachments'));
     assert.equal(paths.runs, join(pluginRoot, 'runs'));
     assert.equal(paths.runtime, join(pluginRoot, 'runtime'));
+    assert.equal(paths.database, join(pluginRoot, 'workflow-one.sqlite'));
     assert.equal(paths.pluginDataLegacy.root, join(dshHome, 'plugin-data', 'dsh-ccpg-orchestrator'));
     assert.equal(paths.packageLegacy.root, legacyRoot);
     assert.equal(existsSync(workspaceRoot), false);

--- a/dsh-plugins/pack.sh
+++ b/dsh-plugins/pack.sh
@@ -14,7 +14,7 @@
 #   sh pack.sh [tag]     # tag 默认取最近 git tag（无则 0.0.0）
 # 环境变量：
 #   PACK_DIR   打包根目录（默认 /tmp/dsh-ccpg-pack），结束后可删
-#   DSH_NODE   构建画布用的 node（默认自动探测，要求 >=20；兼容旧名 WF1_NODE）
+#   DSH_NODE   构建与打包用的 node（默认自动探测，要求 >=24.15；兼容旧名 WF1_NODE）
 set -e
 HERE=$(cd "$(dirname "$0")" && pwd)
 REPO_ROOT=$(cd "$HERE/.." && pwd)
@@ -29,10 +29,13 @@ OPTIONAL_PLUGINS="dsh-ccpg-brand"
 # 聚合壳（bundle patch 挂载七插件 + better-sidebar，可选件 env 门控）；其 node_modules 是本地安装产物，不打包
 AGG="dsh-ccpg-one"
 
-# ---- 0. node（>=20）----
+# ---- 0. node（>=24.15，内置 node:sqlite）----
 NODE_BIN="${DSH_NODE:-${WF1_NODE:-}}"
-[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "console.log(Number(process.versions.node.split('.')[0])>=20?process.execPath:'')" 2>/dev/null || true)
-[ -z "$NODE_BIN" ] && { echo "✗ 需要 node>=20（或设 DSH_NODE 指向）"; exit 1; }
+[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>24||(a===24&&b>=15)?process.execPath:'')" 2>/dev/null || true)
+if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>24||(a===24&&b>=15)?0:1)" 2>/dev/null; then
+  echo "✗ 需要 node>=24.15（或设 DSH_NODE 指向）"
+  exit 1
+fi
 echo "✓ node: $("$NODE_BIN" -v)"
 PATH=$(dirname "$NODE_BIN"):$PATH
 export PATH
@@ -152,7 +155,12 @@ import { pathToFileURL } from 'node:url';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
 const root = process.argv[2];
+const database = new DatabaseSync(':memory:');
+database.exec('CREATE TABLE smoke (value INTEGER) STRICT; INSERT INTO smoke VALUES (1)');
+if (database.prepare('SELECT value FROM smoke').get().value !== 1) throw new Error('node:sqlite smoke 输出错误');
+database.close();
 const { runScript } = await import(pathToFileURL(join(root, 'lib', 'script-runner.js')));
 const workspaceDir = mkdtempSync(join(tmpdir(), 'wf1-pack-script-'));
 try {

--- a/dsh-plugins/setup.sh
+++ b/dsh-plugins/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Workflow One 插件本地分发安装脚本（模拟别人拿到这个仓库后的完整安装）。
-# 前提：已 npm i -g @deepseek-ai/dsh，且 node >= 20
+# 前提：已 npm i -g @deepseek-ai/dsh，且 node >= 24.15（内置 node:sqlite）
 # 用法：
 #   sh setup.sh                  # 安装到默认 profile dsh-ccpg（端口 4021，七插件逐个挂载）
 #   sh setup.sh <profile> <端口> # 安装到自定义 profile
@@ -15,8 +15,11 @@ PROFILE="${1:-dsh-ccpg}"
 PORT="${2:-4021}"
 HERE=$(cd "$(dirname "$0")" && pwd)
 NODE_BIN="${DSH_NODE:-}"
-[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "console.log(Number(process.versions.node.split('.')[0])>=20?process.execPath:'')" 2>/dev/null || true)
-[ -z "$NODE_BIN" ] && { echo "✗ 需要 node>=20（或设 DSH_NODE 指向）"; exit 1; }
+[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>24||(a===24&&b>=15)?process.execPath:'')" 2>/dev/null || true)
+if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>24||(a===24&&b>=15)?0:1)" 2>/dev/null; then
+  echo "✗ 需要 node>=24.15（或设 DSH_NODE 指向）"
+  exit 1
+fi
 PATH=$(dirname "$NODE_BIN"):$PATH
 export PATH
 export DSH_HOME="${DSH_HOME:-$HOME/.dsh}"
@@ -62,7 +65,12 @@ import { pathToFileURL } from 'node:url';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
 const root = process.argv[2];
+const database = new DatabaseSync(':memory:');
+database.exec('CREATE TABLE smoke (value INTEGER) STRICT; INSERT INTO smoke VALUES (1)');
+if (database.prepare('SELECT value FROM smoke').get().value !== 1) throw new Error('node:sqlite smoke 输出错误');
+database.close();
 const { runScript } = await import(pathToFileURL(join(root, 'lib', 'script-runner.js')));
 const workspaceDir = mkdtempSync(join(tmpdir(), 'wf1-setup-script-'));
 try {
@@ -97,7 +105,7 @@ DSH_BIN=$("$NODE_BIN" -e "console.log(require.resolve('@deepseek-ai/dsh/lib/bin.
 [ -z "$DSH_BIN" ] && for c in "$HOME/.local/npm-global/lib/node_modules/@deepseek-ai/dsh/lib/bin.js" "/usr/local/lib/node_modules/@deepseek-ai/dsh/lib/bin.js"; do
   [ -f "$c" ] && DSH_BIN="$c" && break
 done
-[ -z "$DSH_BIN" ] && { echo "✗ 未找到 dsh（先 npm i -g @deepseek-ai/dsh，需要 node>=20）"; exit 1; }
+[ -z "$DSH_BIN" ] && { echo "✗ 未找到 dsh（先 npm i -g @deepseek-ai/dsh，需要 node>=24.15）"; exit 1; }
 DSH_BIN=$("$NODE_BIN" -e "console.log(require('fs').realpathSync(process.argv[1]))" "$DSH_BIN")
 
 # 1. 建_profile（已存在则跳过）

--- a/dsh-plugins/start.sh
+++ b/dsh-plugins/start.sh
@@ -3,10 +3,13 @@
 PROFILE="${1:-}"
 export DSH_HOME="${DSH_HOME:-$HOME/.dsh}"
 
-# 定位能跑 dsh 的 node（>=20）与 dsh bin
+# 定位能跑 Workflow One 的 node（>=24.15，内置 node:sqlite）与 dsh bin
 NODE_BIN="${DSH_NODE:-}"
-[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const v=process.versions.node.split('.')[0]; console.log(v>=20?process.execPath:'')" 2>/dev/null || true)
-[ -z "$NODE_BIN" ] && { echo "✗ 需要 node>=20（或设 DSH_NODE 指向）"; exit 1; }
+[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>24||(a===24&&b>=15)?process.execPath:'')" 2>/dev/null || true)
+if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>24||(a===24&&b>=15)?0:1)" 2>/dev/null; then
+  echo "✗ 需要 node>=24.15（或设 DSH_NODE 指向）"
+  exit 1
+fi
 
 DSH_BIN=$("$NODE_BIN" -e "console.log(require.resolve('@deepseek-ai/dsh/lib/bin.js'))" 2>/dev/null || true)
 [ -z "$DSH_BIN" ] && DSH_BIN=$(command -v dsh 2>/dev/null || true)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "engines": {
+        "node": ">=24.15"
+      },
       "dependencies": {
         "quickjs-emscripten": "0.32.0"
       }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "harness-one",
   "private": true,
   "description": "dsh 插件开发工作区（Workflow One 物业编排套件）",
+  "engines": {
+    "node": ">=24.15"
+  },
   "scripts": {
     "test": "sh scripts/run-tests.sh",
     "build": "sh dsh-plugins/build-web.sh",

--- a/scripts/verify-plugin-packages.mjs
+++ b/scripts/verify-plugin-packages.mjs
@@ -32,7 +32,7 @@ for (const name of packages) {
   assert.equal(pkg.private, false, `${name} must be publishable`);
   assert.equal(pkg.license, 'MIT');
   assert.equal(pkg.repository?.directory, `dsh-plugins/${name}`);
-  assert.equal(pkg.engines?.node, '>=20');
+  assert.equal(pkg.engines?.node, ['dsh-ccpg-orchestrator', 'dsh-ccpg-one'].includes(name) ? '>=24.15' : '>=20');
   assert.equal(pkg.dsh?.bundle?.patch, './cordis.patch.yml');
 
   // 聚合包的最终 bundle 由 publish-npm.sh 在干净 staging 中逐项校验；


### PR DESCRIPTION
## 背景

Workflow One 的工作流与运行历史当前按实体写入 JSON，列表依赖目录扫描和逐文件解析。随着运行输出增长，检查点重写和历史恢复成本持续上升。

Closes #21

## 方案

- 每个 dsh 工作区使用独立 `.workflow-one/workflow-one.sqlite`
- 基于 Node `node:sqlite`，schema v1 使用 JSON 文档列与列表投影列
- 保留旧 JSON 一次性事务迁移、坏文件报告和删除 tombstone 语义
- WAL、busy timeout、增量 vacuum、0600/0700 权限与插件 dispose 关闭
- 工作流/运行改为 SQLite 唯一读写源，attachments/state/runtime 保持文件系统
- Node 基线统一为 `>=24.15`，同步 CI、安装、启动与打包链

## 验证

- `npm test`
- `sh dsh-plugins/build-web.sh`
- `node scripts/verify-plugin-packages.mjs`
- 完整 release pack 冒烟，归档包含 `sqlite-store.js`
- 隔离 dsh profile 真实启动：官方 UI 创建并运行 2 节点工作流成功
- 真实工作区迁移：`PRAGMA integrity_check=ok`、WAL 生效、权限正确、无 JSON 双写、dsh 重启后工作流及运行结果恢复

## 审核

已复查迁移回滚、损坏 JSON、运行恢复、保留清理、工作区隔离和生命周期。审核中补齐了已有 `.workflow-one/` 目录权限收紧及回归测试。