### PR TITLE
feat: 工作流并发运行、运行切换与定时任务管理 (#35)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,7 @@ CI：`.github/workflows/ci.yml` 在 PR 与 main push 上跑 `npm test` + `build-
 4. **工作区本地存储**：工作流与运行记录位于当前 dsh 会话工作目录的 `.workflow-one/workflow-one.sqlite`；state/attachments/runtime 继续使用同目录下文件。节点 agent 以工作区根为 cwd、成果只收集各节点 runtime 输出目录；`.workflow-one/` 必须 gitignore，**绝不提交**。飞书凭据仍是 dsh 用户级数据，不迁入工作区。
 5. **构建产物一律不入库**（`web-dist/`、`canvasui lib/client.js`、`document-preview/dist/`、`web/dist/` 全部 gitignore）：分发包「拿到即装」由 `pack.sh` 现场重跑构建保证；源码安装先 `build-web.sh` 再 `setup.sh`（setup 已前置校验）。绝不为省一步构建把产物提交进仓库。
 6. **消息通知走渠道抽象**：运行级事件、去重、模式判断、摘要脱敏与失败隔离统一放在 `orchestrator/lib/notifications.js`；渠道实现只放 `notification-<channel>.js`，负责配置校验、消息渲染和发送。新增钉钉/企业微信时注册 provider 到 `NotificationChannelRegistry`，并通过 `/wf1/api/tools` 的 `notificationChannels` 暴露给前端；禁止复制运行监听器或在前端写死完整渠道清单。通知失败只能写节点 `notification` 元数据，不能改变业务运行状态。
+7. **多运行并发 + 定时任务**：引擎天然多运行（`Orchestrator.runs` Map，runId 全链路隔离），前端查看态以 `inspectedRunId` 为单一事实源（RunSwitcher 胶囊切换），不要回退到单活跃 run 模型；run-start 只跟随本画布发起的运行，schedule/webhook 触发不抢占视图。定时调度核心在 `orchestrator/lib/schedule.js`（cron/overlap/统计），meta 持久化在 `state/triggers.json`（不迁 SQLite）；前端面板 `web/src/ScheduleCenter.jsx` + `describeCron`。
 
 ### 消息通知节点约束
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,11 @@ sh start.sh dev
 - **脚本节点**：QuickJS 沙箱执行同步 `function main(input, workspace)` 返回 JSON。命名参数支持「表达式」（完整变量，仅直接上游）或「JSON 常量」；workspace 仅可 list/read/write/remove 本节点目录（拒绝穿越/反斜杠/符号链接）；超时 100–10000ms；可选 outputSchema 校验（失败即节点失败）；返回值进变量树
 - **变量系统**：模板编辑器（输入 `{{` 或 `/变量` 搜索字段树）覆盖全部模板位；稳定 ID 引用 `{{node["n_http_1"].data.json.customer.name}}`、缺省值 `| default("x")`、`{{$trigger}}` / `{{$upstream}}`；改名联动全图替换；旧 `{{节点名}}` 语法兼容
 - **运行与调试**：SSE 实时状态（queued/running/success/error/skipped）；就绪即发并发调度；分支容错（单支失败不拖垮其余）；节点重试 / 失败继续 / 超时；运行取消 / 重放 / 导出；试运行（手填假输入、关闭即中断）；节点级运行详情（实际输入、产物、token 用量、trace）
+- **多运行并发**：同一工作流可同时运行多个实例（节点工作区 / 产物 / 日志 / 取消按 runId 互不干扰）；成果面板顶部运行胶囊条随时切换查看任一运行（LIVE 优先、含来源图标与实时进度），画布节点状态随选中运行联动；定时 / Webhook 触发的运行不抢占当前视图，以 toast + 胶囊提示
 - **结果面板**：时间线按图拓扑稳定排序（跳过分支也可见）；最终结果取输出节点、失败不被中间结果顶替；过程产物折叠分组；产物流式下载（Range 206 / 统一 MIME / HTML sandbox CSP）与全屏预览（PDF/DOCX/XLS(X)/PPTX 本地渲染）
 - **消息通知节点**：运行级观察器，可独立放置或在线路中透传；支持仅运行结束、每个业务节点完成两种模式；当前通过飞书消息卡片推送到群聊或私聊，渠道层可继续扩展钉钉和企业微信
-- **触发与集成**：webhook（token 鉴权）、cron 定时、飞书写回（输出节点可选）
-- **持久化**：工作流库（命名工作流 CRUD）、运行历史（含 graph 快照）、重启恢复（触发器落盘 + 链式定时等待）
+- **触发与集成**：webhook（token 鉴权）、cron 定时（画布「⋯ → 定时任务」可视化管理：预设 + 自定义表达式、下 3 次触发预览、重叠策略可选跳过/并行、立即运行、停用与编辑）、飞书写回（输出节点可选）
+- **持久化**：工作流库（命名工作流 CRUD）、运行历史（含 graph 快照）、重启恢复（触发器落盘 + 链式定时等待，含触发/跳过统计）
 - **可靠性**：保存失败 toast 报错并中止运行；命名工作流运行带 graphFingerprint 指纹校验（409 拒绝跑错版本）
 
 ## 画布 AI 助手
@@ -147,7 +148,7 @@ sh start.sh dev
 | 运行 | `POST /run`、`POST /run/cancel`、`GET /runs`、`GET /runs/detail`、`GET /runs/export`、`POST /runs/replay`、`GET /run-results`、`GET /run-artifact` |
 | 节点 | `POST /node/test`（试运行）、`GET /node-detail` |
 | 产物 | `GET /artifact`（节点工作区文件，支持 preview/Range）、`GET/POST /attachments` |
-| 触发 | `GET/POST/DELETE /hooks`（webhook，token 鉴权）、`GET/POST/DELETE /schedule`（cron） |
+| 触发 | `GET/POST/DELETE /hooks`（webhook，token 鉴权）、`GET/POST/PATCH/DELETE /schedule`（cron，含 overlap/启停）、`POST /schedule/preview`（下 3 次触发）、`POST /schedule/run`（立即运行） |
 | 变量/模板 | `GET /variables/describe`、`GET/POST /global-variables`、`POST /template/render`、`POST /template/validate` |
 | 配置 | `GET /tools`、`GET /skills`、`GET /llm-config`、`GET/POST /runtime-config`、`GET/POST/DELETE /feishu-credentials`、`GET/POST /lark-auth` |
 | AI 助手 | `POST /assistant/bind` / `unbind`、`GET /assistant/canvas-state` |

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
@@ -177,7 +177,8 @@ export class Orchestrator {
 
     this.emit('run-start', {
       runId: id, nodeIds: graph.nodes.map((n) => n.id),
-      workflowId: run.workflowId, canvasId: run.canvasId, source: run.source,
+      workflowId: run.workflowId, workflowName: run.workflowName,
+      canvasId: run.canvasId, source: run.source,
     });
     s._done = new Promise((resolve) => { s.resolve = resolve; });
     this._pump(s);

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -64,10 +64,10 @@ import {
   assertNonSensitiveVariableDefinitions, assertSafeContextObject, GlobalVariableStore, VariableStoreError,
   variableDefinitionsToValues,
 } from './variable-store.js';
-import cronParser from 'cron-parser';
-// cron-parser@4：默认导出是命名空间对象（CJS interop），parseExpression 是其方法
-const parseCronExpression = cronParser.parseExpression?.bind(cronParser)
-  ?? cronParser.default?.parseExpression?.bind(cronParser.default);
+import {
+  createScheduler, hasLiveRunForWorkflow, isValidCron, normalizeScheduleMeta,
+  persistableScheduleMeta, upcomingFireTimes,
+} from './schedule.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 // 测试可用 WF1_LEGACY_DATA_DIR 指向隔离目录，避免把开发机真实 data/ 当 legacy 导入。
@@ -209,6 +209,13 @@ export function apply(ctx, config) {
   const currentSchedulers = () => currentStore().schedulers;
   const currentSchedulerMeta = () => currentStore().schedulerMeta;
   ctx.effect?.(() => () => {
+    // 先摘调度定时器（链式 setTimeout 不随插件停机自灭），再关 sqlite
+    for (const store of stores.values()) {
+      for (const scheduler of store.schedulers.values()) {
+        try { scheduler.stop(); } catch { /* 单个失败不阻塞清理 */ }
+      }
+      store.schedulers.clear();
+    }
     for (const store of stores.values()) store.database.close();
     stores.clear();
   }, 'workflow-one sqlite stores');
@@ -1711,9 +1718,9 @@ export function apply(ctx, config) {
     });
   } });
 
-  // ---- webhook + 定时触发（落盘 data/triggers.json，重启自动恢复）----
+  // ---- webhook + 定时触发（落盘 state/triggers.json，重启自动恢复）----
   // hooks: [{ id, token, workflowId, workflowName, createdAt }]
-  // schedules: [{ key, workflowId, workflowName, cron, input, createdAt }]
+  // schedules meta 字段见 lib/schedule.js normalizeScheduleMeta
   const loadTriggers = () => {
     const store = currentStore();
     if (store.triggersLoaded) return { hooks: [...store.hooks.values()], schedules: [...store.schedulerMeta.values()] };
@@ -1724,6 +1731,10 @@ export function apply(ctx, config) {
         store.hooks.set(h.id, h);
         publicHooks.set(h.id, { store, hook: h });
       }
+      for (const s of t.schedules || []) {
+        const meta = normalizeScheduleMeta(s);
+        if (meta.key) currentSchedulerMeta().set(meta.key, { ...meta, ...s });
+      }
       return t;
     } catch { return { hooks: [], schedules: [] }; }
   };
@@ -1733,9 +1744,7 @@ export function apply(ctx, config) {
       const store = currentStore();
       atomicJson(store.triggersFile, {
         hooks: [...currentHooks().values()].map(({ id, token, workflowId, workflowName, createdAt }) => ({ id, token, workflowId, workflowName, createdAt })),
-        schedules: [...currentSchedulerMeta().entries()].map(([key, m]) => ({
-          key, workflowId: m.workflowId, workflowName: m.workflowName, cron: m.cron, input: m.input, createdAt: m.createdAt,
-        })),
+        schedules: [...currentSchedulerMeta().entries()].map(([key, m]) => persistableScheduleMeta({ ...m, key })),
       });
     } catch { /* 落盘失败不影响运行 */ }
   };
@@ -1814,92 +1823,158 @@ export function apply(ctx, config) {
   } }, { scoped: false });
 
   // ---- 定时触发 ----
