### PR TITLE
fix(setup): --one 安装显式注册 better-sidebar 进 bundles，修 release 冒烟挂载

### DIFF
--- a/dsh-plugins/boot-smoke.sh
+++ b/dsh-plugins/boot-smoke.sh
@@ -63,8 +63,14 @@ code=$(probe "http://127.0.0.1:$PORT/wf1/")
 [ "$code" = "200" ] || { echo "✗ 独立画布 /wf1/ 非 200（$code）"; exit 1; }
 echo "✓ 独立画布 /wf1/ 200"
 
-# better-sidebar 真挂载：官方 UI HTML 引用其 client bundle（canvasui 的侧栏 tab 依赖它）
-if ! curl -s --max-time 5 "http://127.0.0.1:$PORT/" | grep -q "better-sidebar/client.js"; then
+# better-sidebar 真挂载：官方 UI HTML 引用其 client bundle（canvasui 的侧栏 tab 依赖它）。
+# UI 200 ≠ client-modules 注入完成（首载注入有延迟），同样放宽到 60s 重试。
+bs_ok=""
+for i in $(seq 1 30); do
+  if curl -s --max-time 5 "http://127.0.0.1:$PORT/" | grep -q "better-sidebar/client.js"; then bs_ok=1; break; fi
+  sleep 2
+done
+if [ -z "$bs_ok" ]; then
   echo "✗ 官方 UI 未加载 better-sidebar/client.js（上游 API 变更或挂载失败）"
   tail -20 "$SMOKE_ROOT/boot.log"
   exit 1

--- a/dsh-plugins/setup.sh
+++ b/dsh-plugins/setup.sh
@@ -164,6 +164,17 @@ if [ "$AGGREGATE" = 1 ]; then
     exit 1
   fi
   cat "$PLUGIN_LOG"
+  # 聚合 patch 已不 insert better-sidebar（挂载归上游包自己的 bundle 层，单点挂载），
+  # link: 安装又不会触发依赖包的 bundle 注册——必须单独 add 让它进 dsh.profile.bundles。
+  # pnpm 依赖去重：聚合包已声明同版本，此处 add 只做 bundle 注册不引入第二实体。
+  # （boot-smoke.sh 断言官方 UI 加载 better-sidebar/client.js，缺这步会直接挂。）
+  if ! "$NODE_BIN" "$DSH_BIN" plugin --profile "$PROFILE" add "$SIDEBAR_SRC" >"$PLUGIN_LOG" 2>&1; then
+    cat "$PLUGIN_LOG" >&2
+    echo "⚠ better-sidebar bundle 注册失败（官方 UI 工作流侧栏不可用；可稍后手动：dsh plugin --profile $PROFILE add $SIDEBAR_SRC）"
+  else
+    cat "$PLUGIN_LOG"
+    echo "✓ dsh-better-sidebar 已注册进 bundles（侧边栏工作台 + 工作流画布）"
+  fi
   # link: 安装时聚合包实体留在源码目录，loader 从 profile 根解析不到聚合 patch 挂载的
   # 子插件/better-sidebar——补链进 profile node_modules（npm 渠道 pnpm 会放实体，无需此步）。
   for pkg in $PLUGINS dsh-better-sidebar; do


### PR DESCRIPTION
## 背景

PR #26 把聚合 patch 的 sidebar insert 行去掉（单点挂载归上游 bundle 层）后，v0.2.2 的 release run 挂在 boot-smoke：`官方 UI 未加载 better-sidebar/client.js`。

根因：npm 渠道 `dsh plugin add dsh-ccpg-one` 会自动把声明 `dsh.bundle.patch` 的依赖包注册进 `dsh.profile.bundles`（已验证）；但 `setup.sh --one`（release tarball 渠道）里 better-sidebar 只是聚合包的传递依赖、从未单独 add，bundle 层不加载它的 patch → 侧栏不挂载。

## 方案

- `setup.sh --one`：聚合包 add 之后单独 `add "$SIDEBAR_SRC"`（vendor tgz/registry 同源；pnpm 依赖去重只多 bundle 注册，不引入第二实体；失败仅告警，与逐插件模式一致）
- `boot-smoke.sh`：client.js 注入检查放宽到 60s 重试——UI 返回 200 不等于 client-modules 注入完成，首载有延迟（本地复现：同二进制立即失败、等待后通过）

## 验证

- tarball 重走 `setup.sh --one` → profile bundles 为 `["dsh-base","dsh-web-app","dsh-ccpg-one","dsh-better-sidebar"]` ✅
- 手动启动：官方 UI HTML 引用 `better-sidebar/client.js` 且 GET 200 ✅
- `boot-smoke.sh` 端到端全绿（官方 UI 200 / 画布 200 / sidebar client 挂载）✅