### PR TITLE
fix(web): 修复工作流导入导出异常

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "test:variables": "node src/variables.test.mjs && node src/global-variables.test.mjs && node src/json-response.test.mjs && node src/api-base.test.mjs && node src/trial-request.test.mjs && node src/variable-scope.test.mjs && node src/run-event-routing.test.mjs && node src/workflow-serialization.test.mjs",
     "test:results": "node src/result-adapter.test.mjs",
     "test:scripts": "node src/script-parameters.test.mjs",
-    "test:ui": "node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs && node src/notify-node.test.mjs"
+    "test:ui": "node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs && node src/notify-node.test.mjs && node src/workflow-transfer-ui.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/web/src/WorkflowList.jsx
+++ b/web/src/WorkflowList.jsx
@@ -1,6 +1,7 @@
 // 工作流列表页：搜索 + 复制 + 导出/导入 JSON + 打开/重命名/删除（弹窗替代原生 prompt/confirm）。
 
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { Download, Upload } from 'lucide-react';
 import { apiUrl } from './api.js';
 import { createWorkflowDocument } from './workflow-serialization.js';
 import { useToast, PromptModal, ConfirmModal } from './ui.jsx';
@@ -61,21 +62,42 @@ export function WorkflowList({ currentId, onOpen, onNew }) {
     if (res.ok) { toast('已创建副本', 'success'); load(); }
   };
 
-  const exportWf = (wf) => {
-    const a = document.createElement('a');
-    a.href = apiUrl(`/workflows/transfer?id=${encodeURIComponent(wf.id)}`);
-    a.download = `${wf.name}.workflow-one.json`;
-    a.click();
+  const exportWf = async (wf) => {
+    setBusy(true);
+    try {
+      const res = await fetch(apiUrl(`/workflows/transfer?id=${encodeURIComponent(wf.id)}`));
+      if (!res.ok) {
+        const out = await res.json().catch(() => ({}));
+        throw new Error(out.error || `请求失败（HTTP ${res.status}）`);
+      }
+      if (!res.headers.get('content-type')?.includes('application/json')) {
+        throw new Error('服务返回的不是工作流 JSON');
+      }
+      const url = URL.createObjectURL(await res.blob());
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${wf.name}.workflow-one.json`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+      toast(`已导出「${wf.name}」`, 'success');
+    } catch (err) {
+      toast(`导出失败：${err.message}`, 'error');
+    } finally {
+      setBusy(false);
+    }
   };
 
   const importWf = async (e) => {
     const file = e.target.files?.[0];
     e.target.value = '';
     if (!file) return;
+    setBusy(true);
     try {
       const text = await file.text();
-      const data = JSON.parse(text);
-      if (!data?.graph?.nodes) throw new Error('格式不对：需要 workflow-one 导出文件（含 graph.nodes）');
+      let data;
+      try { data = JSON.parse(text); } catch { throw new Error('文件不是有效的 JSON'); }
       const res = await fetch(apiUrl('/workflows/transfer'), {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
@@ -84,8 +106,11 @@ export function WorkflowList({ currentId, onOpen, onNew }) {
       if (!res.ok) throw new Error(out.error || '导入失败');
       toast(`已导入「${out.name}」${out.warnings ? `（${out.warnings} 条警告）` : ''}`, 'success');
       load();
+      await onOpen?.(out);
     } catch (err) {
       toast(`导入失败：${err.message}`, 'error');
+    } finally {
+      setBusy(false);
     }
   };
 
@@ -94,7 +119,9 @@ export function WorkflowList({ currentId, onOpen, onNew }) {
       <div className="wf-list-head">
         <h3>我的工作流 <span className="sec-hint">{list.length} 个</span></h3>
         <input className="wf-search" placeholder="搜索名称…" value={query} onChange={(e) => setQuery(e.target.value)} />
-        <button className="btn btn-sm" onClick={() => importRef.current?.click()}>导入</button>
+        <button className="btn btn-sm" disabled={busy} onClick={() => importRef.current?.click()}>
+          <Upload size={14} aria-hidden="true" />导入
+        </button>
         <input ref={importRef} type="file" accept=".json" style={{ display: 'none' }} onChange={importWf} />
         <button className="btn btn-primary btn-sm" disabled={busy} onClick={createNew}>＋ 新建</button>
       </div>
@@ -113,7 +140,9 @@ export function WorkflowList({ currentId, onOpen, onNew }) {
             <div className="wf-card-actions">
               <button className="btn-icon" title="打开" onClick={() => onOpen(wf)}>↗</button>
               <button className="btn-icon" title="复制副本" onClick={() => duplicate(wf)}>⧉</button>
-              <button className="btn-icon" title="导出 JSON" onClick={() => exportWf(wf)}>⬇</button>
+              <button className="btn-icon" title="导出工作流" aria-label={`导出「${wf.name}」`} disabled={busy} onClick={() => exportWf(wf)}>
+                <Download size={15} aria-hidden="true" />
+              </button>
               <button className="btn-icon" title="重命名" onClick={() => rename(wf)}>✏️</button>
               <button className="btn-icon" title="删除" onClick={() => remove(wf)}>🗑</button>
             </div>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -898,6 +898,14 @@ body {
 .wf-card-meta { font-size: 12px; color: var(--fg-faint); margin-top: 3px; }
 .wf-card-actions { display: flex; gap: 2px; }
 
+@media (max-width: 520px) {
+  .wf-view { padding: 20px 16px; }
+  .wf-list-head { flex-wrap: wrap; }
+  .wf-list-head h3 { flex-basis: 100%; }
+  .wf-search { flex: 1; width: auto; min-width: 0; }
+  .wf-list-head .btn { white-space: nowrap; }
+}
+
 /* ============ toast ============ */
 .toast-wrap {
   position: fixed; right: 18px; bottom: 18px; z-index: 999;

--- a/web/src/workflow-transfer-ui.test.mjs
+++ b/web/src/workflow-transfer-ui.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('./WorkflowList.jsx', import.meta.url), 'utf8');
+const styles = readFileSync(new URL('./styles.css', import.meta.url), 'utf8');
+
+assert.doesNotMatch(source, /data\?\.graph\?\.nodes/);
+assert.match(source, /if \(!res\.ok\)/);
+assert.match(source, /URL\.createObjectURL\(await res\.blob\(\)\)/);
+assert.match(source, /await onOpen\?\.\(out\)/);
+assert.match(styles, /@media \(max-width: 520px\)[\s\S]*\.wf-list-head \{ flex-wrap: wrap; \}[\s\S]*\.wf-list-head \.btn \{ white-space: nowrap; \}/);
+
+console.log('workflow transfer UI tests: passed');


### PR DESCRIPTION
## 背景

工作流导入前端校验与后端兼容契约冲突，旧版裸图无法从 UI 导入；导出也未检查 HTTP 状态，失败时缺少反馈。

## 方案

- 移除前端重复格式校验，由后端统一验证并兼容旧版裸图
- 导出检查 HTTP 状态和 JSON 内容类型后再生成下载
- 导入/导出显示成功或失败提示，操作期间防重复点击
- 导入成功后自动打开工作流
- 修复窄屏列表头按钮被挤成竖排的问题

## 验证

- `cd web && npm test`
- `node dsh-plugins/dsh-ccpg-orchestrator/test/workflow-document.test.mjs`（7/7）
- `sh dsh-plugins/build-web.sh`
- 浏览器验证：旧版裸图导入、自动打开、导出成功/500 失败反馈、390px 无横向溢出

Closes #33