### PR TITLE
fix(ci): 避免 squash 合并后重复运行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,18 @@
 name: ci
 
-# PR 与 main push 的门禁：全量单测 + 前端双构建验证。
+# PR 门禁：全量单测 + 前端双构建验证。
 # 单测 = scripts/run-tests.sh（根 npm test 同源，零依赖 node:assert）；
 # 构建只验证能产出（产物不入库，release 打包仍走 release.yml 的 pack.sh）。
 
 on:
   pull_request:
-  push:
-    branches: [main]
 
 permissions:
   contents: read
+
+concurrency:
+  group: ci-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   test-and-build:


### PR DESCRIPTION
## 背景

PR 已通过全量 CI 后，squash merge 到 main 会再次运行同一套测试与构建，浪费约 3 分钟 Actions 时间。

## 方案

- CI 仅由 pull_request 触发
- 同一 PR 推送新提交时取消旧的进行中任务
- main Ruleset 强制 PR，并要求 test + build 通过，直接 push 不再作为漏检入口

## 验证

- ci.yml YAML 解析通过
- git diff --check 通过
- Ruleset 已确认审批数 0、必需状态检查为 test + build、无需基于最新 main 重跑