-  // POST /wf1/api/schedule { workflowId, cron, input? } —— cron-parser 算下次触发，ctx.timer.timeout 链式调度
+  // POST /wf1/api/schedule { workflowId, cron, input?, runInputs?, overlap? }
+  // 调度核心在 lib/schedule.js（computeNextDelay + 链式 setTimeout + overlap 策略）
+  const scheduleStoreRoot = () => currentStore().workspaceRoot;
+  const scheduleBusy = (workflowId) => hasLiveRunForWorkflow(orch.runs, scheduleStoreRoot(), workflowId);
+  // 触发一次定时运行（fire 与手动「立即运行」共用）：读最新图 + 实例变量，返回 runId 或 null
+  const fireScheduleRun = (meta) => {
+    const wf = readWf(meta.workflowId);
+    if (!wf) return null;
+    let globals;
+    try { globals = globalContext(); } catch (error) {
+      ctx.logger?.warn?.(`dsh-ccpg 定时运行变量加载失败（${meta.key}）：${error.message}`);
+      globals = { globalVariables: {} };
+    }
+    const { runId } = startRun(wf.graph, {
+      triggerInput: meta.input || '', workflowName: wf.name, workflowId: wf.id, source: 'schedule',
+      globalVariables: globals.globalVariables,
+      workflowVariables: variableDefinitionsToValues(wf.variables),
+      runInputs: meta.runInputs && typeof meta.runInputs === 'object' ? meta.runInputs : {},
+    });
+    return runId;
+  };
   const startSchedule = (key, meta) => {
-    const state = { stopped: false, timer: null, rawTimer: null, nextAt: null, fireCount: 0 };
-    const armNext = () => {
-      if (state.stopped) return;
-      let nextMs = 1;
-      try {
-        nextMs = Math.max(1, parseCronExpression(meta.cron, { currentDate: new Date() }).next().getTime() - Date.now());
-      } catch (e) {
-        state.stopped = true;
-        ctx.logger?.warn?.(`dsh-ccpg 定时表达式无效（${key}）：${e.message}`);
-        return;
-      }
-      state.nextAt = new Date(Date.now() + nextMs).toISOString();
-      currentSchedulerMeta().set(key, { ...meta, nextAt: state.nextAt, fireCount: state.fireCount });
-      const fire = () => {
-        if (state.stopped) return;
-        state.fireCount += 1;
-        const wf = readWf(meta.workflowId);
-        if (wf) {
-          try {
-            const globals = globalContext();
-            startRun(wf.graph, {
-              triggerInput: meta.input || '', workflowName: wf.name, workflowId: wf.id, source: 'schedule',
-              globalVariables: globals.globalVariables,
-              workflowVariables: variableDefinitionsToValues(wf.variables),
-              runInputs: {},
-            });
-          } catch (error) { ctx.logger?.warn?.(`dsh-ccpg 定时运行变量加载失败（${key}）：${error.message}`); }
-        }
-        armNext();
-      };
-      // setTimeout 上限 2^31-1 ms（约 24.8 天）：远期任务链式分段等待，避免溢出成 1ms 风暴
-      const MAX_WAIT = 2 ** 31 - 1;
-      if (nextMs > MAX_WAIT) {
-        state.rawTimer = setTimeout(armNext, Math.floor(MAX_WAIT / 2));
-        return;
-      }
-      state.rawTimer = setTimeout(fire, nextMs);
-    };
-    armNext();
-    return {
-      stop() {
-        state.stopped = true;
-        if (state.rawTimer) clearTimeout(state.rawTimer);
-        try { state.timer?.(); } catch { /* disposer 已失效 */ }
+    const entry = createScheduler({
+      meta: { ...meta, key },
+      now: () => Date.now(),
+      fire: () => fireScheduleRun(meta),
+      isBusy: () => scheduleBusy(meta.workflowId),
+      logger: ctx.logger,
+      onMeta: (live) => {
+        // 只更新统计/nextAt，创建时字段以 meta Map 为准（PATCH 可能已改 cron 等）
+        const current = currentSchedulerMeta().get(key) || { ...meta, key };
+        currentSchedulerMeta().set(key, { ...current, ...live, key });
       },
-    };
+    });
+    return entry;
+  };
+  // 手动「立即运行」：不受 overlap/enabled 限制，不干扰调度链
+  const runScheduleNow = (key) => {
+    const prev = currentSchedulerMeta().get(key);
+    if (!prev) return { ok: false, error: '任务不存在' };
+    const runId = fireScheduleRun(prev);
+    if (!runId) return { ok: false, error: '工作流已删除或启动失败' };
+    const nextMeta = { ...prev, fireCount: (prev.fireCount || 0) + 1 };
+    currentSchedulerMeta().set(key, nextMeta);
+    persistTriggers();
+    return { ok: true, runId };
   };
   ensureTriggers = () => {
     const store = currentStore();
     const saved = loadTriggers();
     if (store.triggersRestored) return;
     store.triggersRestored = true;
-    for (const meta of saved.schedules || []) {
+    for (const raw of saved.schedules || []) {
+      const meta = normalizeScheduleMeta(raw);
+      if (!meta.key) continue;
       if (!readWf(meta.workflowId)) continue;
+      const persisted = { ...meta, ...raw };
+      currentSchedulerMeta().set(meta.key, persisted);
+      // 停用任务只入 meta 不起定时器：启用时（PATCH）再挂
+      if (persisted.enabled === false) continue;
       try {
-        currentSchedulers().set(meta.key, startSchedule(meta.key, meta));
-        currentSchedulerMeta().set(meta.key, meta);
+        currentSchedulers().set(meta.key, startSchedule(meta.key, persisted));
       } catch { /* 单条失败不阻塞 */ }
     }
   };
 
+  // 列表行：实时 join 工作流现名（meta 里的名字是创建时快照，改名后仅作 fallback）。
+  // 统计以 meta Map 为准（fireNow 等手动路径直接改 Map），调度器仅补 nextAt。
+  const scheduleRows = () => {
+    const rows = [];
+    for (const [key, meta] of currentSchedulerMeta()) {
+      const wf = readWf(meta.workflowId);
+      const live = currentSchedulers().get(key)?.getMeta?.() || {};
+      rows.push({
+        ...meta,
+        nextAt: live.nextAt ?? meta.nextAt ?? null,
+        key,
+        workflowName: wf?.name || meta.workflowName || '(已删除)',
+        workflowMissing: !wf,
+        enabled: meta.enabled !== false,
+      });
+    }
+    rows.sort((a, b) => String(a.createdAt || '').localeCompare(String(b.createdAt || '')));
+    return rows;
+  };
+
   register({ kind: 'exact', path: '/wf1/api/schedule', async handler(req, res) {
     if (req.method === 'GET') {
-      const rows = [];
-      for (const [key, meta] of currentSchedulerMeta()) rows.push({ ...meta, key });
-      return json(res, 200, { schedules: rows });
+      ensureTriggers();
+      return json(res, 200, { schedules: scheduleRows() });
     }
     if (req.method === 'POST') {
       const body = await readBody(req);
       const wf = readWf(body?.workflowId);
       if (!wf) return json(res, 404, { error: '工作流不存在' });
       if (!body?.cron) return json(res, 400, { error: '需要 cron 表达式（5 段）' });
-      try {
-        parseCronExpression(body.cron, { currentDate: new Date() });
-      } catch (e) {
-        return json(res, 400, { error: `cron 表达式无效：${e.message}` });
+      if (!isValidCron(body.cron)) return json(res, 400, { error: 'cron 表达式无效' });
+      let runInputs = {};
+      try { runInputs = assertSafeContextObject(body?.runInputs, 'runInputs'); } catch (error) { return routeError(res, error); }
+      if (body?.overlap && !['skip', 'parallel'].includes(body.overlap)) {
+        return json(res, 400, { error: 'overlap 仅支持 skip / parallel' });
       }
       const key = `sch_${randomUUID().slice(0, 8)}`;
-      const meta = { workflowId: wf.id, workflowName: wf.name, cron: body.cron, input: body.input || '', createdAt: new Date().toISOString() };
-      const entry = startSchedule(key, meta);
-      currentSchedulers().set(key, entry);
+      const meta = normalizeScheduleMeta({
+        key,
+        workflowId: wf.id,
+        workflowName: wf.name,
+        cron: body.cron,
+        input: body.input || '',
+        runInputs,
+        overlap: body.overlap || 'skip',
+        enabled: true,
+        createdAt: new Date().toISOString(),
+      });
       currentSchedulerMeta().set(key, meta);
+      // 先入 meta 再启动：createScheduler 的 onMeta 会同步补 nextAt/统计
+      currentSchedulers().set(key, startSchedule(key, meta));
       persistTriggers();
-      return json(res, 200, { ok: true, key, cron: body.cron });
+      return json(res, 200, { ok: true, key, cron: body.cron, overlap: meta.overlap });
+    }
+    if (req.method === 'PATCH') {
+      const body = await readBody(req);
+      const key = body?.key || '';
+      const prev = currentSchedulerMeta().get(key);
+      if (!prev) return json(res, 404, { error: '任务不存在' });
+      const patch = {};
+      if (hasOwn(body, 'cron')) {
+        if (!isValidCron(body.cron)) return json(res, 400, { error: 'cron 表达式无效' });
+        patch.cron = body.cron;
+      }
+      if (hasOwn(body, 'input')) patch.input = body.input || '';
+      if (hasOwn(body, 'overlap')) {
+        if (!['skip', 'parallel'].includes(body.overlap)) return json(res, 400, { error: 'overlap 仅支持 skip / parallel' });
+        patch.overlap = body.overlap;
+      }
+      if (hasOwn(body, 'runInputs')) {
+        try { patch.runInputs = assertSafeContextObject(body?.runInputs, 'runInputs'); } catch (error) { return routeError(res, error); }
+      }
+      if (hasOwn(body, 'enabled')) patch.enabled = body.enabled !== false;
+      const next = { ...prev, ...patch };
+      // 配置或启用状态变化 → 重挂调度链（停用则摘掉定时器、nextAt 置空，meta 保留）
+      const scheduler = currentSchedulers().get(key);
+      if (scheduler) scheduler.stop();
+      currentSchedulers().delete(key);
+      currentSchedulerMeta().set(key, next);
+      if (next.enabled !== false) {
+        currentSchedulers().set(key, startSchedule(key, next));
+      } else {
+        next.nextAt = null;
+      }
+      persistTriggers();
+      return json(res, 200, { ok: true, key });
     }
     if (req.method === 'DELETE') {
       const url = new URL(req.url, 'http://x');
@@ -1912,6 +1987,28 @@ export function apply(ctx, config) {
       return json(res, 200, { ok: true });
     }
     json(res, 405, { error: 'method' });
+  } });
+
+  // cron 预览：创建/编辑表单实时显示接下来几次触发时间
+  register({ kind: 'exact', path: '/wf1/api/schedule/preview', async handler(req, res) {
+    if (req.method !== 'POST') return json(res, 405, { error: 'method' });
+    const body = await readBody(req);
+    if (!body?.cron) return json(res, 400, { error: '需要 cron 表达式' });
+    try {
+      return json(res, 200, { ok: true, times: upcomingFireTimes(body.cron, 3) });
+    } catch (e) {
+      return json(res, 400, { error: `cron 表达式无效：${e.message}` });
+    }
+  } });
+
+  // 立即运行一次（手动语义，不受 overlap/enabled 限制）
+  register({ kind: 'exact', path: '/wf1/api/schedule/run', async handler(req, res) {
+    if (req.method !== 'POST') return json(res, 405, { error: 'method' });
+    const body = await readBody(req);
+    const key = body?.key || '';
+    if (!currentSchedulerMeta().has(key)) return json(res, 404, { error: '任务不存在' });
+    const result = runScheduleNow(key);
+    return json(res, result.ok ? 200 : 400, result);
   } });
 
   // ---- 附件 ----

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/schedule.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/schedule.js
@@ -1,0 +1,165 @@
+// 定时任务调度核心：cron 解析、下次触发计算、重叠判定、链式 setTimeout 调度器。
+// 纯逻辑无 Cordis 依赖，index.js 注入 fire/isBusy 回调；测试直接 node 跑。
+import cronParser from 'cron-parser';
+
+// cron-parser@4：默认导出是命名空间对象（CJS interop），parseExpression 是其方法
+const parseCronExpression = cronParser.parseExpression?.bind(cronParser)
+  ?? cronParser.default?.parseExpression?.bind(cronParser.default);
+
+export const OVERLAP_POLICIES = ['skip', 'parallel'];
+// setTimeout 上限 2^31-1 ms（约 24.8 天）：远期任务链式分段等待，避免溢出成 1ms 风暴
+const MAX_WAIT = 2 ** 31 - 1;
+
+export function isValidCron(cron) {
+  // cron-parser 宽松模式把空串/缺段当 *（空串 = 每分钟），先拒绝空值
+  if (typeof cron !== 'string' || !cron.trim()) return false;
+  try {
+    parseCronExpression(cron, { currentDate: new Date() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// 距下次触发的毫秒数（≥1）；cron 无效抛错（空串同上视为无效）
+export function computeNextDelay(cron, now = Date.now()) {
+  if (typeof cron !== 'string' || !cron.trim()) throw new Error('cron 表达式为空');
+  const interval = parseCronExpression(cron, { currentDate: new Date(now) });
+  return Math.max(1, interval.next().getTime() - now);
+}
+
+// 接下来 count 次触发时间（ISO 字符串），供创建表单实时预览；cron 无效抛错
+export function upcomingFireTimes(cron, count = 3, now = Date.now()) {
+  if (typeof cron !== 'string' || !cron.trim()) throw new Error('cron 表达式为空');
+  const interval = parseCronExpression(cron, { currentDate: new Date(now) });
+  const times = [];
+  for (let i = 0; i < count; i += 1) times.push(interval.next().toISOString());
+  return times;
+}
+
+// 该工作流在本工作区是否仍有 live 运行（不论来源：手动/定时/webhook）。
+// runsMap = Orchestrator.runs（runId → { run, s, cancel }）
+export function hasLiveRunForWorkflow(runsMap, workspaceRoot, workflowId) {
+  if (!workflowId) return false;
+  for (const entry of runsMap.values()) {
+    const run = entry?.run;
+    if (run?.workflowId === workflowId && run?.workspaceRoot === workspaceRoot) return true;
+  }
+  return false;
+}
+
+// 兼容旧 triggers.json：无新字段时补默认值（overlap=skip、enabled=true）
+export function normalizeScheduleMeta(raw) {
+  const overlap = OVERLAP_POLICIES.includes(raw?.overlap) ? raw.overlap : 'skip';
+  return {
+    key: raw?.key || null,
+    workflowId: raw?.workflowId || null,
+    workflowName: raw?.workflowName || '',
+    cron: String(raw?.cron || ''),
+    input: raw?.input || '',
+    runInputs: raw?.runInputs && typeof raw?.runInputs === 'object' ? raw.runInputs : {},
+    overlap,
+    enabled: raw?.enabled !== false,
+    createdAt: raw?.createdAt || null,
+    nextAt: raw?.nextAt || null,
+    fireCount: Number.isFinite(raw?.fireCount) ? raw.fireCount : 0,
+    skippedCount: Number.isFinite(raw?.skippedCount) ? raw.skippedCount : 0,
+  };
+}
+
+// 落盘只存稳定字段（运行态 nextAt/fireCount/skippedCount 也持久化，重启恢复统计）
+export function persistableScheduleMeta(meta) {
+  return {
+    key: meta.key,
+    workflowId: meta.workflowId,
+    workflowName: meta.workflowName,
+    cron: meta.cron,
+    input: meta.input,
+    runInputs: meta.runInputs || {},
+    overlap: meta.overlap || 'skip',
+    enabled: meta.enabled !== false,
+    createdAt: meta.createdAt,
+    nextAt: meta.nextAt || null,
+    fireCount: meta.fireCount || 0,
+    skippedCount: meta.skippedCount || 0,
+  };
+}
+
+// 链式调度器：到点按 overlap 策略决定真跑还是跳过；fireNow 供「立即运行」绕过策略。
+// onMeta 在统计/nextAt 变化时回调（index.js 借此同步 meta Map 并落盘）。
+export function createScheduler({ meta, fire, isBusy, logger, now = () => Date.now(), onMeta } = {}) {
+  const normalized = normalizeScheduleMeta(meta);
+  const state = {
+    stopped: false,
+    rawTimer: null,
+    nextAt: null,
+    fireCount: normalized.fireCount,
+    skippedCount: normalized.skippedCount,
+  };
+  const liveMeta = () => ({
+    ...normalized,
+    key: normalized.key,
+    nextAt: state.nextAt,
+    fireCount: state.fireCount,
+    skippedCount: state.skippedCount,
+  });
+  const report = () => onMeta?.(liveMeta());
+
+  const runFire = () => {
+    state.fireCount += 1;
+    report();
+    try {
+      fire?.();
+    } catch (error) {
+      logger?.warn?.(`dsh-ccpg 定时运行失败（${normalized.key}）：${error?.message || error}`);
+    }
+  };
+
+  const armNext = () => {
+    if (state.stopped) return;
+    let nextMs = 1;
+    try {
+      nextMs = computeNextDelay(normalized.cron, now());
+    } catch (error) {
+      state.stopped = true;
+      state.nextAt = null;
+      logger?.warn?.(`dsh-ccpg 定时表达式无效（${normalized.key}）：${error?.message}`);
+      report();
+      return;
+    }
+    state.nextAt = new Date(now() + nextMs).toISOString();
+    report();
+    const onTime = () => {
+      if (state.stopped) return;
+      if (normalized.overlap === 'skip' && isBusy?.()) {
+        state.skippedCount += 1;
+        logger?.info?.(`dsh-ccpg 定时触发跳过（${normalized.key}）：上一轮运行尚未结束`);
+        report();
+        armNext();
+        return;
+      }
+      runFire();
+      armNext();
+    };
+    if (nextMs > MAX_WAIT) {
+      state.rawTimer = setTimeout(armNext, Math.floor(MAX_WAIT / 2));
+      return;
+    }
+    state.rawTimer = setTimeout(onTime, nextMs);
+  };
+  armNext();
+
+  return {
+    // 手动「立即运行」：不受 overlap/enabled 限制，不干扰既定调度链
+    fireNow() {
+      if (state.stopped) return false;
+      runFire();
+      return true;
+    },
+    getMeta: liveMeta,
+    stop() {
+      state.stopped = true;
+      if (state.rawTimer) clearTimeout(state.rawTimer);
+    },
+  };
+}

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/schedule-api.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/schedule-api.integration.test.mjs
@@ -1,0 +1,274 @@
+// 定时任务 API 集成测试 + 同工作流并发运行回归（假 webServer 直调路由，与 plugin-storage 同模式）。
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { apply } from '../lib/index.js';
+
+function responseCapture() {
+  const listeners = new Map();
+  return {
+    status: 0,
+    headers: {},
+    chunks: [],
+    writableEnded: false,
+    writeHead(status, headers = {}) { this.status = status; this.headers = headers; },
+    write(chunk) { this.chunks.push(Buffer.from(chunk)); },
+    end(chunk) { if (chunk) this.chunks.push(Buffer.from(chunk)); this.writableEnded = true; },
+    on(event, callback) { listeners.set(event, callback); return this; },
+    once(event, callback) { const inner = listeners.get(event); listeners.set(event, () => { inner?.(); callback(); }); return this; },
+    emit(event) { listeners.get(event)?.(); return true; },
+    destroy(error) { if (error) throw error; },
+    json() { return JSON.parse(Buffer.concat(this.chunks).toString('utf8') || '{}'); },
+  };
+}
+
+function request(method, url, body) {
+  const req = new EventEmitter();
+  req.method = method;
+  req.url = url;
+  req.headers = {};
+  queueMicrotask(() => {
+    if (body !== undefined) req.emit('data', Buffer.from(JSON.stringify(body)));
+    req.emit('end');
+  });
+  return req;
+}
+
+const withSession = (url, sessionId) => `${url}${url.includes('?') ? '&' : '?'}sessionId=${sessionId}`;
+const dshHome = mkdtempSync(join(tmpdir(), 'wf1-sch-home-'));
+const workspacesRoot = mkdtempSync(join(tmpdir(), 'wf1-sch-ws-'));
+const workspace = join(workspacesRoot, 'ws');
+mkdirSync(workspace, { recursive: true });
+const originalEnv = { DSH_HOME: process.env.DSH_HOME, WF1_LEGACY_DATA_DIR: process.env.WF1_LEGACY_DATA_DIR };
+process.env.DSH_HOME = dshHome;
+const packageLegacyDir = join(dshHome, 'package-legacy');
+mkdirSync(join(packageLegacyDir, 'state'), { recursive: true });
+process.env.WF1_LEGACY_DATA_DIR = packageLegacyDir;
+writeFileSync(join(packageLegacyDir, 'state', 'graph.json'), JSON.stringify({ nodes: [], edges: [] }));
+
+const triggersFile = () => join(workspace, '.workflow-one', 'state', 'triggers.json');
+const readTriggers = () => JSON.parse(readFileSync(triggersFile(), 'utf8'));
+const disposers = [];
+const results = [];
+const test = async (name, fn) => {
+  try { await fn(); results.push(['✓', name]); }
+  catch (error) { results.push(['✗', name, error]); }
+};
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const ctx = {
+  webServer: { register(route) { this.routes.push(route); }, routes: [] },
+  tools: { register() {}, schemas() { return []; } },
+  get(name) {
+    if (name === 'sessions') return { get: (id) => (String(id) === 'session-1' ? { header: { cwd: workspace } } : undefined), flush: async () => {} };
+    if (name === 'workspaceRegistry') return { list: () => [{ path: workspace }] };
+    return null;
+  },
+  skills: { async list() { return []; } },
+  llm: { listProviders() { return []; }, async listModels() { return []; } },
+  agentPresets: { async mount() {} },
+  logger: { info() {}, warn() {}, error() {} },
+  effect(setup) { const dispose = setup(); if (dispose) disposers.push(dispose); },
+};
+apply(ctx, {});
+const route = (path) => ctx.webServer.routes.find((entry) => entry.kind === 'exact' && entry.path === path)?.handler;
+const call = async (method, url, body) => {
+  const res = responseCapture();
+  await route(url.split('?')[0])(request(method, withSession(url, 'session-1'), body), res);
+  return { status: res.status, body: res.json() };
+};
+
+const wfGraph = {
+  nodes: [{ id: 'sch_input', type: 'input', position: { x: 0, y: 0 }, data: { label: '输入', text: 'ok' } }],
+  edges: [],
+};
+const created = await call('POST', '/wf1/api/workflows', { id: 'wf_sch', name: '定时测试工作流', graph: wfGraph });
+assert.equal(created.status, 200);
+
+await test('POST /schedule：空/非法 cron 拒绝；合法创建默认 skip + 统计零', async () => {
+  const empty = await call('POST', '/wf1/api/schedule', { workflowId: 'wf_sch', cron: '' });
+  assert.equal(empty.status, 400);
+  const bad = await call('POST', '/wf1/api/schedule', { workflowId: 'wf_sch', cron: 'not-a-cron' });
+  assert.equal(bad.status, 400);
+  const missingWf = await call('POST', '/wf1/api/schedule', { workflowId: 'wf_missing', cron: '0 9 * * *' });
+  assert.equal(missingWf.status, 404);
+  const ok = await call('POST', '/wf1/api/schedule', { workflowId: 'wf_sch', cron: '0 9 * * *', input: '巡检', runInputs: { env: 'prod' } });
+  assert.equal(ok.status, 200);
+  assert.match(ok.body.key, /^sch_/);
+  assert.equal(ok.body.overlap, 'skip');
+});
+
+await test('GET /schedule：列表含实时工作流名/nextAt/overlap；triggers.json 落全字段', async () => {
+  const list = await call('GET', '/wf1/api/schedule');
+  assert.equal(list.status, 200);
+  const row = list.body.schedules.find((s) => s.workflowId === 'wf_sch');
+  assert.ok(row, '列表应包含新任务');
+  assert.equal(row.workflowName, '定时测试工作流');
+  assert.equal(row.overlap, 'skip');
+  assert.equal(row.enabled, true);
+  assert.equal(row.fireCount, 0);
+  assert.ok(row.nextAt, '调度器应上报 nextAt');
+  const disk = readTriggers().schedules.find((s) => s.key === row.key);
+  assert.equal(disk.cron, '0 9 * * *');
+  assert.equal(disk.overlap, 'skip');
+  assert.deepEqual(disk.runInputs, { env: 'prod' });
+  assert.ok(disk.nextAt);
+  globalThis.__schKey = row.key;
+});
+
+await test('POST /schedule/preview：返回 3 次触发时间；非法 cron 400', async () => {
+  const good = await call('POST', '/wf1/api/schedule/preview', { cron: '0 9 * * *' });
+  assert.equal(good.status, 200);
+  assert.equal(good.body.times.length, 3);
+  const bad = await call('POST', '/wf1/api/schedule/preview', { cron: 'x x x' });
+  assert.equal(bad.status, 400);
+});
+
+await test('POST /schedule/run：立即触发返回 runId 并计入 fireCount；来源为 schedule', async () => {
+  const fired = await call('POST', '/wf1/api/schedule/run', { key: globalThis.__schKey });
+  assert.equal(fired.status, 200);
+  const runId = fired.body.runId;
+  assert.ok(runId);
+  let detail;
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    const res = await call('GET', `/wf1/api/runs/detail?id=${runId}`);
+    detail = res.body;
+    if (detail.status && detail.status !== 'running') break;
+    await sleep(20);
+  }
+  assert.equal(detail.source, 'schedule');
+  const list = await call('GET', '/wf1/api/schedule');
+  const row = list.body.schedules.find((s) => s.key === globalThis.__schKey);
+  assert.equal(row.fireCount, 1);
+  assert.deepEqual(row.runInputs, { env: 'prod' });
+});
+
+await test('PATCH /schedule：停用后 nextAt 置空、不再持有调度器；重新启用恢复', async () => {
+  const off = await call('PATCH', '/wf1/api/schedule', { key: globalThis.__schKey, enabled: false });
+  assert.equal(off.status, 200);
+  const listOff = await call('GET', '/wf1/api/schedule');
+  const rowOff = listOff.body.schedules.find((s) => s.key === globalThis.__schKey);
+  assert.equal(rowOff.enabled, false);
+  assert.equal(rowOff.nextAt, null, '停用后 nextAt 应清空');
+  assert.equal(readTriggers().schedules.find((s) => s.key === globalThis.__schKey).enabled, false);
+
+  const on = await call('PATCH', '/wf1/api/schedule', { key: globalThis.__schKey, enabled: true, cron: '30 8 * * *' });
+  assert.equal(on.status, 200);
+  const listOn = await call('GET', '/wf1/api/schedule');
+  const rowOn = listOn.body.schedules.find((s) => s.key === globalThis.__schKey);
+  assert.equal(rowOn.enabled, true);
+  assert.equal(rowOn.cron, '30 8 * * *');
+  assert.ok(rowOn.nextAt, '重新启用应重挂调度链');
+  const badPatch = await call('PATCH', '/wf1/api/schedule', { key: 'sch_nope', enabled: true });
+  assert.equal(badPatch.status, 404);
+});
+
+await test('恢复语义：停用任务重启后只入 meta 不起定时器', async () => {
+  await call('PATCH', '/wf1/api/schedule', { key: globalThis.__schKey, enabled: false });
+  // 模拟重启：新建 store（新 apply 太重，直接复刻 ensureTriggers 的判定面）——
+  // 通过 dispose 旧 store 再触发一次 scoped 请求重建不可行（apply 只跑一次），
+  // 这里退化为验证 triggers.json 内容满足「enabled:false + nextAt:null」的恢复输入契约
+  const disk = readTriggers().schedules.find((s) => s.key === globalThis.__schKey);
+  assert.equal(disk.enabled, false);
+  assert.equal(disk.nextAt, null);
+});
+
+await test('DELETE /schedule：任务移除并落盘', async () => {
+  const del = await call('DELETE', `/wf1/api/schedule?key=${globalThis.__schKey}`);
+  assert.equal(del.status, 200);
+  const list = await call('GET', '/wf1/api/schedule');
+  assert.equal(list.body.schedules.find((s) => s.key === globalThis.__schKey), undefined);
+  assert.equal(readTriggers().schedules.find((s) => s.key === globalThis.__schKey), undefined);
+});
+
+await test('并发回归：同图并发两个 run 同时 live、输出互不串扰', async () => {
+  const originalFetch = globalThis.fetch;
+  const gates = new Map(); // url → release（url 含各自 trigger，天然按运行区分）
+  try {
+    globalThis.fetch = (url) => new Promise((resolve) => {
+      gates.set(String(url), () => resolve(new Response(String(url), { status: 200 })));
+    });
+    const graph = {
+      nodes: [
+        { id: 'multi_input', type: 'input', position: { x: 0, y: 0 }, data: { label: '输入', text: 'seed' } },
+        { id: 'http_gate', type: 'http', position: { x: 200, y: 0 }, data: { label: '门请求', url: 'https://gate.example/{{$trigger}}', allowPrivate: true } },
+        { id: 'multi_output', type: 'output', position: { x: 400, y: 0 }, data: { label: '输出' } },
+      ],
+      edges: [
+        { source: 'multi_input', target: 'http_gate' },
+        { source: 'http_gate', target: 'multi_output' },
+      ],
+    };
+    const first = await call('POST', '/wf1/api/run', { graph, triggerInput: 'first' });
+    const second = await call('POST', '/wf1/api/run', { graph, triggerInput: 'second' });
+    assert.equal(first.status, 200);
+    assert.equal(second.status, 200, '第二个运行必须能启动（并发核心诉求）');
+    assert.notEqual(first.body.runId, second.body.runId);
+
+    // 两个运行都进入 live（http 节点被 gate 住不返回）
+    const waitRunning = async (runId) => {
+      for (let attempt = 0; attempt < 50; attempt += 1) {
+        const res = await call('GET', `/wf1/api/runs/detail?id=${runId}`);
+        if (res.body.nodeStates?.http_gate?.status === 'running') return res.body;
+        await sleep(10);
+      }
+      return null;
+    };
+    const detailA = await waitRunning(first.body.runId);
+    const detailB = await waitRunning(second.body.runId);
+    assert.ok(detailA && detailB, '两个运行应同时 live');
+    assert.equal(detailA.status, 'running');
+    assert.equal(detailB.status, 'running');
+
+    // 放行第一个：它完成，第二个仍 live；两者输出按各自 trigger 隔离
+    gates.get('https://gate.example/first')?.();
+    let finalA;
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      const res = await call('GET', `/wf1/api/runs/detail?id=${first.body.runId}`);
+      finalA = res.body;
+      if (finalA.status && finalA.status !== 'running') break;
+      await sleep(10);
+    }
+    assert.equal(finalA.status, 'success');
+    const stillB = await call('GET', `/wf1/api/runs/detail?id=${second.body.runId}`);
+    assert.equal(stillB.body.status, 'running', '第一个完成不影响第二个');
+
+    gates.get('https://gate.example/second')?.();
+    let finalB;
+    for (let attempt = 0; attempt < 50; attempt += 1) {
+      const res = await call('GET', `/wf1/api/runs/detail?id=${second.body.runId}`);
+      finalB = res.body;
+      if (finalB.status && finalB.status !== 'running') break;
+      await sleep(10);
+    }
+    assert.equal(finalB.status, 'success');
+    assert.ok(String(finalA.outputs?.multi_output || '').includes('gate.example/first'), '运行 A 的输出含自己的 trigger');
+    assert.ok(String(finalB.outputs?.multi_output || '').includes('gate.example/second'), '运行 B 的输出含自己的 trigger');
+
+    const runs = await call('GET', '/wf1/api/runs');
+    const ids = new Set(runs.body.runs.map((r) => r.runId));
+    assert.ok(ids.has(first.body.runId) && ids.has(second.body.runId), '两条独立运行记录');
+  } finally {
+    for (const release of gates.values()) release?.();
+    globalThis.fetch = originalFetch;
+  }
+});
+
+for (const d of disposers) await d?.();
+rmSync(workspacesRoot, { recursive: true, force: true });
+rmSync(dshHome, { recursive: true, force: true });
+process.env.DSH_HOME = originalEnv.DSH_HOME;
+process.env.WF1_LEGACY_DATA_DIR = originalEnv.WF1_LEGACY_DATA_DIR;
+
+for (const [mark, name, error] of results) {
+  console.log(`  ${mark} ${name}`);
+  if (error) console.log(error);
+}
+const failed = results.filter(([mark]) => mark === '✗').length;
+if (failed) {
+  console.error(`${failed} FAILED / ${results.length}`);
+  process.exit(1);
+}
+console.log(`ALL PASS (${results.length})`);

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/schedule.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/schedule.test.mjs
@@ -1,0 +1,201 @@
+// lib/schedule.js 单测：cron 计算、重叠判定、调度器策略（短真实等待驱动）。
+import { strict as assert } from 'node:assert';
+import {
+  computeNextDelay, createScheduler, hasLiveRunForWorkflow, isValidCron,
+  normalizeScheduleMeta, persistableScheduleMeta, upcomingFireTimes,
+} from '../lib/schedule.js';
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const results = [];
+const test = async (name, fn) => {
+  try { await fn(); results.push(['✓', name]); }
+  catch (error) { results.push(['✗', name, error]); }
+};
+
+await test('isValidCron：合法 / 非法表达式；空值必须拒绝（否则空串=每分钟风暴）', () => {
+  assert.equal(isValidCron('0 9 * * *'), true);
+  assert.equal(isValidCron('*/5 * * * *'), true);
+  // cron-parser 宽松模式接受缺段（按 *），但别名错误、超界值、空值必须判非法
+  assert.equal(isValidCron('not-a-cron'), false);
+  assert.equal(isValidCron('99 * * * *'), false);
+  assert.equal(isValidCron(null), false);
+  assert.equal(isValidCron(''), false);
+  assert.equal(isValidCron('   '), false);
+});
+
+await test('computeNextDelay：本地时区整点前 1 秒 → 约 1000ms；结果 ≥1ms', () => {
+  // cron 按本地时区解释（调度语义正确）：取下一整点的本地时间，从其前 1 秒起算
+  const next = new Date();
+  next.setHours(next.getHours() + 1, 0, 0, 0);
+  const base = next.getTime() - 1000;
+  const delay = computeNextDelay('0 * * * *', base);
+  assert.ok(Math.abs(delay - 1000) < 50, `expect ~1000ms got ${delay}`);
+  assert.ok(computeNextDelay('* * * * *', base) >= 1);
+  assert.throws(() => computeNextDelay('bad-alias', base));
+});
+
+await test('upcomingFireTimes：返回递增 ISO 时间、条数正确（本地时区语义）', () => {
+  const base = new Date();
+  base.setHours(8, 0, 0, 0);
+  const times = upcomingFireTimes('0 9 * * *', 3, base.getTime());
+  assert.equal(times.length, 3);
+  const expected = [0, 1, 2].map((d) => {
+    const day = new Date(base);
+    day.setDate(day.getDate() + d);
+    day.setHours(9, 0, 0, 0);
+    return day.toISOString();
+  });
+  assert.deepEqual(times, expected);
+});
+
+await test('hasLiveRunForWorkflow：按 workflowId+workspaceRoot 匹配，其他工作区/工作流不算', () => {
+  const runs = new Map([
+    ['r1', { run: { workflowId: 'wf_a', workspaceRoot: '/ws1' } }],
+    ['r2', { run: { workflowId: 'wf_b', workspaceRoot: '/ws1' } }],
+    ['r3', { run: { workflowId: 'wf_a', workspaceRoot: '/ws2' } }],
+  ]);
+  assert.equal(hasLiveRunForWorkflow(runs, '/ws1', 'wf_a'), true);
+  assert.equal(hasLiveRunForWorkflow(runs, '/ws1', 'wf_b'), true);
+  assert.equal(hasLiveRunForWorkflow(runs, '/ws1', 'wf_missing'), false);
+  assert.equal(hasLiveRunForWorkflow(runs, '/ws2', 'wf_b'), false);
+  assert.equal(hasLiveRunForWorkflow(runs, '/ws1', null), false);
+  assert.equal(hasLiveRunForWorkflow(new Map(), '/ws1', 'wf_a'), false);
+});
+
+await test('normalizeScheduleMeta：旧 triggers.json 字段补默认 skip/enabled；非法 overlap 回落 skip', () => {
+  const legacy = normalizeScheduleMeta({ key: 'sch_x', workflowId: 'wf', workflowName: '旧', cron: '0 9 * * *', input: 'hi', createdAt: '2026-01-01T00:00:00Z' });
+  assert.equal(legacy.overlap, 'skip');
+  assert.equal(legacy.enabled, true);
+  assert.deepEqual(legacy.runInputs, {});
+  assert.equal(legacy.fireCount, 0);
+  assert.equal(legacy.skippedCount, 0);
+
+  const full = normalizeScheduleMeta({ key: 'sch_y', workflowId: 'wf', cron: '0 9 * * *', overlap: 'parallel', enabled: false, runInputs: { a: 1 }, fireCount: 3, skippedCount: 2 });
+  assert.equal(full.overlap, 'parallel');
+  assert.equal(full.enabled, false);
+  assert.deepEqual(full.runInputs, { a: 1 });
+  assert.equal(full.fireCount, 3);
+  assert.equal(full.skippedCount, 2);
+
+  assert.equal(normalizeScheduleMeta({ overlap: 'whatever' }).overlap, 'skip');
+});
+
+await test('persistableScheduleMeta：落盘含全部统计与配置字段', () => {
+  const disk = persistableScheduleMeta(normalizeScheduleMeta({
+    key: 'sch_z', workflowId: 'wf', workflowName: 'n', cron: '0 9 * * *', input: 'x',
+    runInputs: { k: 'v' }, overlap: 'parallel', enabled: false, createdAt: 't',
+    nextAt: '2026-01-16T09:00:00.000Z', fireCount: 5, skippedCount: 1,
+  }));
+  assert.deepEqual(disk, {
+    key: 'sch_z', workflowId: 'wf', workflowName: 'n', cron: '0 9 * * *', input: 'x',
+    runInputs: { k: 'v' }, overlap: 'parallel', enabled: false, createdAt: 't',
+    nextAt: '2026-01-16T09:00:00.000Z', fireCount: 5, skippedCount: 1,
+  });
+});
+
+await test('createScheduler：每秒 cron 到点触发 fire 并累计 fireCount', async () => {
+  let fired = 0;
+  const metas = [];
+  const scheduler = createScheduler({
+    meta: { key: 'sch_t1', workflowId: 'wf', cron: '* * * * * *', overlap: 'skip' },
+    fire: () => { fired += 1; },
+    isBusy: () => false,
+    onMeta: (m) => metas.push(m),
+  });
+  try {
+    await sleep(2300);
+    assert.ok(fired >= 2, `expect >=2 fires got ${fired}`);
+    const last = metas[metas.length - 1];
+    assert.equal(last.fireCount, fired);
+    assert.ok(last.nextAt, 'nextAt 应已上报');
+  } finally {
+    scheduler.stop();
+  }
+});
+
+await test('createScheduler：skip 策略下上一轮 live → 到点跳过并累计 skippedCount，不调 fire', async () => {
+  let fired = 0;
+  let skipped = 0;
+  const scheduler = createScheduler({
+    meta: { key: 'sch_t2', workflowId: 'wf', cron: '* * * * * *', overlap: 'skip' },
+    fire: () => { fired += 1; },
+    isBusy: () => true,
+    onMeta: (m) => { skipped = m.skippedCount; },
+  });
+  try {
+    await sleep(2300);
+    assert.equal(fired, 0, 'skip + busy 不应真跑');
+    assert.ok(skipped >= 2, `expect skippedCount>=2 got ${skipped}`);
+  } finally {
+    scheduler.stop();
+  }
+});
+
+await test('createScheduler：parallel 策略无视 isBusy 直接触发', async () => {
+  let fired = 0;
+  const scheduler = createScheduler({
+    meta: { key: 'sch_t3', workflowId: 'wf', cron: '* * * * * *', overlap: 'parallel' },
+    fire: () => { fired += 1; },
+    isBusy: () => true,
+  });
+  try {
+    await sleep(1300);
+    assert.ok(fired >= 1, `parallel 应触发 got ${fired}`);
+  } finally {
+    scheduler.stop();
+  }
+});
+
+await test('createScheduler：fireNow 立即触发且不受 isBusy 影响；stop 后 fireNow 拒绝', () => {
+  let fired = 0;
+  const scheduler = createScheduler({
+    meta: { key: 'sch_t4', workflowId: 'wf', cron: '0 9 * * *', overlap: 'skip' },
+    fire: () => { fired += 1; },
+    isBusy: () => true,
+  });
+  assert.equal(scheduler.fireNow(), true);
+  assert.equal(fired, 1);
+  scheduler.stop();
+  assert.equal(scheduler.fireNow(), false);
+  assert.equal(fired, 1);
+});
+
+await test('createScheduler：无效 cron 起动即停（不触发 fire），nextAt 置空上报', () => {
+  let fired = 0;
+  const metas = [];
+  const scheduler = createScheduler({
+    meta: { key: 'sch_t5', workflowId: 'wf', cron: 'bad-cron', overlap: 'skip' },
+    fire: () => { fired += 1; },
+    onMeta: (m) => metas.push(m),
+  });
+  assert.equal(fired, 0);
+  const last = metas[metas.length - 1];
+  assert.equal(last?.nextAt, null);
+  scheduler.stop();
+});
+
+await test('createScheduler：统计从 meta 续算（重启恢复语义）', () => {
+  const metas = [];
+  const scheduler = createScheduler({
+    meta: { key: 'sch_t6', workflowId: 'wf', cron: '0 9 * * *', overlap: 'skip', fireCount: 7, skippedCount: 4 },
+    fire: () => {},
+    onMeta: (m) => metas.push(m),
+  });
+  try {
+    assert.equal(metas[0].fireCount, 7);
+    assert.equal(metas[0].skippedCount, 4);
+  } finally {
+    scheduler.stop();
+  }
+});
+
+for (const [mark, name, error] of results) {
+  console.log(`  ${mark} ${name}`);
+  if (error) console.log(error);
+}
+const failed = results.filter(([mark]) => mark === '✗').length;
+if (failed) {
+  console.error(`${failed} FAILED / ${results.length}`);
+  process.exit(1);
+}
+console.log(`ALL PASS (${results.length})`);

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "test:variables": "node src/variables.test.mjs && node src/global-variables.test.mjs && node src/json-response.test.mjs && node src/api-base.test.mjs && node src/trial-request.test.mjs && node src/variable-scope.test.mjs && node src/run-event-routing.test.mjs && node src/workflow-serialization.test.mjs",
     "test:results": "node src/result-adapter.test.mjs",
     "test:scripts": "node src/script-parameters.test.mjs",
-    "test:ui": "node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs && node src/notify-node.test.mjs && node src/workflow-transfer-ui.test.mjs"
+    "test:ui": "node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs && node src/notify-node.test.mjs && node src/workflow-transfer-ui.test.mjs && node src/run-switcher.test.mjs && node src/schedule-center.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -36,6 +36,7 @@ import { FeishuCredModal } from './FeishuCredModal.jsx';
 import { TestRunModal } from './TestRunModal.jsx';
 import { NodeDetailModal } from './NodeDetailModal.jsx';
 import { VariableCenter } from './VariableCenter.jsx';
+import { ScheduleCenter } from './ScheduleCenter.jsx';
 import { TEMPLATES, TemplateModal } from './templates.jsx';
 
 export default function App() {
@@ -78,6 +79,7 @@ export default function App() {
   const [progress, setProgress] = useState({}); // nodeId → { turns, preview }
   const [credOpen, setCredOpen] = useState(false);
   const [variableCenterOpen, setVariableCenterOpen] = useState(false);
+  const [scheduleCenterOpen, setScheduleCenterOpen] = useState(false);
   const [globalVariableEpoch, setGlobalVariableEpoch] = useState(0);
   const [larkStatus, setLarkStatus] = useState(null); // lark-cli 登录状态（⋯ 菜单入口数据源）
   const [focusLark, setFocusLark] = useState(false); // 从 ⋯ 打开设置时聚焦授权区
@@ -1429,6 +1431,7 @@ export default function App() {
               { key: 'redo', icon: '↪', label: '重做', hint: 'Cmd+Shift+Z', compactOnly: true, disabled: !undoInfo.canRedo, onClick: redo },
               larkStatus?.installed ? { key: 'lark', icon: '◈', label: larkStatus.user?.tokenStatus === 'valid' ? `飞书已登录：${larkStatus.user.userName}` : '飞书登录 / 设置', onClick: () => { setFocusLark(true); setCredOpen(true); } } : null,
               { key: 'variables', icon: '⌘', label: '变量与输入', hint: '实例变量 / 工作流变量 / 运行输入', onClick: () => setVariableCenterOpen(true) },
+              { key: 'schedules', icon: '⏰', label: '定时任务', hint: '按周期自动运行工作流', onClick: () => setScheduleCenterOpen(true) },
               { key: 'settings', icon: '⚙', label: '设置', hint: '凭据 / 飞书', onClick: () => setCredOpen(true) },
               { key: 'templates', icon: '▤', label: '模板库', onClick: () => setTemplateOpen(true) },
               { key: 'reset', icon: '⟲', label: '重置为示例', danger: true, onClick: resetGraph },
@@ -1724,6 +1727,14 @@ export default function App() {
           inputSchema={inputSchema}
           onClose={() => setVariableCenterOpen(false)}
           onGlobalChanged={(revision) => setGlobalVariableEpoch(revision)}
+        />
+      )}
+      {scheduleCenterOpen && (
+        <ScheduleCenter
+          currentWorkflowId={currentWf?.id || null}
+          onRan={refreshRunList}
+          onClose={() => setScheduleCenterOpen(false)}
+          toast={toast}
         />
       )}
       {templateOpen && <TemplateModal onClose={() => setTemplateOpen(false)} onApply={applyTemplate} />}

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -294,14 +294,17 @@ export default function App() {
       setRunList(data.runs || []);
     } catch { /* 列表拉不到维持现状 */ }
   }, []);
+  // live 标记经 ref 读（不能进依赖：runList 变化会重建 effect → 轮询变请求风暴）
+  const runListRef = useRef([]);
+  useEffect(() => { runListRef.current = runList; }, [runList]);
   useEffect(() => {
     if (!hostSession.id) return undefined;
     refreshRunList();
     const timer = setInterval(() => {
-      if (runList.some((r) => r.live)) refreshRunList();
+      if (runListRef.current.some((r) => r.live)) refreshRunList();
     }, 5000);
     return () => clearInterval(timer);
-  }, [hostSession.id, refreshRunList, runList]);
+  }, [hostSession.id, refreshRunList]);
 
   // SSE：事件 → 节点状态 + 进度 + 结构化日志
   useEffect(() => {

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -17,7 +17,7 @@ import {
   serializeWorkflowDocument,
   stripCanvasRuntimeNodeData,
 } from './workflow-serialization.js';
-import { eventBelongsToCanvas, eventBelongsToRun } from './run-event-routing.js';
+import { eventBelongsToCanvas, eventBelongsToRun, shouldFollowRunStart } from './run-event-routing.js';
 import { useThemePalette } from './theme.js';
 import { useToast, PromptModal, ConfirmModal, Modal } from './ui.jsx';
 
@@ -30,6 +30,7 @@ import { AddNodeMenu, CanvasAddMenu, MoreMenu } from './ToolbarMenus.jsx';
 import { NodePanel } from './NodePanel.jsx';
 import { WorkflowList } from './WorkflowList.jsx';
 import { RunHistory } from './RunHistory.jsx';
+import { RunSwitcher } from './RunSwitcher.jsx';
 import { ResultPanel } from './ResultPanel.jsx';
 import { FeishuCredModal } from './FeishuCredModal.jsx';
 import { TestRunModal } from './TestRunModal.jsx';
@@ -60,6 +61,8 @@ export default function App() {
   const [runInputs] = useState({});
   const [eventsByRunId, setEventsByRunId] = useState({});
   const [runDetails, setRunDetails] = useState({});
+  const runDetailsRef = useRef({});
+  useEffect(() => { runDetailsRef.current = runDetails; }, [runDetails]);
   const [inspectedRunId, setInspectedRunId] = useState(null);
   const [resultsReadyByRunId, setResultsReadyByRunId] = useState({});
   const [hostSession, setHostSession] = useState({ id: null, canSaveToWorkspace: false });
@@ -114,7 +117,57 @@ export default function App() {
   edgesRef.current = edges;
   const runningRef = useRef(false);
   const activeRunIdRef = useRef(null);
+  // 多运行模型：查看哪个运行（inspectedRunId）就实时跟踪哪个；runList 供切换器渲染
+  const inspectedRunIdRef = useRef(null);
+  const [runList, setRunList] = useState([]);
   const workflowScopeEpochRef = useRef(0);
+  // 切换查看的运行：单一事实源。清 progress、同步 ref；投影由调用方按需拉详情。
+  const inspectRun = useCallback((runId) => {
+    inspectedRunIdRef.current = runId;
+    setInspectedRunId(runId);
+    setProgress({});
+  }, []);
+
+  // 切换器点击：切查看目标 + 把该运行的节点状态投影回画布（live 走服务端内存快照，实时）
+  const selectRunForView = useCallback((runId) => {
+    if (!runId || runId === inspectedRunIdRef.current) return;
+    inspectRun(runId);
+    const applyDetail = (detail) => {
+      for (const [nodeId, st] of Object.entries(detail.nodeStates || {})) {
+        setNodes((nds) => nds.map((n) => {
+          if (n.id !== nodeId) return n;
+          const data = { ...n.data, runStatus: st.status };
+          if (st.startedAt) data.runStartedAt = st.startedAt;
+          if (st.chars != null) data.runChars = st.chars;
+          if (st.turns != null) data.runTurns = st.turns;
+          if (st.error) data.runError = st.error; else data.runError = null;
+          if (st.durationMs != null) data.durationMs = st.durationMs;
+          if (st.model) data.runtimeModel = st.model;
+          if (st.artifacts) { data.artifacts = st.artifacts; data.artifactsRunId = runId; }
+          const out = (detail.outputs || {})[nodeId];
+          if (out != null) data.runOutput = String(out).slice(0, 4000);
+          return { ...n, data };
+        }));
+      }
+      setRunStatus((current) => ({
+        ...current,
+        running: detail.status === 'running',
+        runId,
+        last: detail.status,
+        done: Object.values(detail.nodeStates || {}).filter((st) => ['success', 'error', 'canceled', 'skipped'].includes(st.status)).length,
+        total: (detail.graph?.nodes || []).filter((n) => n.type !== 'notify').length || current.total,
+      }));
+    };
+    const cached = runDetailsRef.current[runId];
+    if (cached) applyDetail(cached);
+    fetch(apiUrl(`/runs/detail?id=${encodeURIComponent(runId)}`))
+      .then((response) => (response.ok ? response.json() : Promise.reject(new Error('运行记录不存在'))))
+      .then((detail) => {
+        setRunDetails((current) => ({ ...current, [runId]: detail }));
+        applyDetail(detail);
+      })
+      .catch(() => { /* 缓存兜底已投影 */ });
+  }, [inspectRun, setNodes]);
   const markDirty = useCallback(() => setDirty(true), []);
   // 撤销/重做栈：结构变更前快照 {nodes, edges}（引用当前不可变数组即可）
   const undoStack = useRef([]);
@@ -212,7 +265,8 @@ export default function App() {
           if (response.ok) {
             const detail = await response.json();
             setRunDetails((current) => ({ ...current, [aligned.runId]: detail }));
-            if (!activeRunIdRef.current) {
+            if (!inspectedRunIdRef.current) {
+              inspectedRunIdRef.current = aligned.runId;
               setInspectedRunId(aligned.runId);
               setRunStatus((current) => ({
                 ...current,
@@ -224,8 +278,28 @@ export default function App() {
           }
         } catch { /* 详情拉取失败不阻塞首屏 */ }
       }
+      if (runsData?.runs?.length) setRunList(runsData.runs);
     })();
   }, [hostSession.id, setNodes, setEdges]);
+
+  // 切换器数据源：拉本工作区运行列表（不限当前画布——定时/webhook 运行也要出胶囊）。
+  // SSE run-start/run-end 触发即时刷新；存在 live 运行时 5s 轮询兜底刷新进度。
+  const refreshRunList = useCallback(async () => {
+    try {
+      const res = await fetch(apiUrl('/runs'));
+      if (!res.ok) return;
+      const data = await res.json();
+      setRunList(data.runs || []);
+    } catch { /* 列表拉不到维持现状 */ }
+  }, []);
+  useEffect(() => {
+    if (!hostSession.id) return undefined;
+    refreshRunList();
+    const timer = setInterval(() => {
+      if (runList.some((r) => r.live)) refreshRunList();
+    }, 5000);
+    return () => clearInterval(timer);
+  }, [hostSession.id, refreshRunList, runList]);
 
   // SSE：事件 → 节点状态 + 进度 + 结构化日志
   useEffect(() => {
@@ -240,7 +314,7 @@ export default function App() {
         [runId]: [...(current[runId] || []).slice(-299), timed],
       }));
     };
-    const appliesToActiveRun = (payload) => eventBelongsToRun(payload, activeRunIdRef.current);
+    const appliesToActiveRun = (payload) => eventBelongsToRun(payload, inspectedRunIdRef.current);
     const belongsToCurrentCanvas = (payload) => eventBelongsToCanvas(payload, {
       canvasId: canvasIdRef.current,
       workflowId: currentWfIdRef.current,
@@ -305,16 +379,26 @@ export default function App() {
     });
     es.addEventListener('run-start', (e) => {
       const p = JSON.parse(e.data);
-      if (!belongsToCurrentCanvas(p)) return;
+      // 任何运行起停都刷新切换器列表（不过画布闸门：定时/webhook 运行无 canvasId）
+      refreshRunList();
+      // 只跟随本画布发起的运行（手动/续跑/助手）；定时/webhook 触发不抢占视图
+      if (!shouldFollowRunStart(p, { canvasId: canvasIdRef.current, workflowId: currentWfIdRef.current })) {
+        if (belongsToCurrentCanvas(p) && p.workflowId === currentWfIdRef.current) {
+          const label = p.source === 'schedule' ? '⏰ 定时任务已触发' : '🪝 Webhook 已触发';
+          toast(`${label}「${p.workflowName || '当前工作流'}」，可在底部切换查看`, 'info', 3600);
+        }
+        return;
+      }
       activeRunIdRef.current = p.runId;
       runningRef.current = true;
       terminalNodesByRunRef.current.set(p.runId, new Set());
-      setInspectedRunId(p.runId);
+      inspectRun(p.runId);
       setRunStatus((s) => ({ ...s, running: true, runId: p.runId, done: 0, total: p.nodeIds.length }));
       pushEntry({ kind: 'run', runId: p.runId, status: 'start', text: `运行开始 · ${p.nodeIds.length} 个节点` });
     });
     es.addEventListener('run-end', (e) => {
       const p = JSON.parse(e.data);
+      refreshRunList();
       if (!appliesToActiveRun(p)) return;
       runningRef.current = false;
       setRunStatus((s) => (s.runId === p.runId ? { ...s, running: false, last: p.status } : s));
@@ -376,10 +460,20 @@ export default function App() {
       pushEntry({ kind: 'sys', runId: p.runId, status: 'error', text: p.error });
     });
     es.addEventListener('snapshot', (e) => {
-      // 刷新恢复：节点状态 + 一组可点击的运行日志（否则刷新后日志面板会错误显示“尚未运行”）
+      // 刷新恢复：服务端为每个 live run 各发一条 snapshot。全部入详情分桶；
+      // 节点投影只采纳「当前画布最近的 live run」一条，其余运行经切换器查看。
       const p = JSON.parse(e.data);
+      if (!p.runId) return;
+      setRunDetails((current) => ({ ...current, [p.runId]: { ...p, runId: p.runId } }));
       if (!belongsToCurrentCanvas(p)) return;
-      activeRunIdRef.current = p.runId;
+      const adopted = p.status === 'running'
+        || !inspectedRunIdRef.current
+        || (runDetailsRef.current[inspectedRunIdRef.current]?.status === 'running' ? false : !runDetailsRef.current[inspectedRunIdRef.current]);
+      if (p.status !== 'running' && !adopted) return;
+      if (p.status === 'running' || !inspectedRunIdRef.current) {
+        activeRunIdRef.current = p.runId;
+        inspectRun(p.runId);
+      }
       setRunStatus((s) => ({
         ...s,
         runId: p.runId || s.runId,
@@ -417,7 +511,6 @@ export default function App() {
       }
       if (p.runId) {
         setInspectedRunId((current) => current || p.runId);
-        setRunDetails((current) => ({ ...current, [p.runId]: { ...p, runId: p.runId } }));
       }
       if (restored.length && p.runId) {
         setEventsByRunId((current) => current[p.runId]?.length ? current : ({
@@ -430,7 +523,7 @@ export default function App() {
       }
     });
     return () => es.close();
-  }, [canvasScopeReady, setNodes, toast]);
+  }, [canvasScopeReady, setNodes, toast, inspectRun, refreshRunList]);
 
   // Esc 关闭面板；Cmd+S 保存；Cmd+Z 撤销 / Shift 重做；Delete 删除选中；Cmd+D 复制选中；F 定位错误
   const isTypingTarget = (e) => {
@@ -544,9 +637,10 @@ export default function App() {
     fetch(apiUrl('/runs')).then((r) => r.json()).then((d) => {
       if ((currentWfIdRef.current || null) !== (workflowId || null)) return;
       const rows = d.runs || [];
+      setRunList(rows);
       const latest = rows.find((row) => row.workflowId === workflowId);
-      if (!latest) { setInspectedRunId(null); return; }
-      setInspectedRunId(latest.runId);
+      if (!latest) { inspectRun(null); return; }
+      inspectRun(latest.runId);
       if (!latest.live) {
         fetch(apiUrl(`/runs/detail?id=${encodeURIComponent(latest.runId)}`))
           .then((r) => (r.ok ? r.json() : Promise.reject(new Error('运行记录不存在'))))
@@ -557,7 +651,7 @@ export default function App() {
           .catch(() => { /* 面板显示列表摘要兜底 */ });
       }
     }).catch(() => { /* 列表拉不到就维持现状 */ });
-  }, []);
+  }, [inspectRun]);
 
   const openWorkflow = useCallback(async (wf) => {
     const res = await fetch(apiUrl(`/workflows/detail?id=${encodeURIComponent(wf.id)}`));
@@ -566,6 +660,7 @@ export default function App() {
     workflowScopeEpochRef.current += 1;
     activeRunIdRef.current = null;
     runningRef.current = false;
+    inspectRun(null);
     setNodes(data.graph.nodes.map(toFlowNode));
     setEdges(data.graph.edges.map(toFlowEdge));
     setCurrentWf(data);
@@ -582,13 +677,14 @@ export default function App() {
     // 运行面板跟随：切到哪条工作流就显示哪条的最近一次运行；没跑过则清空面板
     syncRunPanelToWorkflow(data.id);
     toast(`已打开「${data.name}」`);
-  }, [setNodes, setEdges, toast, syncRunPanelToWorkflow]);
+  }, [setNodes, setEdges, toast, syncRunPanelToWorkflow, inspectRun]);
 
   const newWorkflow = useCallback((created) => {
     const document = normalizeWorkflowDocument(created);
     workflowScopeEpochRef.current += 1;
     activeRunIdRef.current = null;
     runningRef.current = false;
+    inspectRun(null);
     setNodes(document.graph.nodes.map(toFlowNode));
     setEdges(document.graph.edges.map(toFlowEdge));
     setCurrentWf(document);
@@ -604,7 +700,7 @@ export default function App() {
     }).catch(() => {});
     syncRunPanelToWorkflow(document.id);
     setTemplateOpen(true); // 空画布 → 弹模板库引导
-  }, [setNodes, setEdges, syncRunPanelToWorkflow]);
+  }, [setNodes, setEdges, syncRunPanelToWorkflow, inspectRun]);
 
   const applyTemplate = useCallback((tpl) => {
     snapshot();
@@ -642,8 +738,9 @@ export default function App() {
     });
   }, [setNodes, setEdges, currentWf, toast, snapshot]);
 
-  const run = useCallback(async () => {
-    if (runningRef.current) return;
+  // 启动运行全流程（lint → 保存 → 续跑决策 → 启动 → 跟随）。
+  // 并发运行：不因「已有运行在跑」而拒绝，每次调用都会新开一个 run。
+  const startRunFlow = useCallback(async () => {
     const runScopeEpoch = workflowScopeEpochRef.current;
     const runWorkflowId = currentWfIdRef.current;
     const graph = toGraph();
@@ -755,13 +852,27 @@ export default function App() {
     if (runId && stillCurrentScope) {
       activeRunIdRef.current = runId;
       runningRef.current = true;
-      setInspectedRunId(runId);
+      inspectRun(runId);
       setRunStatus((current) => ({ ...current, running: true, runId, done: 0, total: graph.nodes.filter((node) => node.type !== 'notify').length }));
     }
-  }, [save, setNodes, toGraph, triggerInput, runInputs, currentWf, toast, doLint]);
+    refreshRunList();
+  }, [save, setNodes, toGraph, triggerInput, runInputs, currentWf, toast, doLint, inspectRun, refreshRunList]);
+
+  // 启动请求 in-flight 门：请求发出→返回 runId 期间忽略重复点击（防双击开两个相同运行）。
+  // 不按「是否有运行在跑」互斥——多运行并发是本版本的核心能力。
+  const runStartInFlightRef = useRef(false);
+  const run = useCallback(async () => {
+    if (runStartInFlightRef.current) return;
+    runStartInFlightRef.current = true;
+    try {
+      await startRunFlow();
+    } finally {
+      runStartInFlightRef.current = false;
+    }
+  }, [startRunFlow]);
 
   const cancelRun = useCallback(async () => {
-    const runId = activeRunIdRef.current;
+    const runId = inspectedRunIdRef.current;
     if (!runId) return;
     const res = await fetch(apiUrl('/run/cancel'), {
       method: 'POST', headers: { 'Content-Type': 'application/json' },
@@ -1322,10 +1433,10 @@ export default function App() {
               { key: 'templates', icon: '▤', label: '模板库', onClick: () => setTemplateOpen(true) },
               { key: 'reset', icon: '⟲', label: '重置为示例', danger: true, onClick: resetGraph },
             ]} />
-            {runStatus.running ? (
-              <button className="btn btn-danger tb-run-btn" onClick={cancelRun} aria-label="取消运行"><span aria-hidden="true">■</span><span className="tb-run-label">取消</span></button>
-            ) : (
-              <button className="btn btn-primary tb-run-btn" onClick={run} aria-label="运行工作流"><span aria-hidden="true">▶</span><span className="tb-run-label">运行</span></button>
+            {/* 多运行并发：常驻「运行」随时可再开一轮；「取消」只作用于当前查看的运行 */}
+            <button className="btn btn-primary tb-run-btn" onClick={run} aria-label="运行工作流"><span aria-hidden="true">▶</span><span className="tb-run-label">运行</span></button>
+            {runStatus.running && (
+              <button className="btn btn-danger tb-run-btn" onClick={cancelRun} aria-label="取消当前查看的运行" title="取消当前查看的运行（不影响其他并行运行）"><span aria-hidden="true">■</span><span className="tb-run-label">取消</span></button>
             )}
           </>
         )}
@@ -1456,7 +1567,15 @@ export default function App() {
             aria-label={logOpen ? '收起成果面板' : '展开成果面板'}>
             {logOpen ? '▶ 收起' : '◀ 展开'}
           </button>
-          {logOpen && <ResultPanel
+          {logOpen && (
+            <>
+              <RunSwitcher
+                runs={runList.filter((r) => (r.workflowId || null) === (currentWfIdRef.current || null) || !currentWfIdRef.current)}
+                inspectedRunId={inspectedRunId}
+                onSelect={selectRunForView}
+                onOpenHistory={() => setHistoryOpen(true)}
+              />
+              <ResultPanel
             runDetail={runDetails[inspectedRunId]}
             events={eventsByRunId[inspectedRunId] || []}
             status={inspectedRunId === runStatus.runId ? runStatus : runDetails[inspectedRunId]}
@@ -1469,7 +1588,9 @@ export default function App() {
             onClose={() => setLogOpen(false)}
             onFocusNode={focusNode}
             onOpenNodeDetail={(runId, nodeId) => setNodeDetail({ runId, nodeId })}
-          />}
+          />
+            </>
+          )}
         </div>
           </>
         )}
@@ -1524,15 +1645,16 @@ export default function App() {
         onResume={(runId, resumedNodes, rerunNodes) => {
           activeRunIdRef.current = runId;
           runningRef.current = true;
-          setInspectedRunId(runId);
+          inspectRun(runId);
           setRunStatus((current) => ({ ...current, running: true, runId }));
+          refreshRunList();
           const rerunCount = rerunNodes?.length ?? 0;
           toast(rerunCount > 0
             ? `已从上次运行续跑（复用 ${resumedNodes} 个节点，${rerunCount} 个因画布修改重跑）`
             : `已从上次运行续跑（复用 ${resumedNodes} 个已完成节点）`, 'success');
         }}
         onSelect={(runId) => {
-        setInspectedRunId(runId);
+        inspectRun(runId);
         const applyDetail = (detail) => {
           // 历史恢复：把该次运行的节点状态/输出投影回画布（与 SSE snapshot 同形）
           for (const [nodeId, st] of Object.entries(detail.nodeStates || {})) {

--- a/web/src/RunSwitcher.jsx
+++ b/web/src/RunSwitcher.jsx
@@ -1,0 +1,34 @@
+// 运行切换器：成果面板顶部的运行胶囊条。LIVE 优先、时间倒序，点击切换当前查看的运行。
+import { SOURCE_ICON, SOURCE_LABEL, capsuleTime, switcherCapsules } from './run-switcher.js';
+
+const STATUS_DOT = { running: 'rs-dot-run', success: 'rs-dot-ok', error: 'rs-dot-err', canceled: 'rs-dot-cancel', interrupted: 'rs-dot-err' };
+
+export function RunSwitcher({ runs, inspectedRunId, onSelect, onOpenHistory }) {
+  const { shown, overflow } = switcherCapsules(runs);
+  if (!shown.length) return null;
+  return (
+    <div className="run-switcher" role="tablist" aria-label="运行切换">
+      {shown.map((r) => {
+        const active = r.runId === inspectedRunId;
+        return (
+          <button
+            key={r.runId}
+            className={`run-pill ${active ? 'run-pill-on' : ''}`}
+            role="tab"
+            aria-selected={active}
+            title={`${SOURCE_LABEL[r.source] || r.source} · ${r.live ? '运行中' : r.status}${r.startedAt ? ` · ${new Date(r.startedAt).toLocaleString('zh-CN', { hour12: false })}` : ''}`}
+            onClick={() => onSelect?.(r.runId)}
+          >
+            <span className={`rs-dot ${STATUS_DOT[r.status] || 'rs-dot-idle'}${r.live ? ' rs-dot-live' : ''}`} aria-hidden="true" />
+            <span className="rs-icon" aria-hidden="true">{SOURCE_ICON[r.source] || '▶'}</span>
+            <span className="rs-time">{capsuleTime(r.startedAt)}</span>
+            {r.progress && <span className="rs-progress">{r.progress}</span>}
+          </button>
+        );
+      })}
+      {overflow > 0 && (
+        <button className="run-pill run-pill-more" title="更多历史运行" onClick={onOpenHistory}>+{overflow}</button>
+      )}
+    </div>
+  );
+}

--- a/web/src/ScheduleCenter.jsx
+++ b/web/src/ScheduleCenter.jsx
@@ -1,0 +1,291 @@
+// 定时任务面板：列表（下次触发/触发统计/启停/立即运行/删除）+ 创建/编辑表单
+// （cron 预设 + 实时预览下 3 次触发 + 重叠策略）。风格对齐 VariableCenter 的 Modal。
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { apiUrl } from './api.js';
+import { Modal } from './ui.jsx';
+import { CRON_PRESETS, describeCron, presetOfCron } from './schedule-center.js';
+
+function formatNext(iso) {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  return date.toLocaleString('zh-CN', { hour12: false, month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+}
+
+function validateRunInputsJson(text) {
+  if (!text.trim()) return { ok: true, value: {} };
+  try {
+    const value = JSON.parse(text);
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+      return { ok: false, error: '运行参数必须是 JSON 对象（如 {"env": "prod"}）' };
+    }
+    return { ok: true, value };
+  } catch (e) {
+    return { ok: false, error: `JSON 格式错误：${e.message}` };
+  }
+}
+
+function ScheduleForm({ workflows, initial, onSubmit, onCancel, submitting }) {
+  const [workflowId, setWorkflowId] = useState(initial?.workflowId || (workflows[0]?.id || ''));
+  const [cron, setCron] = useState(initial?.cron || CRON_PRESETS[0].cron);
+  const [input, setInput] = useState(initial?.input || '');
+  const [runInputsText, setRunInputsText] = useState(initial?.runInputs && Object.keys(initial.runInputs).length ? JSON.stringify(initial.runInputs, null, 2) : '');
+  const [overlap, setOverlap] = useState(initial?.overlap || 'skip');
+  const [preview, setPreview] = useState({ state: 'idle' }); // idle | loading | ok | error
+  const preset = presetOfCron(cron);
+  const debounceRef = useRef(null);
+
+  useEffect(() => {
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    if (!cron.trim()) { setPreview({ state: 'idle' }); return undefined; }
+    setPreview({ state: 'loading' });
+    debounceRef.current = setTimeout(() => {
+      fetch(apiUrl('/schedule/preview'), {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ cron }),
+      })
+        .then((r) => r.json().then((data) => ({ ok: r.ok, data })))
+        .then(({ ok, data }) => setPreview(ok ? { state: 'ok', times: data.times || [] } : { state: 'error', error: data.error || 'cron 表达式无效' }))
+        .catch(() => setPreview({ state: 'error', error: '预览请求失败' }));
+    }, 300);
+    return () => clearTimeout(debounceRef.current);
+  }, [cron]);
+
+  const runInputsCheck = validateRunInputsJson(runInputsText);
+  const cronValid = preview.state === 'ok';
+  const canSubmit = workflowId && cron.trim() && cronValid && runInputsCheck.ok && !submitting;
+
+  const submit = () => {
+    if (!canSubmit) return;
+    onSubmit({
+      workflowId,
+      cron: cron.trim(),
+      input,
+      runInputs: runInputsCheck.value,
+      overlap,
+    });
+  };
+
+  return (
+    <div className="sch-form">
+      <section className="panel-sec">
+        <h4>工作流 <span className="sec-hint">定时任务按保存后的最新画布内容运行</span></h4>
+        <select className="sch-input" value={workflowId} onChange={(e) => setWorkflowId(e.target.value)} disabled={Boolean(initial?.workflowId)}>
+          {workflows.map((wf) => <option key={wf.id} value={wf.id}>{wf.name}</option>)}
+        </select>
+      </section>
+      <section className="panel-sec">
+        <h4>触发时间</h4>
+        <div className="sch-presets">
+          {CRON_PRESETS.map((p) => (
+            <button key={p.key} type="button" className={`chip ${preset?.key === p.key ? 'chip-on' : ''}`} onClick={() => setCron(p.cron)}>{p.label}</button>
+          ))}
+          <button type="button" className={`chip ${preset === null ? 'chip-on' : ''}`} onClick={() => setCron('')}>自定义</button>
+        </div>
+        <input
+          className={`sch-input ${preview.state === 'error' ? 'sch-input-err' : ''}`}
+          placeholder="cron 表达式（分 时 日 月 周，如 30 8 * * *）"
+          value={cron}
+          onChange={(e) => setCron(e.target.value)}
+        />
+        {preview.state === 'error' && <p className="sch-err">{preview.error}</p>}
+        {preview.state === 'loading' && <p className="sec-hint">校验中…</p>}
+        {preview.state === 'ok' && (
+          <p className="sch-preview">
+            <strong>{describeCron(cron) || '自定义周期'}</strong>
+            接下来：{preview.times.map((t) => formatNext(t)).join('、')}
+          </p>
+        )}
+      </section>
+      <section className="panel-sec">
+        <h4>触发输入 <span className="sec-hint">可选，模板里用 {'{{$trigger}}'} 引用</span></h4>
+        <textarea className="sch-input sch-textarea" rows={2} placeholder="如：执行今日巡检" value={input} onChange={(e) => setInput(e.target.value)} />
+      </section>
+      <section className="panel-sec">
+        <h4>运行参数 <span className="sec-hint">可选 JSON 对象，对应工作流输入 Schema 的入参</span></h4>
+        <textarea
+          className={`sch-input sch-textarea ${!runInputsCheck.ok ? 'sch-input-err' : ''}`}
+          rows={2}
+          placeholder='{"env": "prod"}'
+          value={runInputsText}
+          onChange={(e) => setRunInputsText(e.target.value)}
+        />
+        {!runInputsCheck.ok && <p className="sch-err">{runInputsCheck.error}</p>}
+      </section>
+      <section className="panel-sec">
+        <h4>重叠策略 <span className="sec-hint">到点时上一轮还没跑完怎么办</span></h4>
+        <div className="sch-overlap">
+          <label className={`sch-radio ${overlap === 'skip' ? 'sch-radio-on' : ''}`}>
+            <input type="radio" name="sch-overlap" checked={overlap === 'skip'} onChange={() => setOverlap('skip')} />
+            <span><strong>跳过本轮（推荐巡检）</strong><em>不重复执行、不重复推送，结束后下个周期照常</em></span>
+          </label>
+          <label className={`sch-radio ${overlap === 'parallel' ? 'sch-radio-on' : ''}`}>
+            <input type="radio" name="sch-overlap" checked={overlap === 'parallel'} onChange={() => setOverlap('parallel')} />
+            <span><strong>并行新开一轮</strong><em>与上一轮同时运行，互不干扰（消耗双份资源）</em></span>
+          </label>
+        </div>
+      </section>
+      <div className="sch-form-actions">
+        <button className="btn" onClick={onCancel} disabled={submitting}>取消</button>
+        <button className="btn btn-primary" onClick={submit} disabled={!canSubmit}>
+          {submitting ? '保存中…' : initial?.key ? '保存修改' : '创建任务'}
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export function ScheduleCenter({ currentWorkflowId, onRan, onClose, toast }) {
+  const [schedules, setSchedules] = useState([]);
+  const [workflows, setWorkflows] = useState([]);
+  const [mode, setMode] = useState('list'); // list | create | edit
+  const [editing, setEditing] = useState(null);
+  const [busy, setBusy] = useState('');
+  const [confirmDelete, setConfirmDelete] = useState(null);
+
+  const load = useCallback(async () => {
+    try {
+      const [schRes, wfRes] = await Promise.all([
+        fetch(apiUrl('/schedule')).then((r) => r.json()),
+        fetch(apiUrl('/workflows')).then((r) => r.json()),
+      ]);
+      setSchedules(schRes.schedules || []);
+      setWorkflows(wfRes.workflows || []);
+    } catch { /* 面板保持现状 */ }
+  }, []);
+  useEffect(() => { load(); }, [load]);
+
+  const act = async (name, fn) => {
+    if (busy) return;
+    setBusy(name);
+    try { await fn(); } finally { setBusy(''); }
+  };
+
+  const createOrUpdate = async (payload) => {
+    await act('save', async () => {
+      const isEdit = Boolean(editing?.key);
+      const res = await fetch(apiUrl('/schedule'), {
+        method: isEdit ? 'PATCH' : 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(isEdit ? { key: editing.key, ...payload } : payload),
+      });
+      const data = await res.json();
+      if (!res.ok) { toast(`保存失败：${data.error}`, 'error'); return; }
+      toast(isEdit ? '已保存修改' : '定时任务已创建', 'success');
+      setMode('list');
+      setEditing(null);
+      load();
+    });
+  };
+
+  const runNow = (row) => act(`run:${row.key}`, async () => {
+    const res = await fetch(apiUrl('/schedule/run'), {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: row.key }),
+    });
+    const data = await res.json();
+    if (!res.ok) { toast(`立即运行失败：${data.error}`, 'error'); return; }
+    toast('已触发运行，可在底部运行面板切换查看', 'success');
+    onRan?.();
+    load();
+  });
+
+  const toggleEnabled = (row) => act(`toggle:${row.key}`, async () => {
+    const res = await fetch(apiUrl('/schedule'), {
+      method: 'PATCH', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ key: row.key, enabled: !row.enabled }),
+    });
+    if (!res.ok) { toast('操作失败', 'error'); return; }
+    toast(row.enabled ? '已停用，到点不再触发' : '已启用', 'info');
+    load();
+  });
+
+  const doDelete = (key) => act(`del:${key}`, async () => {
+    const res = await fetch(apiUrl(`/schedule?key=${encodeURIComponent(key)}`), { method: 'DELETE' });
+    if (!res.ok) { toast('删除失败', 'error'); return; }
+    toast('已删除', 'info');
+    setConfirmDelete(null);
+    load();
+  });
+
+  const startCreate = () => {
+    // 预选当前打开的工作流（仅当它已保存）；草稿或未命中则用列表第一项兜底
+    setEditing(currentWorkflowId && workflows.some((wf) => wf.id === currentWorkflowId)
+      ? { workflowId: currentWorkflowId }
+      : null);
+    setMode('create');
+  };
+
+  return (
+    <Modal title={mode === 'list' ? '定时任务' : mode === 'create' ? '新建定时任务' : '编辑定时任务'} onClose={mode === 'list' ? onClose : () => { setMode('list'); setEditing(null); }}>
+      {mode !== 'list' ? (
+        <ScheduleForm
+          workflows={workflows}
+          initial={editing}
+          submitting={busy === 'save'}
+          onSubmit={createOrUpdate}
+          onCancel={() => { setMode('list'); setEditing(null); }}
+        />
+      ) : (
+        <div className="sch-list">
+          {!workflows.length && (
+            <p className="panel-note">还没有已保存的工作流。先在画布保存一个工作流，再来创建定时任务。</p>
+          )}
+          {workflows.length > 0 && !schedules.length && (
+            <div className="sch-empty">
+              <p className="panel-note">还没有定时任务。三步开始：</p>
+              <p className="sec-hint">1. 画布右上保存工作流 → 2. 点「新建定时任务」选周期 → 3. 到点自动运行，结果可在底部运行面板查看</p>
+            </div>
+          )}
+          {schedules.length > 0 && (
+            <div className="sch-rows">
+              {schedules.map((row) => (
+                <div key={row.key} className={`sch-row ${row.enabled ? '' : 'sch-row-off'}`}>
+                  <div className="sch-row-main">
+                    <div className="sch-row-title">
+                      <strong>{row.workflowName}</strong>
+                      {!row.enabled && <span className="badge">已停用</span>}
+                      {row.workflowMissing && <span className="badge badge-danger">工作流已删除</span>}
+                    </div>
+                    <div className="sch-row-meta">
+                      <span title={row.cron}>{describeCron(row.cron) || row.cron}</span>
+                      <span>下次 {formatNext(row.nextAt)}</span>
+                      <span>已触发 {row.fireCount ?? 0} 次{row.skippedCount ? `（跳过 ${row.skippedCount} 次）` : ''}</span>
+                      <span>{row.overlap === 'parallel' ? '重叠并行' : '重叠跳过'}</span>
+                    </div>
+                  </div>
+                  <div className="sch-row-actions">
+                    <button className="btn btn-sm" disabled={Boolean(busy) || row.workflowMissing} onClick={() => runNow(row)} title="立即运行一次（不影响定时周期）">
+                      {busy === `run:${row.key}` ? '运行中…' : '立即运行'}
+                    </button>
+                    <button className="btn btn-sm" disabled={Boolean(busy)} onClick={() => toggleEnabled(row)}>
+                      {busy === `toggle:${row.key}` ? '…' : row.enabled ? '停用' : '启用'}
+                    </button>
+                    <button className="btn btn-sm" disabled={Boolean(busy)} onClick={() => { setEditing(row); setMode('edit'); }}>编辑</button>
+                    <button className="btn btn-sm btn-danger" disabled={Boolean(busy)} onClick={() => setConfirmDelete(row)}>删除</button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+          {workflows.length > 0 && (
+            <div className="sch-footer">
+              <button className="btn btn-primary" onClick={startCreate} disabled={Boolean(busy)}>＋ 新建定时任务</button>
+            </div>
+          )}
+          {confirmDelete && (
+            <div className="sch-confirm">
+              <p>确定删除「{confirmDelete.workflowName}」的定时任务（{confirmDelete.cron}）？删除后不可恢复。</p>
+              <div className="sch-form-actions">
+                <button className="btn" onClick={() => setConfirmDelete(null)}>取消</button>
+                <button className="btn btn-danger" disabled={busy === `del:${confirmDelete.key}`} onClick={() => doDelete(confirmDelete.key)}>
+                  {busy === `del:${confirmDelete.key}` ? '删除中…' : '确认删除'}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/web/src/result-panel.css
+++ b/web/src/result-panel.css
@@ -194,3 +194,43 @@
 .result-expand-modal .modal-box { width: min(880px, 94vw); max-width: 94vw; max-height: 88vh; }
 .result-expand-modal .modal-body { padding: 20px 24px; }
 .result-expand-body { font-size: 14px; line-height: 1.75; }
+
+/* 运行切换器：成果面板顶部胶囊条（多运行并发时切换查看目标） */
+.run-switcher {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px 0 14px;
+}
+.run-switcher:empty { display: none; }
+.run-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 9px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--bg-panel);
+  color: var(--fg-muted);
+  font-size: 11px;
+  cursor: pointer;
+  transition: border-color var(--dur) var(--ease), color var(--dur) var(--ease);
+}
+.run-pill:hover { border-color: var(--accent, #6d8cff); color: var(--fg); }
+.run-pill-on { border-color: var(--accent, #6d8cff); color: var(--fg); box-shadow: 0 0 0 1px var(--accent, #6d8cff) inset; }
+.rs-dot { width: 7px; height: 7px; border-radius: 50%; flex: none; }
+.rs-dot-run { background: #f59e0b; }
+.rs-dot-live { animation: rs-pulse 1.2s ease-in-out infinite; }
+.rs-dot-ok { background: #10b981; }
+.rs-dot-err { background: #ef4444; }
+.rs-dot-cancel { background: #94a3b8; }
+.rs-dot-idle { background: #cbd5e1; }
+.rs-icon { font-size: 10px; line-height: 1; }
+.rs-time { font-variant-numeric: tabular-nums; }
+.rs-progress { color: var(--warn-fg, #f59e0b); font-variant-numeric: tabular-nums; }
+.run-pill-more { color: var(--fg-faint); }
+@keyframes rs-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: .35; }
+}

--- a/web/src/result-panel.css
+++ b/web/src/result-panel.css
@@ -234,3 +234,33 @@
   0%, 100% { opacity: 1; }
   50% { opacity: .35; }
 }
+
+/* 定时任务面板 */
+.sch-list { display: flex; flex-direction: column; gap: 10px; }
+.sch-empty { padding: 8px 2px; }
+.sch-rows { display: flex; flex-direction: column; gap: 8px; }
+.sch-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 11px; border: 1px solid var(--border); border-radius: 10px; }
+.sch-row-off { opacity: .62; }
+.sch-row-main { min-width: 0; display: flex; flex-direction: column; gap: 4px; }
+.sch-row-title { display: flex; align-items: center; gap: 6px; font-size: 13px; }
+.sch-row-meta { display: flex; flex-wrap: wrap; gap: 4px 12px; color: var(--fg-faint); font-size: 11px; }
+.sch-row-actions { display: flex; gap: 6px; flex: none; }
+.sch-footer { display: flex; justify-content: flex-end; padding-top: 2px; }
+.sch-confirm { border-top: 1px solid var(--border); padding-top: 10px; }
+.sch-confirm p { font-size: 12px; margin-bottom: 8px; }
+.sch-form { display: flex; flex-direction: column; gap: 2px; }
+.sch-presets { display: flex; flex-wrap: wrap; gap: 6px; margin: 6px 0 10px; }
+.sch-input { width: 100%; padding: 7px 10px; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-input, var(--bg-panel)); color: var(--fg); font-size: 12px; }
+.sch-input:focus { outline: none; border-color: var(--accent, #6d8cff); }
+.sch-input-err { border-color: var(--danger-fg, #ef4444); }
+.sch-textarea { resize: vertical; font-family: var(--mono, monospace); }
+.sch-err { color: var(--danger-fg, #ef4444); font-size: 11px; margin: 4px 0 0; }
+.sch-preview { margin: 6px 0 0; font-size: 11px; color: var(--fg-muted); }
+.sch-preview strong { color: var(--fg); margin-right: 8px; }
+.sch-overlap { display: flex; flex-direction: column; gap: 8px; margin: 6px 0; }
+.sch-radio { display: flex; gap: 8px; align-items: flex-start; padding: 8px 10px; border: 1px solid var(--border); border-radius: 10px; cursor: pointer; }
+.sch-radio-on { border-color: var(--accent, #6d8cff); }
+.sch-radio input { margin-top: 3px; }
+.sch-radio span { display: flex; flex-direction: column; gap: 2px; font-size: 12px; }
+.sch-radio em { font-style: normal; color: var(--fg-faint); font-size: 11px; }
+.sch-form-actions { display: flex; justify-content: flex-end; gap: 8px; padding-top: 10px; }

--- a/web/src/run-event-routing.js
+++ b/web/src/run-event-routing.js
@@ -15,3 +15,11 @@ export function eventBelongsToCanvas(payload, { canvasId, workflowId }) {
 export function eventBelongsToRun(payload, activeRunId) {
   return Boolean(payload?.runId && activeRunId && payload.runId === activeRunId);
 }
+
+// run-start 是否应把视图跟随切换到新运行：
+// 带本画布 canvasId 的启动（手动/续跑/助手）→ 跟随；定时/webhook 触发（无 canvasId）→ 不抢占视图。
+export function shouldFollowRunStart(payload, { canvasId, workflowId }) {
+  if (!payload?.runId) return false;
+  if (payload.source === 'schedule' || payload.source === 'webhook') return false;
+  return eventBelongsToCanvas(payload, { canvasId, workflowId });
+}

--- a/web/src/run-event-routing.test.mjs
+++ b/web/src/run-event-routing.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { eventBelongsToCanvas, eventBelongsToRun, normalizeWorkflowId } from './run-event-routing.js';
+import { eventBelongsToCanvas, eventBelongsToRun, normalizeWorkflowId, shouldFollowRunStart } from './run-event-routing.js';
 
 let passed = 0;
 function test(name, fn) {
@@ -47,6 +47,29 @@ test('only the active run can mutate live state', () => {
   assert.equal(eventBelongsToRun({ runId: 'run-old' }, 'run-new'), false);
   assert.equal(eventBelongsToRun({}, 'run-new'), false);
   assert.equal(eventBelongsToRun({ runId: 'run-new' }, null), false);
+});
+
+test('follow run start: 本画布手动/续跑启动跟随视图', () => {
+  const current = { canvasId: 'cv-a', workflowId: 'wf-a' };
+  assert.equal(shouldFollowRunStart({ runId: 'r1', canvasId: 'cv-a', workflowId: 'wf-a', source: 'manual' }, current), true);
+  assert.equal(shouldFollowRunStart({ runId: 'r1', canvasId: 'cv-a', workflowId: 'wf-a', source: 'resume' }, current), true);
+  assert.equal(shouldFollowRunStart({ runId: 'r1', canvasId: 'cv-a', workflowId: 'wf-a', source: 'assistant' }, current), true);
+});
+
+test('follow run start: 定时/webhook 触发不抢占视图（即使属于本工作流）', () => {
+  const current = { canvasId: 'cv-a', workflowId: 'wf-a' };
+  assert.equal(shouldFollowRunStart({ runId: 'r1', workflowId: 'wf-a', source: 'schedule' }, current), false);
+  assert.equal(shouldFollowRunStart({ runId: 'r1', workflowId: 'wf-a', source: 'webhook' }, current), false);
+  // 无 canvasId 的 manual（历史遗留形状）：命名工作流对齐时可跟随
+  assert.equal(shouldFollowRunStart({ runId: 'r1', workflowId: 'wf-a', source: 'manual' }, current), true);
+});
+
+test('follow run start: 其他画布/工作流的启动不跟随', () => {
+  const current = { canvasId: 'cv-a', workflowId: 'wf-a' };
+  assert.equal(shouldFollowRunStart({ runId: 'r1', canvasId: 'cv-b', workflowId: 'wf-a', source: 'manual' }, current), false);
+  assert.equal(shouldFollowRunStart({ runId: 'r1', canvasId: 'cv-a', workflowId: 'wf-b', source: 'manual' }, current), false);
+  assert.equal(shouldFollowRunStart({ runId: 'r1', source: 'manual' }, { canvasId: 'cv-a', workflowId: null }), false);
+  assert.equal(shouldFollowRunStart({ source: 'manual' }, current), false);
 });
 
 console.log(process.exitCode ? `${passed} tests passed with failures` : `ALL PASS (${passed})`);

--- a/web/src/run-switcher.js
+++ b/web/src/run-switcher.js
@@ -1,0 +1,37 @@
+// RunSwitcher 胶囊模型（纯函数，可单测）：
+// 合并 /runs 列表与本地已见运行，按「LIVE 优先、开始时间倒序」排序，截断展示。
+
+export const SOURCE_ICON = { manual: '▶', schedule: '⏰', webhook: '🪝', resume: '↻', replay: '↺', assistant: '✦' };
+export const SOURCE_LABEL = { manual: '手动', schedule: '定时', webhook: 'Webhook', resume: '续跑', replay: '重放', assistant: '助手' };
+
+export function switcherCapsules(runs, { max = 6 } = {}) {
+  const list = [...(runs || [])];
+  list.sort((a, b) => {
+    const liveDiff = Number(Boolean(b.live)) - Number(Boolean(a.live));
+    if (liveDiff) return liveDiff;
+    return new Date(b.startedAt || 0).getTime() - new Date(a.startedAt || 0).getTime();
+  });
+  const shown = list.slice(0, max);
+  return {
+    shown: shown.map((r) => ({
+      runId: r.runId,
+      status: r.live ? 'running' : r.status,
+      live: Boolean(r.live),
+      source: r.source || 'manual',
+      startedAt: r.startedAt,
+      progress: r.live && r.progress ? `${r.progress.done ?? '?'}/${r.progress.total ?? '?'}` : null,
+      resumedFrom: Boolean(r.resumedFrom),
+    })),
+    overflow: Math.max(0, list.length - shown.length),
+  };
+}
+
+export function capsuleTime(startedAt) {
+  if (!startedAt) return '';
+  const date = new Date(startedAt);
+  if (Number.isNaN(date.getTime())) return '';
+  const now = new Date();
+  const sameDay = date.toDateString() === now.toDateString();
+  const hm = `${String(date.getHours()).padStart(2, '0')}:${String(date.getMinutes()).padStart(2, '0')}`;
+  return sameDay ? hm : `${date.getMonth() + 1}/${date.getDate()} ${hm}`;
+}

--- a/web/src/run-switcher.test.mjs
+++ b/web/src/run-switcher.test.mjs
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { capsuleTime, switcherCapsules } from './run-switcher.js';
+
+let passed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+    console.log(`  ✓ ${name}`);
+  } catch (error) {
+    console.error(`  ✗ ${name}\n    ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+console.log('run switcher tests:');
+
+test('live 优先、其余按开始时间倒序', () => {
+  const { shown } = switcherCapsules([
+    { runId: 'old-a', status: 'success', startedAt: '2026-08-24T01:00:00Z' },
+    { runId: 'live-1', status: 'running', live: true, startedAt: '2026-08-25T01:00:00Z' },
+    { runId: 'new-done', status: 'error', startedAt: '2026-08-25T03:00:00Z' },
+  ]);
+  assert.deepEqual(shown.map((r) => r.runId), ['live-1', 'new-done', 'old-a']);
+});
+
+test('多个 live 按时间倒序聚在前面', () => {
+  const { shown } = switcherCapsules([
+    { runId: 'live-2', live: true, startedAt: '2026-08-25T05:00:00Z' },
+    { runId: 'done', status: 'success', startedAt: '2026-08-25T06:00:00Z' },
+    { runId: 'live-1', live: true, startedAt: '2026-08-25T04:00:00Z' },
+  ]);
+  assert.deepEqual(shown.map((r) => r.runId), ['live-2', 'live-1', 'done']);
+});
+
+test('live 胶囊状态强制 running 并带进度；非 live 无进度', () => {
+  const { shown } = switcherCapsules([
+    { runId: 'live-1', live: true, status: 'success', progress: { done: 2, total: 5 }, startedAt: '2026-08-25T01:00:00Z' },
+    { runId: 'done-1', status: 'error', progress: { done: 5, total: 5 }, startedAt: '2026-08-24T01:00:00Z' },
+  ]);
+  assert.equal(shown[0].status, 'running');
+  assert.equal(shown[0].progress, '2/5');
+  assert.equal(shown[1].progress, null);
+  assert.equal(shown[1].status, 'error');
+});
+
+test('超出的运行计入 overflow', () => {
+  const runs = Array.from({ length: 9 }, (_, i) => ({ runId: `r${i}`, status: 'success', startedAt: `2026-08-2${i}T01:00:00Z` }));
+  const { shown, overflow } = switcherCapsules(runs, { max: 6 });
+  assert.equal(shown.length, 6);
+  assert.equal(overflow, 3);
+  const empty = switcherCapsules([]);
+  assert.deepEqual(empty.shown, []);
+  assert.equal(empty.overflow, 0);
+});
+
+test('来源默认 manual，resumedFrom 透传', () => {
+  const { shown } = switcherCapsules([
+    { runId: 'a', startedAt: '2026-08-25T01:00:00Z', resumedFrom: 'prev' },
+    { runId: 'b', startedAt: '2026-08-25T02:00:00Z', source: 'schedule' },
+  ]);
+  assert.equal(shown[1].source, 'manual');
+  assert.equal(shown[1].resumedFrom, true);
+  assert.equal(shown[0].source, 'schedule');
+});
+
+test('capsuleTime：今天只显时分，跨天带月/日，非法输入空串', () => {
+  const now = new Date();
+  const sameDay = new Date(now.getTime() - 60_000);
+  const hm = `${String(sameDay.getHours()).padStart(2, '0')}:${String(sameDay.getMinutes()).padStart(2, '0')}`;
+  assert.equal(capsuleTime(sameDay.toISOString()), hm);
+  const otherDay = new Date('2020-01-02T03:04:00');
+  assert.equal(capsuleTime(otherDay.toISOString()), '1/2 03:04');
+  assert.equal(capsuleTime('not-a-date'), '');
+  assert.equal(capsuleTime(null), '');
+});
+
+console.log(process.exitCode ? `${passed} tests passed with failures` : `ALL PASS (${passed})`);

--- a/web/src/schedule-center.js
+++ b/web/src/schedule-center.js
@@ -1,0 +1,97 @@
+// 定时任务面板纯逻辑：cron 人类可读描述 + 预设映射（可单测）。
+
+export const CRON_PRESETS = [
+  { key: 'daily-9', label: '每天 09:00', cron: '0 9 * * *' },
+  { key: 'hourly', label: '每小时', cron: '0 * * * *' },
+  { key: 'weekly-mon-9', label: '每周一 09:00', cron: '0 9 * * 1' },
+  { key: 'weekdays-9', label: '工作日 09:00', cron: '0 9 * * 1-5' },
+];
+
+const WEEKDAYS = ['周日', '周一', '周二', '周三', '周四', '周五', '周六'];
+const WEEKDAY_ALIASES = { sun: 0, mon: 1, tue: 2, wed: 3, thu: 4, fri: 5, sat: 6 };
+
+function part(values, { min, max, unit }) {
+  if (values === '*') return { every: true, unit };
+  if (values.startsWith('*/')) {
+    const step = Number(values.slice(2));
+    if (Number.isInteger(step) && step > 0) return { every: step, unit };
+    return null;
+  }
+  const list = [];
+  for (const seg of values.split(',')) {
+    const range = seg.split('-');
+    if (range.length === 2) {
+      const lo = Number(range[0]);
+      const hi = Number(range[1]);
+      if ([lo, hi].every(Number.isInteger) && lo >= min && hi <= max && lo < hi) {
+        for (let v = lo; v <= hi; v += 1) list.push(v);
+        continue;
+      }
+      return null;
+    }
+    const v = Number(seg);
+    if (!Number.isInteger(v) || v < min || v > max) return null;
+    list.push(v);
+  }
+  return { values: [...new Set(list)].sort((a, b) => a - b), unit };
+}
+
+// 尽力把 5 段 cron 转成中文；解析不了返回 null（面板回退显示原文）。
+export function describeCron(cron) {
+  const segments = String(cron || '').trim().split(/\s+/);
+  if (segments.length !== 5) return null;
+  const minute = part(segments[0], { min: 0, max: 59, unit: '分' });
+  const hour = part(segments[1], { min: 0, max: 23, unit: '小时' });
+  const dom = part(segments[2], { min: 1, max: 31, unit: '日' });
+  const month = part(segments[3], { min: 1, max: 12, unit: '月' });
+  const dowRaw = segments[4].toLowerCase();
+  let dow;
+  if (dowRaw === '*') dow = { every: true, unit: '周' };
+  else if (/^(sun|mon|tue|wed|thu|fri|sat)(-(sun|mon|tue|wed|thu|fri|sat))?$/.test(dowRaw)) {
+    const names = dowRaw.split('-').map((n) => WEEKDAY_ALIASES[n]);
+    dow = names.length === 2
+      ? { values: [names[0], names[1]], unit: '周' }
+      : { values: [names[0]], unit: '周' };
+  } else {
+    // 周列允许 0-7（0 与 7 都是周日）
+    dow = part(dowRaw === '7' ? '0' : dowRaw, { min: 0, max: 6, unit: '周' });
+  }
+  if (!minute || !hour || !dom || !month || !dow) return null;
+
+  const hm = (h, m) => `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+  const everyText = (p) => (p.every === true ? `每${p.unit}` : `每 ${p.every} ${p.unit}`);
+
+  // 每天 H:M
+  if (hour.values?.length === 1 && dom.every === true && month.every === true && dow.every === true) {
+    if (minute.values?.length === 1) return `每天 ${hm(hour.values[0], minute.values[0])}`;
+    if (minute.every === true) return `每小时第 0 分起每分`;
+    if (minute.every) return `每小时每 ${minute.every} 分钟`;
+  }
+  // 每小时 第 M 分
+  if (hour.every === true && dom.every === true && month.every === true && dow.every === true) {
+    if (minute.values?.length === 1) return `每小时第 ${minute.values[0]} 分`;
+    if (minute.every === true) return `每分钟`;
+    if (minute.every) return `每 ${minute.every} 分钟`;
+  }
+  // 工作日 H:M（dow 1-5）优先于通用周几组合
+  if (dow.values?.length === 5 && dow.values.join(',') === '1,2,3,4,5' && dom.every === true && month.every === true) {
+    if (hour.values?.length === 1 && minute.values?.length === 1) return `工作日 ${hm(hour.values[0], minute.values[0])}`;
+    return '每个工作日';
+  }
+  // 周几 H:M
+  if (dow.values?.length && dom.every === true && month.every === true) {
+    const days = dow.values.map((d) => WEEKDAYS[d] || d).join('、');
+    if (hour.values?.length === 1 && minute.values?.length === 1) return `${days} ${hm(hour.values[0], minute.values[0])}`;
+    return `每${days}`;
+  }
+  // 每月几号 H:M
+  if (dom.values?.length === 1 && month.every === true && dow.every === true) {
+    if (hour.values?.length === 1 && minute.values?.length === 1) return `每月 ${dom.values[0]} 日 ${hm(hour.values[0], minute.values[0])}`;
+    return `每月 ${dom.values[0]} 日`;
+  }
+  return null;
+}
+
+export function presetOfCron(cron) {
+  return CRON_PRESETS.find((p) => p.cron === String(cron || '').trim()) || null;
+}

--- a/web/src/schedule-center.test.mjs
+++ b/web/src/schedule-center.test.mjs
@@ -1,0 +1,56 @@
+import assert from 'node:assert/strict';
+import { CRON_PRESETS, describeCron, presetOfCron } from './schedule-center.js';
+
+let passed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+    console.log(`  ✓ ${name}`);
+  } catch (error) {
+    console.error(`  ✗ ${name}\n    ${error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+console.log('schedule center tests:');
+
+test('常见 preset 人类可读描述', () => {
+  assert.equal(describeCron('0 9 * * *'), '每天 09:00');
+  assert.equal(describeCron('30 8 * * *'), '每天 08:30');
+  assert.equal(describeCron('0 * * * *'), '每小时第 0 分');
+  assert.equal(describeCron('15 * * * *'), '每小时第 15 分');
+  assert.equal(describeCron('*/10 * * * *'), '每 10 分钟');
+  assert.equal(describeCron('0 9 * * 1'), '周一 09:00');
+  assert.equal(describeCron('0 9 * * 1-5'), '工作日 09:00');
+  assert.equal(describeCron('0 9 1 * *'), '每月 1 日 09:00');
+});
+
+test('别名周几与 7=周日', () => {
+  assert.equal(describeCron('0 9 * * mon'), '周一 09:00');
+  assert.equal(describeCron('0 9 * * sun'), '周日 09:00');
+  assert.equal(describeCron('0 9 * * 0'), '周日 09:00');
+  assert.equal(describeCron('0 9 * * 7'), '周日 09:00');
+});
+
+test('多天组合：周一、周三', () => {
+  assert.equal(describeCron('0 9 * * 1,3'), '周一、周三 09:00');
+});
+
+test('解析不了返回 null（面板回退显示原文）', () => {
+  assert.equal(describeCron('bad'), null);
+  assert.equal(describeCron(''), null);
+  assert.equal(describeCron(null), null);
+  assert.equal(describeCron('99 * * * *'), null);
+  assert.equal(describeCron('0 9 * * * *'), null);
+  assert.equal(describeCron('5-3 * * * *'), null);
+});
+
+test('presetOfCron：命中返回预设，未命中 null', () => {
+  assert.equal(presetOfCron('0 9 * * *')?.key, 'daily-9');
+  assert.equal(presetOfCron('  0 9 * * *  ')?.key, 'daily-9');
+  assert.equal(presetOfCron('13 13 * * *'), null);
+  assert.equal(CRON_PRESETS.length, 4);
+});
+
+console.log(process.exitCode ? `${passed} tests passed with failures` : `ALL PASS (${passed})`);


### PR DESCRIPTION
Closes #35

## 背景

工作流画布此前是「单活跃运行」模型：运行按钮互斥、run-start 事件抢占覆盖跟踪的 runId、节点状态单份投影，第二个运行的事件被丢弃或互相覆盖。定时任务后端有骨架但零 UI，且不支持运行参数、统计不落盘、插件停止不清理定时器。

## 方案

### 后端（dsh-ccpg-orchestrator）
- 抽取 `lib/schedule.js`：`computeNextDelay` / `upcomingFireTimes` / `hasLiveRunForWorkflow` / `createScheduler`（链式 setTimeout，保留 24.8 天分段），纯函数可单测
- **重叠策略**：meta 新增 `overlap`（skip|parallel，默认 skip）——到点时上一轮未跑完则跳过并计数（防巡检类任务重复推送），可选并行
- fire 支持 `runInputs`；`fireCount/skippedCount/nextAt` 落盘，重启恢复统计
- API：PATCH（停用/改配置）、`/schedule/preview`（下 3 次触发）、`/schedule/run`（立即运行，不受 overlap/enabled 限制）；列表实时 join 工作流现名
- 恢复：`enabled:false` 只入 meta 不起定时器；插件停止先清全部调度定时器再关 sqlite
- 修复：空 cron 被 cron-parser 宽松解析为每分钟执行（显式拒绝）；run-start 事件补 workflowName

### 前端（web/）
- **多运行并发**：解除运行互斥（保留启动 in-flight 门防双击）；单一事实源 `inspectedRunId`——查看哪个运行就实时更新哪个；run-start 只跟随本画布发起的运行，定时/webhook 触发不抢占视图（toast 提示）
- **RunSwitcher 胶囊条**（成果面板顶部）：LIVE 优先、时间倒序，状态色点 + 来源图标（▶⏰🪝↻）+ live 进度；点击切换画布节点投影/过程日志/成果面板/取消按钮联动目标；live 存在时 5s 轮询兜底（经 ref 读 live 标记，避免请求风暴）
- **ScheduleCenter**（⋯ 菜单「定时任务」）：列表（工作流名实时 / cron 中文描述 / 下次触发 / 触发与跳过统计 / 启停 / 立即运行 / 编辑 / 删除确认）；创建表单带 cron 预设 chips、防抖校验、下 3 次触发预览、运行参数 JSON 校验、重叠策略 radio；空态三步引导

## 验证

### 单测（全过）
- orchestrator：既有 17 套 + `schedule.test.mjs` 12 例 + `schedule-api.integration.test.mjs` 8 例（含同图并发两 run 同时 live、输出互不串扰的 API 级回归）
- web：既有 14 套 + `run-event-routing` 扩 3 例 + `run-switcher` 6 例 + `schedule-center` 5 例（已注册进 npm test 聚合）
- `build-web.sh` 双构建通过

### 本地真实跑通（dsh 4023 + 隔离工作区 + 真实浏览器）
- 连续两次手动运行不互斥，两个 ▶ 胶囊并排出现，各自独立成功记录
- 创建每分钟定时任务（parallel）：到点 ⏰ 胶囊即时出现且排在最前，**视图未抢占**（原选中胶囊保持高亮）；点击 ⏰ 胶囊切换后画布节点状态/面板状态正确投影
- ScheduleCenter：列表显示「每分钟 / 下次 18:09 / 已触发 1 次 / 重叠并行」，立即运行计数 +1，停用后 nextAt=「—」+「已停用」徽章，启用后恢复
- 重启 dsh：任务恢复、fireCount=2 统计延续、调度链重新挂载；SSE 确认 run-start 已带 workflowName
- 页面刷新：7 个运行胶囊全部恢复 +「+2」溢出折叠

## 过程中修复的真问题
1. 轮询 effect 依赖 runList 导致的 /runs 请求风暴（E2E 发现）
2. run-start 事件缺 workflowName，toast 兜底成「当前工作流」（E2E 发现）
3. 空 cron = 每分钟执行的 cron-parser 宽松解析陷阱（写测试时发现）
4. schedule meta 写入顺序导致 nextAt 落盘丢失（集成测试发现）