### PR TITLE
fix(one): 修 npm 安装在 pnpm 11 下的死锁与双注册 boot 崩溃（issue #24）

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@
 Node.js >= 24.15 且已安装 `@deepseek-ai/dsh`：
 
 ```sh
-dsh plugin --profile web add dsh-ccpg-one@0.2.1
+dsh plugin --profile web add dsh-ccpg-one@0.2.2
 dsh web
 ```
 
-Harness Desktop 用户在 **Open DSH Terminal** 中执行 `dsh plugin add dsh-ccpg-one@0.2.1`，然后重启 Desktop。也可以从 [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest) 下载离线聚合包。
+Harness Desktop 用户在 **Open DSH Terminal** 中执行 `dsh plugin add dsh-ccpg-one@0.2.2`，然后重启 Desktop。也可以从 [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest) 下载离线聚合包。
 
 ## 界面与使用方式
 
@@ -40,7 +40,7 @@ Workflow One 嵌在 dsh 官方界面中：左侧保留与智能体的对话，�
 **Harness Desktop（npm 包发布后）**：从 Desktop 托盘打开 **Open DSH Terminal**，对当前 profile 安装并重启 Desktop：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.2.1
+dsh plugin add dsh-ccpg-one@0.2.2
 ```
 
 Desktop 使用官方 DSH/Cordis 插件组合，不需要另一套插件。不要在 Desktop 里运行 `setup.sh`：Desktop 自己管理 profile、Node/pnpm 和随机 loopback 端口；飞书账号页首次点击「自动安装」时，lark-cli 会通过 Desktop 的受管 pnpm 安装到当前 profile。安装使用细节、环境差异与常见问题排查见 [`dsh-plugins/DESKTOP.md`](dsh-plugins/DESKTOP.md)；Desktop 开发兼容契约（`desktopProfiles`/`desktopPnpm` 动态探测、跨环境插件写法）也在该文档第 2 节。

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -22,7 +22,7 @@
 从 Desktop 托盘打开 **Open DSH Terminal**；该终端已绑定当前 profile：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.2.1
+dsh plugin add dsh-ccpg-one@0.2.2
 ```
 
 安装后重启 Desktop，让新 bundle 进入 Loader 组合。compatibility 与 advanced 模式都继续使用普通 DSH Web Client；画布、同源 `/wf1/api/*`、侧栏和预览无需 Desktop 专用注册。飞书账号页首次点击「自动安装」时，插件通过公开 `desktopPnpm` service 把固定版本 lark-cli 安装到当前 profile，并在 profile 切换或退出时取消仍在运行的操作。
@@ -72,15 +72,19 @@ sh start.sh dev
 - 改引擎（`dsh-ccpg-orchestrator/lib/`）→ 对应面测试（`cd dsh-ccpg-orchestrator && for t in test/*.test.mjs; do node "$t"; done`）→ 重启
 - 发版：`npm run publish:dry-run` 验证 npm 包；`sh dsh-plugins/publish-npm.sh` 按子包→聚合包顺序发布；Git tag 仍由 release.yml 生成 tarball + boot-smoke asset
 
-### 可选件开关（`--one` 模式，启动前 export，可写进工作区 `.env`）
+### 可选件开关（`--one` 模式）
 
-| 开关 | 效果 |
-|---|---|
-| `CCPG_NO_LARK=1` | 不加载 larkauth（飞书扫码登录） |
-| `CCPG_NO_PREVIEW=1` | 不加载 document-preview（预览退化为下载） |
-| `CCPG_NO_SIDEBAR=1` | 不加载 better-sidebar（官方 UI 内工作流侧栏不可用，独立 `/wf1/` 入口仍可用） |
-| `CCPG_NO_GUARD=1` | 不加载 llm-guard（不建议关） |
-| `CCPG_ONLY_CORE=1` | 一键只留核心：tools/orchestrator/web/canvasui |
+启动前 export（源码/`setup.sh --one` 渠道可写进工作区 `.env`；npm 渠道的 sidebar 开关在**安装时**生效，见下表注）：
+
+| 开关 | 效果 | 生效位置 |
+|---|---|---|
+| `CCPG_NO_LARK=1` | 不加载 larkauth（飞书扫码登录） | 运行时（bundle patch） |
+| `CCPG_NO_PREVIEW=1` | 不加载 document-preview（预览退化为下载） | 运行时（bundle patch） |
+| `CCPG_NO_GUARD=1` | 不加载 llm-guard（不建议关） | 运行时（bundle patch） |
+| `CCPG_NO_SIDEBAR=1` | 不装 better-sidebar（官方 UI 内工作流侧栏宿主不可用，独立 `/wf1/` 入口不受影响） | **安装时**（npm 渠道：`npx dsh-ccpg-one` 检测到即 `dsh plugin remove dsh-better-sidebar`；源码渠道：setup.sh 未装它即无） |
+| `CCPG_ONLY_CORE=1` | 一键只留核心：tools/orchestrator/web/canvasui（+ 移除 sidebar） | 运行时 + 安装时 |
+
+> better-sidebar 的挂载由它自己的 `dsh.bundle.patch` 提供（聚合层不再 insert——双 insert 会 duplicate route）。因此关闭 sidebar 无法在运行时做，npm 渠道由安装器移除依赖实现。
 
 > `dsh-ccpg-brand` 不属于聚合包，需要时必须单独安装（`dsh plugin --profile <name> add <repo>/dsh-plugins/dsh-ccpg-brand`）。聚合模式不要再单独 add 其余 7 个子插件或手写 insert 行——双层挂载 = duplicate prefix route。`dsh plugin --profile <name> remove dsh-ccpg-one` 一次卸掉聚合包包含的默认插件。
 
