### PR TITLE
fix(larkauth): 修侧边栏 footer 飞书入口与第三方图标并排、收起态与设置按钮不对齐

### DIFF
--- a/dsh-plugins/dsh-ccpg-larkauth/lib/client.js
+++ b/dsh-plugins/dsh-ccpg-larkauth/lib/client.js
@@ -200,17 +200,31 @@ window.__ModuleLoader__.load({
 			link: { fontSize: "13px", color: "var(--dsw-alias-accent-bg, #4F46E5)" },
 		};
 
-		// 状态点全局样式：注入一次（官方 UI 无此类名约定）
-		function ensureDotStyle() {
-			if (document.getElementById("larka-dot-style")) return;
-			var css = ".larka-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0;background:#9CA3AF}"
-				+ ".larka-dot.ok{background:#10B981;box-shadow:0 0 6px rgba(16,185,129,.5)}"
-				+ ".larka-dot.warn{background:#F59E0B;box-shadow:0 0 6px rgba(245,158,11,.5)}";
-			var el = document.createElement("style");
-			el.id = "larka-dot-style";
-			el.textContent = css;
-			document.head.appendChild(el);
-		}
+	// 全局样式：注入一次（官方 UI 无此类名约定）。
+	// larka-entry 几何逐项对齐官方设置触发器（ui-settings-general VOzbGW_trigger）：
+	// 宽态 42px 满行 12px 圆角、收起态 36px 圆——两态都与「设置」按钮同轴。
+	// footerActions 官方是横向 flex：多个 footer.action 注册者（如 dsh-remote-web-ui）
+	// 会并排挤一行。slot anchor 是 display:contents（不参与布局），真正的 flex 上下文
+	// 是 anchor 的父容器；这里用 :has() 命中「含有本入口的 footerActions 容器」，
+	// 改为纵向堆叠——每个 footer 图标独占一行，与设置按钮同宽对齐。
+	function ensureDotStyle() {
+		if (document.getElementById("larka-dot-style")) return;
+		var css = ".larka-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0;background:#9CA3AF}"
+			+ ".larka-dot.ok{background:#10B981;box-shadow:0 0 6px rgba(16,185,129,.5)}"
+			+ ".larka-dot.warn{background:#F59E0B;box-shadow:0 0 6px rgba(245,158,11,.5)}"
+			+ ".larka-entry{box-sizing:border-box;cursor:pointer;width:calc(100% + 4px);height:42px;"
+			+ "color:var(--dsw-alias-label-primary);background:0 0;border:none;border-radius:12px;"
+			+ "flex:none;align-items:center;justify-content:flex-start;gap:8px;margin:4px -2px;"
+			+ "padding:0 10px 0 8px;font-family:inherit;font-size:14px;line-height:22px;"
+			+ "display:flex;overflow:hidden;white-space:nowrap}"
+			+ ".larka-entry:hover{background:var(--dsw-alias-interactive-bg-hover)}"
+			+ ".larka-entry.larka-rail{border-radius:50%;justify-content:center;gap:0;width:36px;height:36px;margin:8px 0 10px;padding:0}"
+			+ ":has(> [data-slot=\"sidebar.footer.action\"] .larka-entry){display:flex;flex-direction:column}";
+		var el = document.createElement("style");
+		el.id = "larka-dot-style";
+		el.textContent = css;
+		document.head.appendChild(el);
+	}
 
 		// ---- 侧边栏 footer 入口：点击打开设置面板 ----
 		// settings 面板由官方 ui-settings 打开；这里用官方入口同款方式：派发打开设置后切换到本 section。
@@ -230,24 +244,11 @@ window.__ModuleLoader__.load({
 			};
 			var label = st[0] && st[0].user && st[0].user.tokenStatus === "valid"
 				? "飞书 " + (st[0].user.userName || "已登录") : "飞书账号";
+			// 几何走 larka-entry/larka-rail 类（见 ensureDotStyle）：与官方设置按钮逐项同款
 			return react.createElement("button", {
 				onClick: openSettings,
 				title: "飞书账号授权（lark-cli 扫码登录）",
-				style: {
-					display: "inline-flex", alignItems: "center", justifyContent: "center", gap: "8px",
-					width: wide ? "auto" : "36px",
-					alignSelf: wide ? "stretch" : "center",
-					height: "36px", margin: wide ? "2px 0 2px -4px" : "2px 0",
-					padding: wide ? "0 12px" : "0",
-					border: "1px solid transparent", borderRadius: wide ? "10px" : "50%",
-					background: "transparent", color: "inherit",
-					fontSize: "14px", cursor: "pointer", whiteSpace: "nowrap", overflow: "hidden",
-					transition: "background .15s ease",
-				},
-				onMouseEnter: (e) => { e.currentTarget.style.background = "var(--dsw-alias-interactive-bg-hover, rgba(0,0,0,.06))"; },
-				onMouseLeave: (e) => { e.currentTarget.style.background = "transparent"; },
-				onMouseDown: (e) => { e.currentTarget.style.transform = "scale(.97)"; },
-				onMouseUp: (e) => { e.currentTarget.style.transform = ""; },
+				className: wide ? "larka-entry" : "larka-entry larka-rail",
 			},
 				react.createElement("span", { className: dotClass(st[0]) }),
 				wide ? react.createElement("span", null, label) : null);


### PR DESCRIPTION
## 背景

Fixes #29

dsh 主界面侧边栏 footer 的飞书账号入口存在两个布局问题：

1. **与其他插件图标并排**：官方 ui-sidebar 的 `footerActions` 容器是横向 flex（`display:flex` 无 column），多个 `sidebar.footer.action` 注册者（本机实测为 dsh web ui 的 `dsh-remote-web-ui` 手机遥控入口，36px 圆 trigger；官方 ui-cordis 的 cordis-panel 也是潜在注册者）会并排挤在同一行。
2. **收起态与设置按钮不对齐**：原入口用 inline style 自定几何（36px 高、宽态不满行），与官方设置触发器（宽态 42px 满行 / 收起态 36px 圆）不同轴。

## 方案

`dsh-plugins/dsh-ccpg-larkauth/lib/client.js`：

- 入口按钮改为 `larka-entry` / `larka-rail` 类，几何逐项对齐官方设置触发器（ui-settings-general `VOzbGW_trigger`）：宽态 `calc(100% + 4px)` × 42px、12px 圆角、`margin: 4px -2px`；收起态 36px 圆居中——两态都与「设置」按钮同轴。
- 注入 `:has(> [data-slot="sidebar.footer.action"] .larka-entry)` 规则把含有本入口的 footerActions 容器改为 `flex-direction: column`：每个 footer 图标独占一行。关键认知：slot anchor 是 `display: contents` 不参与布局，真正的 flex 上下文是 anchor 的**父容器**，所以 `:has` 必须命中容器本身（第一版写成命中 anchor 已在实测中证伪并修正）。
- hover 态改用 CSS 类 `var(--dsw-alias-interactive-bg-hover)`，替换原 inline JS 改背景色的写法（与官方主题变量一致）。

## 验证（本地真实浏览器，127.0.0.1:4021 + Playwright DOM 断言）

| 场景 | 结果 |
|---|---|
| 宽态几何 | 飞书按钮与设置按钮同左缘（x=10）同宽（260px）同高（42px） |
| 多注册者堆叠 | 注入第二 footer entry 模拟 dsh-remote-web-ui：容器 `flexDirection=column`，两图标纵向堆叠，不再并排 |
| 收起态对齐 | 36px 圆，中心点 cx=28 与设置按钮完全一致 |
| 点击功能 | 宽/窄两态点击均打开设置面板，飞书账号 section 可见 |
| 单测 | `scripts/run-tests.sh` 全量通过 |

修复前（宽态，注入第二图标复现并排）：

> lark (x=8,y=775,w=98) ⚡ (x=106,y=773) —— 同一行并排

修复后：

> lark (x=10,w=260,h=42) ⚡ (x=12,y=833) —— 纵向堆叠；lark 与 settings (x=10,w=260,h=42) 完全同轴

## 备注

- 验证过程中顺带修复了本机 `~/.dsh/.credentials.yaml` 旧版嵌套格式（`version:`/`refs:`）导致 dsh 0.1.x credentials-local 启动崩溃的问题（平铺重建，原文件备份为 `.credentials.yaml.bak-issue29`）——与本项目无关，仅记录。