### PR TITLE
fix(orchestrator): 定时统计唯一属主与触发即落盘（#35 自查遗留）

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -1844,6 +1844,14 @@ export function apply(ctx, config) {
     });
     return runId;
   };
+  // 计数唯一属主是 meta Map：调度器经 onFire/onSkip 回调增量、这里落盘。
+  // onMeta 只回传 nextAt（不含计数），手动「立即运行」也走 onFire，统计不会被覆盖回退。
+  const bumpScheduleStat = (key, field) => {
+    const prev = currentSchedulerMeta().get(key);
+    if (!prev) return;
+    currentSchedulerMeta().set(key, { ...prev, [field]: (prev[field] || 0) + 1 });
+    persistTriggers();
+  };
   const startSchedule = (key, meta) => {
     const entry = createScheduler({
       meta: { ...meta, key },
@@ -1852,22 +1860,22 @@ export function apply(ctx, config) {
       isBusy: () => scheduleBusy(meta.workflowId),
       logger: ctx.logger,
       onMeta: (live) => {
-        // 只更新统计/nextAt，创建时字段以 meta Map 为准（PATCH 可能已改 cron 等）
         const current = currentSchedulerMeta().get(key) || { ...meta, key };
-        currentSchedulerMeta().set(key, { ...current, ...live, key });
+        // 只取 nextAt，配置与计数以 Map 为准（PATCH 可能已改 cron，手动运行已改计数）
+        currentSchedulerMeta().set(key, { ...current, nextAt: live.nextAt ?? null, key });
       },
+      onFire: () => bumpScheduleStat(key, 'fireCount'),
+      onSkip: () => bumpScheduleStat(key, 'skippedCount'),
     });
     return entry;
   };
-  // 手动「立即运行」：不受 overlap/enabled 限制，不干扰调度链
+  // 手动「立即运行」：不受 overlap/enabled 限制，不干扰调度链；经 onFire 记账
   const runScheduleNow = (key) => {
     const prev = currentSchedulerMeta().get(key);
     if (!prev) return { ok: false, error: '任务不存在' };
     const runId = fireScheduleRun(prev);
     if (!runId) return { ok: false, error: '工作流已删除或启动失败' };
-    const nextMeta = { ...prev, fireCount: (prev.fireCount || 0) + 1 };
-    currentSchedulerMeta().set(key, nextMeta);
-    persistTriggers();
+    bumpScheduleStat(key, 'fireCount');
     return { ok: true, runId };
   };
   ensureTriggers = () => {

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/schedule.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/schedule.js
@@ -86,30 +86,23 @@ export function persistableScheduleMeta(meta) {
 }
 
 // 链式调度器：到点按 overlap 策略决定真跑还是跳过；fireNow 供「立即运行」绕过策略。
-// onMeta 在统计/nextAt 变化时回调（index.js 借此同步 meta Map 并落盘）。
-export function createScheduler({ meta, fire, isBusy, logger, now = () => Date.now(), onMeta } = {}) {
+// 计数属主是调用方（meta Map）：onFire/onSkip 回调时由调用方增量并落盘，
+// onMeta 只回传 nextAt（不带 fireCount/skippedCount，避免覆盖调用方的手动计数）。
+export function createScheduler({ meta, fire, isBusy, logger, now = () => Date.now(), onMeta, onFire, onSkip } = {}) {
   const normalized = normalizeScheduleMeta(meta);
   const state = {
     stopped: false,
     rawTimer: null,
     nextAt: null,
-    fireCount: normalized.fireCount,
-    skippedCount: normalized.skippedCount,
   };
-  const liveMeta = () => ({
-    ...normalized,
-    key: normalized.key,
-    nextAt: state.nextAt,
-    fireCount: state.fireCount,
-    skippedCount: state.skippedCount,
-  });
+  // onMeta 只回传 { key, nextAt }：计数属主是调用方（回传计数会把它手动记的账覆盖回退）
+  const liveMeta = () => ({ key: normalized.key, nextAt: state.nextAt });
   const report = () => onMeta?.(liveMeta());
 
   const runFire = () => {
-    state.fireCount += 1;
-    report();
     try {
       fire?.();
+      onFire?.();
     } catch (error) {
       logger?.warn?.(`dsh-ccpg 定时运行失败（${normalized.key}）：${error?.message || error}`);
     }
@@ -132,13 +125,16 @@ export function createScheduler({ meta, fire, isBusy, logger, now = () => Date.n
     const onTime = () => {
       if (state.stopped) return;
       if (normalized.overlap === 'skip' && isBusy?.()) {
-        state.skippedCount += 1;
+        state.skipped = true;
         logger?.info?.(`dsh-ccpg 定时触发跳过（${normalized.key}）：上一轮运行尚未结束`);
+        onSkip?.();
         report();
         armNext();
         return;
       }
+      state.skipped = false;
       runFire();
+      report();
       armNext();
     };
     if (nextMs > MAX_WAIT) {
@@ -150,7 +146,8 @@ export function createScheduler({ meta, fire, isBusy, logger, now = () => Date.n
   armNext();
 
   return {
-    // 手动「立即运行」：不受 overlap/enabled 限制，不干扰既定调度链
+    // 手动「立即运行」：不受 overlap/enabled 限制，不干扰既定调度链。
+    // 计数同样经 onFire 回调由调用方记账。
     fireNow() {
       if (state.stopped) return false;
       runFire();

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/schedule-api.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/schedule-api.integration.test.mjs
@@ -143,6 +143,22 @@ await test('POST /schedule/run：立即触发返回 runId 并计入 fireCount；
   const row = list.body.schedules.find((s) => s.key === globalThis.__schKey);
   assert.equal(row.fireCount, 1);
   assert.deepEqual(row.runInputs, { env: 'prod' });
+  // 手动计数不能被调度链的 nextAt 上报冲掉（onMeta 只回传 nextAt）
+  const listAgain = await call('GET', '/wf1/api/schedule');
+  assert.equal(listAgain.body.schedules.find((s) => s.key === globalThis.__schKey).fireCount, 1);
+});
+
+await test('PATCH：改配置/启停不清零触发与跳过统计', async () => {
+  await call('PATCH', '/wf1/api/schedule', { key: globalThis.__schKey, cron: '0 7 * * *' });
+  const afterCron = await call('GET', '/wf1/api/schedule');
+  const rowCron = afterCron.body.schedules.find((s) => s.key === globalThis.__schKey);
+  assert.equal(rowCron.fireCount, 1, '改 cron 不应清零 fireCount');
+  await call('PATCH', '/wf1/api/schedule', { key: globalThis.__schKey, enabled: false });
+  await call('PATCH', '/wf1/api/schedule', { key: globalThis.__schKey, enabled: true });
+  const afterToggle = await call('GET', '/wf1/api/schedule');
+  const rowToggle = afterToggle.body.schedules.find((s) => s.key === globalThis.__schKey);
+  assert.equal(rowToggle.fireCount, 1, '停用/启用不应清零 fireCount');
+  await call('PATCH', '/wf1/api/schedule', { key: globalThis.__schKey, cron: '0 9 * * *' });
 });
 
 await test('PATCH /schedule：停用后 nextAt 置空、不再持有调度器；重新启用恢复', async () => {

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/schedule.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/schedule.test.mjs
@@ -93,39 +93,42 @@ await test('persistableScheduleMeta：落盘含全部统计与配置字段', () 
   });
 });
 
-await test('createScheduler：每秒 cron 到点触发 fire 并累计 fireCount', async () => {
+await test('createScheduler：每秒 cron 到点触发 fire 并回调 onFire', async () => {
   let fired = 0;
+  let onFire = 0;
   const metas = [];
   const scheduler = createScheduler({
     meta: { key: 'sch_t1', workflowId: 'wf', cron: '* * * * * *', overlap: 'skip' },
     fire: () => { fired += 1; },
+    onFire: () => { onFire += 1; },
     isBusy: () => false,
     onMeta: (m) => metas.push(m),
   });
   try {
     await sleep(2300);
     assert.ok(fired >= 2, `expect >=2 fires got ${fired}`);
+    assert.equal(onFire, fired, 'onFire 每次真跑都应回调');
     const last = metas[metas.length - 1];
-    assert.equal(last.fireCount, fired);
     assert.ok(last.nextAt, 'nextAt 应已上报');
+    assert.equal(last.fireCount, undefined, 'onMeta 不回传计数（计数属主是调用方）');
   } finally {
     scheduler.stop();
   }
 });
 
-await test('createScheduler：skip 策略下上一轮 live → 到点跳过并累计 skippedCount，不调 fire', async () => {
+await test('createScheduler：skip 策略下上一轮 live → onSkip 回调且不调 fire', async () => {
   let fired = 0;
   let skipped = 0;
   const scheduler = createScheduler({
     meta: { key: 'sch_t2', workflowId: 'wf', cron: '* * * * * *', overlap: 'skip' },
     fire: () => { fired += 1; },
+    onSkip: () => { skipped += 1; },
     isBusy: () => true,
-    onMeta: (m) => { skipped = m.skippedCount; },
   });
   try {
     await sleep(2300);
     assert.equal(fired, 0, 'skip + busy 不应真跑');
-    assert.ok(skipped >= 2, `expect skippedCount>=2 got ${skipped}`);
+    assert.ok(skipped >= 2, `expect onSkip>=2 got ${skipped}`);
   } finally {
     scheduler.stop();
   }
@@ -146,15 +149,18 @@ await test('createScheduler：parallel 策略无视 isBusy 直接触发', async 
   }
 });
 
-await test('createScheduler：fireNow 立即触发且不受 isBusy 影响；stop 后 fireNow 拒绝', () => {
+await test('createScheduler：fireNow 立即触发且走 onFire、不受 isBusy 影响；stop 后拒绝', () => {
   let fired = 0;
+  let onFire = 0;
   const scheduler = createScheduler({
     meta: { key: 'sch_t4', workflowId: 'wf', cron: '0 9 * * *', overlap: 'skip' },
     fire: () => { fired += 1; },
+    onFire: () => { onFire += 1; },
     isBusy: () => true,
   });
   assert.equal(scheduler.fireNow(), true);
   assert.equal(fired, 1);
+  assert.equal(onFire, 1, 'fireNow 也应经 onFire 记账');
   scheduler.stop();
   assert.equal(scheduler.fireNow(), false);
   assert.equal(fired, 1);
@@ -174,16 +180,16 @@ await test('createScheduler：无效 cron 起动即停（不触发 fire），nex
   scheduler.stop();
 });
 
-await test('createScheduler：统计从 meta 续算（重启恢复语义）', () => {
-  const metas = [];
+await test('createScheduler：fire 失败也照常链下一轮（不卡死调度）', async () => {
+  let fired = 0;
   const scheduler = createScheduler({
-    meta: { key: 'sch_t6', workflowId: 'wf', cron: '0 9 * * *', overlap: 'skip', fireCount: 7, skippedCount: 4 },
-    fire: () => {},
-    onMeta: (m) => metas.push(m),
+    meta: { key: 'sch_t6', workflowId: 'wf', cron: '* * * * * *', overlap: 'skip' },
+    fire: () => { fired += 1; throw new Error('boom'); },
+    logger: { warn() {} },
   });
   try {
-    assert.equal(metas[0].fireCount, 7);
-    assert.equal(metas[0].skippedCount, 4);
+    await sleep(2300);
+    assert.ok(fired >= 2, `异常后链式调度应继续 got ${fired}`);
   } finally {
     scheduler.stop();
   }

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -159,6 +159,23 @@ export default function App() {
         done: Object.values(detail.nodeStates || {}).filter((st) => ['success', 'error', 'canceled', 'skipped'].includes(st.status)).length,
         total: (detail.graph?.nodes || []).filter((n) => n.type !== 'notify').length || current.total,
       }));
+      // 未旁观过的运行（定时触发/历史）没有过程事件，从详情合成一份，过程 tab 不空白
+      setEventsByRunId((current) => (current[runId]?.length ? current : {
+        ...current,
+        [runId]: [
+          ...Object.entries(detail.nodeStates || {})
+            .filter(([, st]) => st.status !== 'queued')
+            .map(([nodeId, st]) => ({
+              t: Date.now(), kind: 'node', runId, nodeId,
+              nodeLabel: labelOf(nodesRef.current, nodeId).replace(/\(.*\)$/, ''),
+              status: st.status, text: st.error, chars: st.chars, durationMs: st.durationMs,
+            })),
+          {
+            t: Date.now(), kind: 'run', runId, status: detail.status,
+            text: detail.status === 'running' ? '运行进行中' : `运行：${STATUS_CN[detail.status] || detail.status}`,
+          },
+        ],
+      }));
     };
     const cached = runDetailsRef.current[runId];
     if (cached) applyDetail(cached);


### PR DESCRIPTION
Relates #35（PR #36 合并后的自查复审发现）

## 问题

1. **手动计数被冲掉**：`/schedule/run` 直接把 Map 里 fireCount+1，但调度器内部有独立计数，下次到点 `onMeta` 回传时覆盖 Map —— 手动触发的次数从统计消失
2. **纯 cron 计数不落盘**：`onMeta` 只改内存 Map，仅 POST/PATCH/DELETE/手动运行时才 persistTriggers。重启后纯 cron 触发的增量全部丢失（此前 E2E 看到的 fireCount=2 恰是手动运行那次 persist 的值，掩盖了缺陷）
3. **前端短板**：RunSwitcher 切到未旁观过的运行（定时触发/刷新后）过程 tab 空白——RunHistory 有合成逻辑，selectRunForView 没有

## 修复

- `createScheduler` 不再持有计数：新增 `onFire`/`onSkip` 回调，调用方（meta Map）增量并**即时 persistTriggers**；`onMeta` 只回传 `{key, nextAt}`（不携带计数，杜绝覆盖）
- 手动「立即运行」同样经 `onFire` 记账；PATCH 改 cron/启停展开自 prev，计数天然保留
- `selectRunForView` 从详情合成过程事件（与历史抽屉同形），过程 tab 不再空白

## 验证

- 单测：schedule 12 例改断言 onFire/onSkip 契约 + 新增 fire 异常不卡调度链；集成 9 例补「手动计数不被 nextAt 上报冲掉」「PATCH 不清零统计」；orchestrator 19 套 + web 全量 + 双构建全过（pre-push 钩子亦全绿）
- **E2E 实证**（真实 dsh + 每分钟任务）：
  - 纯 cron 触发 2 次后，磁盘 triggers.json 落盘 `fireCount:2`（修复前停留 0）
  - 重启 dsh → 恢复 `fireCount:2`，下一分钟到点递增至 3
  - 面板显示「已触发 2 次」；点击 ⏰ 胶囊后过程 tab 显示 3 条合成记录（总时长 + 节点步骤）