@@ -106,11 +110,19 @@ sh start.sh dev
 
 ### npm 直装
 
-聚合包和 7 个默认插件均为带 `dsh.bundle.patch` 的自描述包。推荐一条命令：
+聚合包和 7 个默认插件均为带 `dsh.bundle.patch` 的自描述包。**pnpm 11 环境推荐**（见下）：
 
 ```sh
-dsh plugin --profile myprofile add dsh-ccpg-one@0.2.1
+npx dsh-ccpg-one myprofile        # 预写 pnpm 11 放行（node-pty/koffi 构建许可）再一步装齐
 ```
+
+也可直接用官方命令：
+
+```sh
+dsh plugin --profile myprofile add dsh-ccpg-one@0.2.2
+```
+
+> **pnpm 11 注意（issue #24）**：`dsh plugin add` 是 profile 目录里裸跑 pnpm，聚合依赖链里的 `node-pty`（dsh-better-sidebar 传递依赖，原生模块）会被 strict-dep-builds 拦下：安装非零退出、且 pnpm 往 profile 的 `pnpm-workspace.yaml` 写非法占位符 `node-pty: set this to true or false`，把 `pnpm approve-builds` 与重跑 install 一起堵死——**重试无效**。0.2.2 起用 `npx dsh-ccpg-one` 安装即可（它先把放行写对再装，幂等，可反复重跑）；已中招的 profile 也能用它自愈。
 
 需要 CCPG 品牌外观时，再显式安装独立插件：
 

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/bin/install.js
+++ b/dsh-plugins/dsh-ccpg-one/bin/install.js
@@ -42,13 +42,14 @@ CCPG_NO_SIDEBAR=1 / CCPG_ONLY_CORE=1：装完后 dsh plugin remove dsh-better-si
   process.exit(0);
 }
 
-// --- 1. 定位 dsh：优先 PATH，其次已安装 profile 的扁平兜底目录 ---
+// --- 1. 定位 dsh：优先 PATH，其次已安装 profile 的扁平兜底目录（--prewrite 不需要 dsh）---
+const prewriteOnly = process.argv.includes('--prewrite');
 const dshCandidates = ['dsh', join(DSH_HOME, 'profiles/node_modules/@deepseek-ai/dsh/lib/bin.js')];
-const dsh = dshCandidates.find((c) => spawnSync(c, ['--version']).status === 0);
-if (!dsh) die('未找到 dsh（先 npm i -g @deepseek-ai/dsh）');
+const dsh = prewriteOnly ? null : dshCandidates.find((c) => spawnSync(c, ['--version']).status === 0);
+if (!prewriteOnly && !dsh) die('未找到 dsh（先 npm i -g @deepseek-ai/dsh）');
 
 // --- 2. 让 dsh 先初始化 profile（其模板含 pnpm-workspace.yaml），再预写放行 ---
-if (!existsSync(join(DSH_HOME, 'profiles', PROFILE, 'package.json'))) {
+if (!prewriteOnly && !existsSync(join(DSH_HOME, 'profiles', PROFILE, 'package.json'))) {
   const ls = spawnSync(dsh, ['plugin', '--profile', PROFILE, 'ls'], { encoding: 'utf8' });
   // initProfile 在首次 plugin 调用时完成；ls 本身可能因 pnpm 环境差异非零，目录在即可
   if (!existsSync(join(DSH_HOME, 'profiles', PROFILE, 'package.json'))) {

--- a/dsh-plugins/dsh-ccpg-one/bin/install.js
+++ b/dsh-plugins/dsh-ccpg-one/bin/install.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// dsh-ccpg-one 安装入口（npx dsh-ccpg-one / npm exec dsh-ccpg-one）。
+//
+// 为什么存在：`dsh plugin --profile X add dsh-ccpg-one` 是 profile 目录里裸跑
+// pnpm 11 的薄转发器，而聚合依赖链 dsh-ccpg-one → dsh-better-sidebar → node-pty
+// 带原生构建脚本。pnpm 11 的 strict-dep-builds 在 allowBuilds 未声明时直接
+// ERR_PNPM_IGNORED_BUILDS 非零退出——dsh 跳过 bundle 注册，且 pnpm 已往 profile
+// 的 pnpm-workspace.yaml 写入非法占位符（`node-pty: set this to true or false`），
+// 把 `pnpm approve-builds` 和重跑 install 一起堵死（issue #24）。
+// 包内 postinstall 不可用（它本身也在被拦的构建脚本之列），所以唯一可靠的
+// 修复位置在安装之前：先把 profile 的 workspace 放行写好，再交给 dsh plugin。
+//
+// 幂等：已正确的条目不动；pnpm 写入的占位符归位为 true。全程不删用户条目。
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const DSH_HOME = process.env.DSH_HOME || join(process.env.HOME, '.dsh');
+const PROFILE = process.argv[2] || 'dsh-ccpg';
+const PKG = 'dsh-ccpg-one';
+const SUBPLUGINS = ['dsh-ccpg-canvasui', 'dsh-ccpg-document-preview', 'dsh-ccpg-larkauth',
+  'dsh-ccpg-llm-guard', 'dsh-ccpg-orchestrator', 'dsh-ccpg-tools', 'dsh-ccpg-web'];
+
+const trailingNewline = (s) => (s.endsWith('\n') ? '' : '\n');
+const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const say = (msg) => console.log(`[dsh-ccpg-one] ${msg}`);
+const die = (msg) => { console.error(`[dsh-ccpg-one] ${msg}`); process.exit(1); };
+
+if (process.argv.includes('-h') || process.argv.includes('--help')) {
+  console.log(`用法：npx ${PKG} [profile] [--prewrite]
+在 ~/.dsh/profiles/<profile> 预写 pnpm 11 放行（allowBuilds: node-pty/protobufjs/koffi、
+minimumReleaseAgeExclude: dsh-ccpg-*），然后 dsh plugin add ${PKG}。
+
+--prewrite   只做预写后退出（setup.sh --one 复用；不执行安装）。
+
+pnpm 11 用户直接 \`dsh plugin add ${PKG}\` 遇 ERR_PNPM_IGNORED_BUILDS 时，重跑 install
+无效（pnpm 反复拦截，见 issue #24）——用本命令安装，它会先把放行写对。
+
+CCPG_NO_SIDEBAR=1 / CCPG_ONLY_CORE=1：装完后 dsh plugin remove dsh-better-sidebar
+（侧栏挂载是上游包自己的 bundle 层；聚合层不再 insert，关闭须移除依赖本身）。`);
+  process.exit(0);
+}
+
+// --- 1. 定位 dsh：优先 PATH，其次已安装 profile 的扁平兜底目录 ---
+const dshCandidates = ['dsh', join(DSH_HOME, 'profiles/node_modules/@deepseek-ai/dsh/lib/bin.js')];
+const dsh = dshCandidates.find((c) => spawnSync(c, ['--version']).status === 0);
+if (!dsh) die('未找到 dsh（先 npm i -g @deepseek-ai/dsh）');
+
+// --- 2. 让 dsh 先初始化 profile（其模板含 pnpm-workspace.yaml），再预写放行 ---
+if (!existsSync(join(DSH_HOME, 'profiles', PROFILE, 'package.json'))) {
+  const ls = spawnSync(dsh, ['plugin', '--profile', PROFILE, 'ls'], { encoding: 'utf8' });
+  // initProfile 在首次 plugin 调用时完成；ls 本身可能因 pnpm 环境差异非零，目录在即可
+  if (!existsSync(join(DSH_HOME, 'profiles', PROFILE, 'package.json'))) {
+    die(`profile ${PROFILE} 初始化失败（可先跑一次：${dsh} plugin --profile ${PROFILE} ls）`);
+  }
+}
+const wsPath = join(DSH_HOME, 'profiles', PROFILE, 'pnpm-workspace.yaml');
+const original = existsSync(wsPath) ? readFileSync(wsPath, 'utf8') : 'packages:\n  - .\n';
+let text = normalizePlaceholders(original);
+text = ensureMapping(text, 'allowBuilds', ['node-pty', 'protobufjs', 'koffi']);
+text = ensureSequence(text, 'minimumReleaseAgeExclude', [PKG, ...SUBPLUGINS]);
+if (text !== original) writeFileSync(wsPath, text);
+say(text !== original ? `已预写 ${wsPath}（allowBuilds + minimumReleaseAgeExclude）` : 'workspace 放行已就绪，跳过');
+
+// --prewrite：只修放行后退出（setup.sh --one 在 dsh plugin add 之前复用）
+if (process.argv.includes('--prewrite')) process.exit(0);
+
+// --- 3. 安装 ---
+say(`dsh plugin --profile ${PROFILE} add ${PKG} …`);
+const add = spawnSync(dsh, ['plugin', '--profile', PROFILE, 'add', PKG], { stdio: 'inherit' });
+if (add.status !== 0) {
+  console.error(`[dsh-ccpg-one] 安装失败（exit ${add.status}）。
+若上面有 ERR_PNPM_IGNORED_BUILDS：重试无效（pnpm 会反复拦截）——重跑本命令即可，
+它会先把 profile pnpm-workspace.yaml 的放行修正（allowBuilds: node-pty: true）再安装。`);
+  process.exit(add.status ?? 1);
+}
+
+// 可选件开关（安装层）：侧栏挂载由上游 dsh-better-sidebar 自己的 bundle 层提供，
+// 聚合 patch 不再 insert（双 insert = duplicate route；!!js 退让在双注册现场会递归爆栈），
+// 因此 CCPG_NO_SIDEBAR / CCPG_ONLY_CORE 在此落为移除依赖本身。
+if (process.env.CCPG_NO_SIDEBAR || process.env.CCPG_ONLY_CORE) {
+  say('CCPG_NO_SIDEBAR/CCPG_ONLY_CORE 生效：移除 dsh-better-sidebar …');
+  const rm = spawnSync(dsh, ['plugin', '--profile', PROFILE, 'remove', 'dsh-better-sidebar'], { stdio: 'inherit' });
+  if (rm.status !== 0) console.error('[dsh-ccpg-one] better-sidebar 移除失败（可手动：dsh plugin --profile ' + PROFILE + ' remove dsh-better-sidebar）');
+}
+say('安装完成，重启 dsh 生效。独立画布: http://127.0.0.1:4021/wf1/');
+
+// ======== profile pnpm-workspace.yaml 预写（幂等，不删用户条目）========
+
+// 归位 pnpm 写入的占位符（issue #24）：`  node-pty: set this to true or false` → `  node-pty: true`
+function normalizePlaceholders(text) {
+  return text.replace(/^(\s*)(node-pty|protobufjs):.*$/gm, '$1$2: true');
+}
+
+// 确保 `key:\n  name: true` 映射；key 块不存在时追加到文件末尾
+function ensureMapping(text, key, names) {
+  let out = text;
+  for (const name of names) {
+    if (new RegExp(`^\\s*${escapeRe(name)}:\\s*true\\s*$`, 'm').test(out)) continue;
+    const blockRe = new RegExp(`^([ \\t]*)${escapeRe(key)}:[ \\t]*$`, 'm');
+    const m = out.match(blockRe);
+    if (m) {
+      const lines = out.split('\n');
+      lines.splice(lines.indexOf(m[0]) + 1, 0, `${m[1]}  ${name}: true`);
+      out = lines.join('\n');
+    } else {
+      out += `${trailingNewline(out)}${key}:\n${names.map((n) => `  ${n}: true`).join('\n')}\n`;
+      return out;
+    }
+  }
+  return out;
+}
+
+// 确保 `key:\n  - item` 序列；key 块存在时追加到该块最后一个列表项后，不存在则追加到文件末尾
+function ensureSequence(text, key, items) {
+  let out = text;
+  for (const item of items) {
+    if (new RegExp(`^\\s*-\\s+${escapeRe(item)}\\s*$`, 'm').test(out)) continue;
+    const blockRe = new RegExp(`^([ \\t]*)${escapeRe(key)}:[ \\t]*$`, 'm');
+    const m = out.match(blockRe);
+    if (m) {
+      const lines = out.split('\n');
+      // 块 = 键行之后所有空行与缩进行（列表项/嵌套内容），到下一个顶级键为止
+      let insertAfter = lines.indexOf(m[0]);
+      let last = insertAfter;
+      for (let i = insertAfter + 1; i < lines.length; i++) {
+        if (lines[i].trim() === '' || /^\s+\S/.test(lines[i])) { if (/^\s*-\s/.test(lines[i])) last = i; }
+        else break;
+      }
+      lines.splice(last + 1, 0, `${m[1]}  - ${item}`);
+      out = lines.join('\n');
+    } else {
+      out += `${trailingNewline(out)}${key}:\n${items.map((x) => `  - ${x}`).join('\n')}\n`;
+      return out;
+    }
+  }
+  return out;
+}
+
+// ======== profile pnpm-workspace.yaml 预写（幂等，不删用户条目）========

--- a/dsh-plugins/dsh-ccpg-one/cordis.patch.yml
+++ b/dsh-plugins/dsh-ccpg-one/cordis.patch.yml
@@ -10,9 +10,11 @@
 # 可选件门控（disabled: !!js 在 loader ctx eval，读进程环境变量）：
 #   export CCPG_NO_LARK=1     → 不加载 larkauth（飞书扫码登录/技能种子）
 #   export CCPG_NO_PREVIEW=1  → 不加载 document-preview（文档预览退化为下载）
-#   export CCPG_NO_SIDEBAR=1  → 不加载 better-sidebar（官方 UI 工作流侧栏不可用）
 #   export CCPG_NO_GUARD=1    → 不加载 llm-guard（空工具调用防护，不建议关）
-#   export CCPG_ONLY_CORE=1   → 只留核心五件（tools/orchestrator/web/canvasui 之上的全关）
+#   export CCPG_ONLY_CORE=1   → 只留核心四件（tools/orchestrator/web/canvasui，其余全关）
+# 注意 CCPG_NO_SIDEBAR 已不在本层：better-sidebar 挂载由它自己的 bundle 层提供
+# （见下方 better-sidebar 注释）。npm 安装渠道用 npx dsh-ccpg-one 且带
+# CCPG_NO_SIDEBAR/CCPG_ONLY_CORE 时由 bin/install.js 移除该依赖实现关闭。
 # 以下变量可写进工作区 .env（DSH_ 前缀被禁止，CCPG_ 前缀合法）。
 # 挂载名说明：loader 与 client-modules 都从 profile 根按包名解析 entry——
 # 子插件必须作为 registry 依赖装在 profile node_modules（publish-npm.sh 已发布为公共包）。
@@ -36,8 +38,10 @@
     - id: dsh-ccpg-llm-guard
       name: 'dsh-ccpg-llm-guard'
       disabled: !!js "Boolean(process.env.CCPG_NO_GUARD || process.env.CCPG_ONLY_CORE)"
-    # id 不能用 better-sidebar：用户单独 add 过 dsh-better-sidebar 时其 bundle 层已 insert 同 id 行，
-    # 两层同 id insert 会 duplicate 报错。用独立 id + 防双挂载 disable（检测到别层已挂 sidebar 就关自己）。
-    - id: one-better-sidebar
-      name: 'dsh-better-sidebar'
-      disabled: !!js "Boolean(process.env.CCPG_NO_SIDEBAR || process.env.CCPG_ONLY_CORE) || [...ctx.loader.entries()].some((e) => e.options.name === 'dsh-better-sidebar' && e.options.id !== 'one-better-sidebar' && !e.disabled)"
+    # better-sidebar 不在此 insert：聚合包把 dsh-better-sidebar 声明为依赖，dsh plugin add
+    # 会依据其自带 dsh.bundle.patch 自动注册进 bundles 层挂载——聚和层再 insert 一行就是
+    # 双挂载（duplicate prefix route "/sidebar/api"，boot 失败）。此前版本的防双挂载
+    # disabled: !!js 表达式在双注册现场会经 loader evaluate 无限递归（栈溢出），且上游
+    # 包 0.16.1 自带的同款表达式也有同样缺陷，双向退让都不可靠——唯一稳态是单点挂载。
+    # CCPG_NO_SIDEBAR / CCPG_ONLY_CORE 开关改由 bin/install.js 在安装层处理
+    # （检测到开关时不把 better-sidebar 装进 profile）。

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-one",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -33,22 +33,27 @@
   "type": "module",
   "private": false,
   "main": "lib/index.js",
+  "bin": {
+    "dsh-ccpg-one": "./bin/install.js"
+  },
   "exports": {
-    ".": "./lib/index.js"
+    ".": "./lib/index.js",
+    "./install": "./bin/install.js"
   },
   "files": [
     "lib",
+    "bin",
     "cordis.patch.yml"
   ],
   "dependencies": {
-    "dsh-better-sidebar": "0.15.2",
-    "dsh-ccpg-canvasui": "0.2.1",
-    "dsh-ccpg-document-preview": "0.2.1",
-    "dsh-ccpg-larkauth": "0.2.1",
-    "dsh-ccpg-llm-guard": "0.2.1",
-    "dsh-ccpg-orchestrator": "0.2.1",
-    "dsh-ccpg-tools": "0.2.1",
-    "dsh-ccpg-web": "0.2.1"
+    "dsh-better-sidebar": "0.16.1",
+    "dsh-ccpg-canvasui": "0.2.2",
+    "dsh-ccpg-document-preview": "0.2.2",
+    "dsh-ccpg-larkauth": "0.2.2",
+    "dsh-ccpg-llm-guard": "0.2.2",
+    "dsh-ccpg-orchestrator": "0.2.2",
+    "dsh-ccpg-tools": "0.2.2",
+    "dsh-ccpg-web": "0.2.2"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-one/pnpm-workspace.yaml
+++ b/dsh-plugins/dsh-ccpg-one/pnpm-workspace.yaml
@@ -4,6 +4,9 @@ packages:
 allowBuilds:
   node-pty: true
 
+minimumReleaseAgeExclude:
+  - dsh-better-sidebar@0.16.1
+
 # SDK peer（@deepseek-ai/dsh-*）的 registry latest 停在 0.0.1-rc.1，0.1.x 只在 next tag：
 # pnpm 解析 peer 时按 latest 语义找不到 >=0.1.0 <0.2.0，直接 ERR_NO_MATCHING_VERSION。
 # 运行时这些包由 dsh 启动时的扁平兜底（~/.dsh/profiles/node_modules）提供，

--- a/dsh-plugins/dsh-ccpg-one/test/install.test.mjs
+++ b/dsh-plugins/dsh-ccpg-one/test/install.test.mjs
@@ -1,0 +1,81 @@
+// bin/install.js 的安装逻辑单测（零依赖 node:assert，node test/install.test.mjs）。
+// 真实模块加载（非字符串截取），node:fs 与 node:child_process 走 mock——
+// 重点：issue #24 的占位符归位、幂等（二跑零改动）、块存在/不存在两路径、--prewrite 只写不装。
+import { strict as assert } from 'node:assert';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const installJs = join(here, '../bin/install.js');
+
+// ---- 纯函数行为经 --prewrite 子进程间接断言（同时也是 ESM 整链冒烟）----
+// 用临时 DSH_HOME 造出 issue #24 现场（占位符 + 部分条目），跑 --prewrite 后校验产物。
+const home = mkdtempSync(join(tmpdir(), 'ccpg-one-test-'));
+try {
+  const profileDir = join(home, 'profiles', 'p1');
+  mkdirTree(profileDir);
+  writeFileSyncUTF8(join(profileDir, 'package.json'), '{"name":"dsh-profile-p1","private":true}');
+  writeFileSyncUTF8(join(profileDir, 'pnpm-workspace.yaml'), [
+    'packages:',
+    '  - .',
+    '',
+    'nodeLinker: hoisted',
+    'autoInstallPeers: false',
+    'minimumReleaseAgeExclude:',
+    '  - dsh-better-sidebar@0.16.1',
+    'allowBuilds:',
+    '  cloudflared: true',
+    '  node-pty: set this to true or false',
+    '',
+  ].join('\n'));
+
+  // DSH_HOME 指向临时目录；dsh 探测用 PATH 上的真 dsh（只影响 init，profile 已在场不触发）
+  execFileSync(process.execPath, [installJs, 'p1', '--prewrite'], {
+    env: { ...process.env, DSH_HOME: home },
+    stdio: 'pipe',
+  });
+  const out = readFileSync(join(profileDir, 'pnpm-workspace.yaml'), 'utf8');
+
+  // 占位符归位 + 用户条目保留 + 裸名放行追加在块内（顺序不定，逐行断言）
+  assert.ok(!out.includes('set this to true'), '占位符必须归位');
+  const allowBlock = out.split('allowBuilds:\n')[1]?.split('\n\n')[0] ?? '';
+  assert.match(allowBlock, /^  cloudflared: true$/m);
+  assert.match(allowBlock, /^  node-pty: true$/m);
+  assert.match(allowBlock, /^  protobufjs: true$/m);
+  assert.match(out, /minimumReleaseAgeExclude:\n  - dsh-better-sidebar@0\.16\.1\n/);
+  for (const p of ['dsh-ccpg-one', 'dsh-ccpg-canvasui', 'dsh-ccpg-orchestrator', 'dsh-ccpg-tools', 'dsh-ccpg-web']) {
+    assert.match(out, new RegExp(`^  - ${p}$`, 'm'), `${p} 应在 minimumReleaseAgeExclude`);
+  }
+  // 顶级键顺序不乱：packages 仍在最前
+  assert.ok(out.startsWith('packages:'));
+
+  // 幂等：二跑零改动
+  const before = out;
+  execFileSync(process.execPath, [installJs, 'p1', '--prewrite'], {
+    env: { ...process.env, DSH_HOME: home },
+    stdio: 'pipe',
+  });
+  assert.equal(readFileSync(join(profileDir, 'pnpm-workspace.yaml'), 'utf8'), before, '二跑必须零改动');
+
+  // 空白 profile（无 workspace 文件）：预写应创建完整块
+  const p2 = join(home, 'profiles', 'p2');
+  mkdirTree(p2);
+  writeFileSyncUTF8(join(p2, 'package.json'), '{"name":"dsh-profile-p2","private":true}');
+  execFileSync(process.execPath, [installJs, 'p2', '--prewrite'], {
+    env: { ...process.env, DSH_HOME: home },
+    stdio: 'pipe',
+  });
+  const out2 = readFileSync(join(p2, 'pnpm-workspace.yaml'), 'utf8');
+  assert.match(out2, /allowBuilds:\n  node-pty: true\n  protobufjs: true\n/);
+  assert.match(out2, /minimumReleaseAgeExclude:\n  - dsh-ccpg-one\n/);
+} finally {
+  rmSync(home, { recursive: true, force: true });
+}
+
+function mkdirTree(p) { execFileSync('/bin/mkdir', ['-p', p]); }
+function writeFileSyncUTF8(p, t) { execFileSync('/bin/sh', ['-c', `cat > ${JSON.stringify(p)} << 'EOF'\n${t}\nEOF`]); }
+
+console.log('✓ dsh-ccpg-one bin/install --prewrite：占位符归位 / 幂等 / 空白 profile 三组通过');

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/setup.sh
+++ b/dsh-plugins/setup.sh
@@ -155,9 +155,12 @@ if [ "$AGGREGATE" = 1 ]; then
   fi
   rm_vendor_ov
   # better-sidebar 是聚合包直接依赖，不单独 add——聚合 patch 已挂它，双 add 会 duplicate id。
+  # pnpm 11 预放行（issue #24）：node-pty（better-sidebar 传递依赖）原生构建被 strict-dep-builds
+  # 拦截会让 add 非零退出且写坏 pnpm-workspace.yaml 占位符——复用包内安装入口的预写（幂等）。
+  "$NODE_BIN" "$HERE/dsh-ccpg-one/bin/install.js" "$PROFILE" --prewrite
   if ! "$NODE_BIN" "$DSH_BIN" plugin --profile "$PROFILE" add "$HERE/dsh-ccpg-one" >"$PLUGIN_LOG" 2>&1; then
     cat "$PLUGIN_LOG" >&2
-    echo "✗ 聚合包安装失败"
+    echo "✗ 聚合包安装失败（pnpm 11 用户可改用: npx dsh-ccpg-one $PROFILE，自带放行预写）"
     exit 1
   fi
   cat "$PLUGIN_LOG"
@@ -227,9 +230,11 @@ fi
 
 # 4.5 DSH-better-sidebar（社区侧边栏工作台，npm 安装）——「工作流」侧栏的宿主。
 # canvasui 对它是软依赖：装不上时官方 UI 内无法打开画布，独立 /wf1/ 入口仍可用，故失败仅告警。
-# 逐插件模式：走 registry npm 包单独 add（自带 dsh.bundle.patch 一步挂载）。
+# 逐插件模式：走 registry npm 包单独 add（自带 dsh.bundle.patch 一步挂载）；
+# pnpm 11 下先预放行 node-pty 构建（与聚合模式同源，issue #24）。
 # 聚合模式：聚合包直接依赖已带 + bundle patch 已挂，单独 add 会 duplicate id——跳过。
 if [ "$AGGREGATE" != 1 ]; then
+  "$NODE_BIN" "$HERE/dsh-ccpg-one/bin/install.js" "$PROFILE" --prewrite
   if ! "$NODE_BIN" "$DSH_BIN" plugin --profile "$PROFILE" add "$SIDEBAR_SRC" >/dev/null 2>&1; then
     echo "⚠ dsh-better-sidebar 安装失败（官方 UI 工作流侧栏不可用；可稍后手动：dsh plugin --profile $PROFILE add $SIDEBAR_SRC）"
   else

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -24,6 +24,7 @@ run_suite dsh-plugins/dsh-ccpg-orchestrator/test '*.test.mjs'
 run_suite dsh-plugins/dsh-ccpg-llm-guard/test '*.test.mjs'
 run_suite dsh-plugins/dsh-ccpg-canvasui/test '*.test.mjs'
 run_suite dsh-plugins/dsh-ccpg-larkauth/test '*.test.mjs'
+run_suite dsh-plugins/dsh-ccpg-one/test '*.test.mjs'
 
 # document-preview 用 node --test runner
 echo "→ dsh-plugins/dsh-ccpg-document-preview/test"


### PR DESCRIPTION
## 背景

issue #24：`dsh plugin --profile X add dsh-ccpg-one` 在 pnpm 11 下以 `ERR_PNPM_IGNORED_BUILDS` 失败，且 pnpm 往 profile `pnpm-workspace.yaml` 写非法占位符 `node-pty: set this to true or false`，`pnpm approve-builds` 与重跑 install 全部堵死（实测重跑 exit=1、占位符原样、二进制缺失）——用户没有任何文档化自救路径。

## 根因链（三层）

1. **安装死锁**：`dsh plugin add` = profile 目录裸跑 pnpm 11；聚合依赖链 `dsh-ccpg-one → dsh-better-sidebar → node-pty`（原生构建）被 strict-dep-builds 拦截。包内 postinstall 自愈不可行（它本身也在被拦之列），唯一可靠位置是安装**之前**。
2. **聚合 patch 栈溢出**：防双挂载 `!!js` 表达式读取 `e.disabled`，disabled 求值期间经 loader evaluate 无限递归（getter → _disabled → evaluate → e.disabled → …）→ `Maximum call stack size exceeded`，双注册现场必现。
3. **上游同款缺陷 + duplicate route**：dsh-better-sidebar@0.16.1 自带 patch 的同款表达式有同样问题；且聚合层双 insert sidebar 会 `duplicate prefix route /sidebar/api`。结论：双向退让都不可靠，唯一稳态是**单点挂载**。

## 方案

- **新增 `npx dsh-ccpg-one [profile]` 安装入口**（包 bin）：先幂等归位占位符、预写 `allowBuilds: node-pty/protobufjs/koffi` 与 `minimumReleaseAgeExclude`（裸名，防 <24h 发布被 supply-chain 门二次拒绝），再调 `dsh plugin add`；`--prewrite` 子模式供 setup.sh 复用。可反复重跑，已中招的 profile 也能自愈。
- **聚合 patch 删除 sidebar insert 行**：挂载完全交给上游包自己的 bundle 层；`CCPG_NO_SIDEBAR` / `CCPG_ONLY_CORE` 的 sidebar 关闭改由安装器移除依赖实现。
- **依赖升级** dsh-better-sidebar 0.15.2 → 0.16.1（运行时 pty 自愈：激活时自动恢复 pnpm 剥掉的 spawn-helper 可执行位）；七子包 0.2.1 → 0.2.2。
- setup.sh 两模式 add 前跑同一预写。

## 验证（模拟 npm 用户，2026-08-25）

| 项 | 结果 |
|---|---|
| 对照组：全新 profile 装 0.2.1 | 复现 ERR + 占位符 ✅ |
| 治疗组：损坏 profile 跑 0.2.2 安装器 | 放行归位、node-pty 构建完成、bundles 注册 ✅ |
| node-pty 功能 | `fork('/bin/sh')` 输出捕获 pty-ok ✅ |
| boot | 无栈溢出 / 无 duplicate / 无 activation 失败 ✅ |
| 浏览器 | 官方 UI（canvasui 按钮、larkauth 面板）+ `/wf1/` 画布完整渲染（React Flow/迷你图/三页）+「打开工作流画布」→ 新 tab ✅ |
| API | `/wf1/api/workflows` 返回既有 3 个工作流（SQLite 链路） ✅ |
| 单测 | `npm test` 34 项全过（含新增安装器套件） ✅ |

Closes #24