### PR TITLE
feat(orchestrator): workflow_* 助手工具家族——对话查询/运行/终止/修改/切换画布

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,10 @@
 - **PR 流程**（主题分支专用）：
   - push 后开 PR，标题即 Conventional Commit 格式（squash merge 后 commit 历史天然规范）
   - PR 描述写背景/方案/验证结果（截图、测试数字），这是决策记录的档案
+  - **合并门槛（缺一不可，合并前自查）**：
+    1. **代码审核已做且问题已修**：对完整 diff 自审（可叫 AI 复审），发现的缺陷修完并复测
+    2. **本地真实跑通**：改动面相关的真实环境验证——引擎/插件改动要起真 dsh 实测，前端改动要在真实浏览器里点到（E2E 配方见「测试与验证」），不是单测绿就完
+    3. 全量回归 + `build-web.sh` 双构建通过；CI 绿
   - **Squash and merge** 合并：WIP 细分提交压成 1 个干净提交；确需保留细分时用 Rebase merge；不用 merge commit
   - 自查：开 PR 后隔 10 分钟过一遍完整 diff 再合
 - **多主题并行用 worktree**：`git worktree add ../harness-one-<topic> -b feat/<topic>` 开独立工作目录，各主题互不干扰、随时可弃；同一分支不能检出两个 worktree；新 worktree 要重装 node_modules（多 package 仓库）；用完 `git worktree remove` + 定期 `git worktree prune`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ CI：`.github/workflows/ci.yml` 在 PR 与 main push 上跑 `npm test` + `build-
 5. **构建产物一律不入库**（`web-dist/`、`canvasui lib/client.js`、`document-preview/dist/`、`web/dist/` 全部 gitignore）：分发包「拿到即装」由 `pack.sh` 现场重跑构建保证；源码安装先 `build-web.sh` 再 `setup.sh`（setup 已前置校验）。绝不为省一步构建把产物提交进仓库。
 6. **消息通知走渠道抽象**：运行级事件、去重、模式判断、摘要脱敏与失败隔离统一放在 `orchestrator/lib/notifications.js`；渠道实现只放 `notification-<channel>.js`，负责配置校验、消息渲染和发送。新增钉钉/企业微信时注册 provider 到 `NotificationChannelRegistry`，并通过 `/wf1/api/tools` 的 `notificationChannels` 暴露给前端；禁止复制运行监听器或在前端写死完整渠道清单。通知失败只能写节点 `notification` 元数据，不能改变业务运行状态。
 7. **多运行并发 + 定时任务**：引擎天然多运行（`Orchestrator.runs` Map，runId 全链路隔离），前端查看态以 `inspectedRunId` 为单一事实源（RunSwitcher 胶囊切换），不要回退到单活跃 run 模型；run-start 只跟随本画布发起的运行，schedule/webhook 触发不抢占视图。定时调度核心在 `orchestrator/lib/schedule.js`（cron/overlap/统计），meta 持久化在 `state/triggers.json`（不迁 SQLite）；前端面板 `web/src/ScheduleCenter.jsx` + `describeCron`。
+8. **助手工具两家族分工**：`canvas_*` 锚定当前绑定画布/草稿（须 `/assistant/bind` 绑定会话）；`workflow_*` 按工作流 id/name 管库，任意会话可用（按会话 cwd 经 `sessionStore` 定工作区，解析失败不回退默认工作区）。两家族共享 `startWorkflowRun`（启动已保存工作流：组装全局/工作流变量+runInputs 校验）与 `runProgressOf/resumableRun` 整形；改库后若画布正打开该工作流必须同步 cv 并广播 `assistant-patch`，`workflow_open` 广播 `assistant-open-workflow`（前端复用 openWorkflow 路径，脏草稿先静默保存）。节点 agent 工具白名单不含 workflow_*/canvas_*，不会递归发起运行。
 
 ### 消息通知节点约束
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ sh start.sh dev
 
 官方 dsh Web UI 的聊天里直接改图（同 session，经 canvas_* 工具落图）：`canvas_get_graph` / `canvas_graph_summary` / `canvas_graph_patch`（批量原子操作，含 script 节点契约）/ `canvas_lint_graph` / `canvas_run_workflow` / `canvas_run_status`。点击对话输入框旁的工作流按钮，在右侧 better-sidebar 打开当前 session 的画布；主区对话持续可见。
 
+**workflow_* 工具家族**（按工作流 id/name 操作，不依赖画布绑定，任意官方聊天会话可用；按会话 cwd 定工作区）：
+
+- 查询：`workflow_list`（清单+各 live 运行数）/ `workflow_get`（概要省 token 或完整图）/ `workflow_runs`（live 优先+最近 N，可过滤）/ `workflow_run_status`（单 run 详情）
+- 运行：`workflow_run`（异步返回 runId）/ `workflow_run_cancel`（按 runId、工作流或 all 批量）
+- 管理：`workflow_patch`（原子改图+可选改名，正打开的画布实时同步）/ `workflow_create` / `workflow_delete`（confirm 门 + live/webhook/定时关联守卫）/ `workflow_open`（把绑定画布切到指定工作流，SSE 联动）
+
 ## 飞书
 
 - **账号登录**：官方 dsh Web UI 设置面板「飞书账号」扫码（lark-cli Device Flow，token 由 CLI 自管零落盘）；user token 后台自动续约（refresh 轮换，授权长期有效）

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/assistant.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/assistant.js
@@ -202,10 +202,13 @@ export function canvasAssistantPersona() {
 - 节点 label 用中文短名（如「分类智能体」）；上下游引用靠 label（{{分类智能体}}）。
 
 ## 操作规范
-1. 改图一律用 canvas_graph_patch（一批 ops 原子生效，出错整批拒绝会返回错误让你修正）；不要试图整图重写。
+1. 改图一律用 canvas_graph_patch（当前画布/草稿）或 workflow_patch（已保存工作流，按 id）；一批 ops 原子生效，出错整批拒绝会返回错误让你修正；不要试图整图重写。
 2. 新节点接入链路：addNode 带 after=<上游节点id> 自动连线；显式连线用 connect。
 3. 每次改完调 canvas_lint_graph 自检；有 error 必须修掉再回复用户。
-4. 需要看当前图调 canvas_get_graph；运行/试运行调 canvas_run_workflow / canvas_test_node / canvas_run_status。
-5. 修改已有节点用 updateNode 只传变化字段；改名用 renameNode（下游模板引用会自动同步）。
-6. 回复用户时简洁说明改了什么（节点名/连线），不复述 JSON。`;
+4. 运行：当前画布用 canvas_run_workflow；按工作流 id/name 运行用 workflow_run。两者都异步返回 runId，用 canvas_run_status / workflow_run_status 轮询，或 workflow_runs 查列表。
+5. 用户问「有哪些工作流」「现在在跑什么、什么状态」：workflow_list / workflow_runs（onlyLive 只看运行中）。取消/终止运行用 workflow_run_cancel。
+6. 管理已保存工作流（新建/改名/复制/删除）用 workflow_create / workflow_patch(name) / workflow_delete；删除必须 confirm:true，有关联运行/定时/webhook 时工具会拒绝并列出关联。
+7. 让用户屏幕切到某工作流：workflow_open（需本会话绑定画布）。
+8. 修改已有节点用 updateNode 只传变化字段；改名用 renameNode（下游模板引用会自动同步）。
+9. 回复用户时简洁说明改了什么（节点名/连线/运行结果），不复述 JSON。`;
 }

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -782,7 +782,8 @@ export function apply(ctx, config) {
         if (r.error) return r.error;
         const cv = canvasOf(exec.canvasId);
         cv.workflowId = r.wf.id;
-        cv.graph = r.wf.graph;
+        // 浅拷贝防别名：库里的图对象与画布态解耦，后续任一侧替换互不影响
+        cv.graph = { nodes: r.wf.graph.nodes.map((n) => ({ ...n, data: { ...n.data } })), edges: r.wf.graph.edges.map((e) => ({ ...e })) };
         cv.version += 1;
         broadcast('assistant-open-workflow', {
           canvasId: exec.canvasId, workflowId: r.wf.id,

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -345,6 +345,27 @@ export function apply(ctx, config) {
     return { applied: true };
   };
 
+  // 按已保存工作流启动运行（/run API 的 workflowId 分支与 canvas_run_workflow / workflow_run 工具同源）：
+  // 组装全局/工作流变量、校验 runInputs，统一走 startRun。
+  const startWorkflowRun = (wf, { triggerInput = '', runInputs = {}, canvasId = null, source = 'manual' } = {}) => {
+    const lint = lintWorkflowGraph(wf.graph);
+    if (!lint.ok) {
+      const err = lint.issues.find((i) => i.level === 'error')?.message || '图存在错误';
+      return { ok: false, error: `图有错误不能运行：${err}` };
+    }
+    let globals; try { globals = globalContext(); } catch (error) { return { ok: false, error: String(error.message || error) }; }
+    let inputs; try { inputs = assertSafeContextObject(runInputs, 'runInputs'); } catch (error) { return { ok: false, error: String(error.message || error) }; }
+    const { runId } = startRun(wf.graph, {
+      triggerInput, workflowName: wf.name, workflowId: wf.id,
+      canvasId,
+      globalVariables: globals.globalVariables,
+      workflowVariables: variableDefinitionsToValues(wf.variables),
+      runInputs: inputs,
+      source,
+    });
+    return { ok: true, runId };
+  };
+
   const canvasTools = {
     canvas_get_graph: {
       description: '获取当前工作流画布的完整图 JSON（节点+边）。',
@@ -427,12 +448,18 @@ export function apply(ctx, config) {
       async execute(args, exec) {
         const cv = canvasOf(exec.canvasId);
         if (!cv.graph) return '画布尚未打开或未上报图。';
-        const graph = cv.workflowId ? (() => { try { return readWf(cv.workflowId)?.graph || cv.graph; } catch { return cv.graph; } })() : cv.graph;
-        const lint = lintWorkflowGraph(graph);
+        if (cv.workflowId) {
+          const wf = readWf(cv.workflowId);
+          if (!wf) return '画布绑定的工作流已不存在（可能已删除），请重新打开或保存。';
+          const r = startWorkflowRun(wf, { triggerInput: args.triggerInput ?? '', canvasId: exec.canvasId, source: 'assistant' });
+          if (!r.ok) return r.error;
+          return JSON.stringify({ started: true, runId: r.runId });
+        }
+        const lint = lintWorkflowGraph(cv.graph);
         if (!lint.ok) return `图有错误不能运行：\n${lint.issues.filter((x) => x.level === 'error').map((x) => x.message).join('\n')}`;
         const globals = (() => { try { return globalContext(); } catch { return { globalVariables: {} }; } })();
-        const { runId } = startRun(graph, {
-          triggerInput: args.triggerInput ?? '', workflowName: null, workflowId: cv.workflowId,
+        const { runId } = startRun(cv.graph, {
+          triggerInput: args.triggerInput ?? '', workflowName: null, workflowId: null,
           canvasId: exec.canvasId,
           globalVariables: globals.globalVariables,
           source: 'assistant',
@@ -496,6 +523,303 @@ export function apply(ctx, config) {
     });
     try { ctx.tools.register(wrapped); } catch (e) { ctx.logger?.warn?.(`assistant tool ${name} 注册失败: ${e.message}`); }
   }
+
+  // ---- workflow_* 工具家族：按工作流 ID/name 操作，不依赖画布绑定 ----
+  // 与 canvas_*（锚定当前绑定画布/草稿）分工：workflow_* 管库（查询/运行/终止/改/删/切换），
+  // 任意官方聊天会话可用；执行按该会话自己的 cwd 定工作区（sessionStore），解析失败不回退默认工作区。
+  // 注意：节点 agent 的工具白名单不含这些名字，不会出现节点递归发起工作流运行。
+  // 画布同步：改库后若目标工作流正被某画布打开，同步服务端 cv 并广播 assistant-patch（复用版本跳变兜底）。
+  const syncCanvasForWorkflow = (workflowId, nextGraph, patch) => {
+    for (const [key, cv] of canvases) {
+      if (cv.workflowId !== workflowId || key.split('\0')[0] !== currentStore().workspaceRoot) continue;
+      cv.graph = nextGraph;
+      cv.version += 1;
+      broadcast('assistant-patch', {
+        canvasId: key.split('\0')[1], version: cv.version,
+        patch: patch || [], graph: nextGraph, workflowId,
+      });
+    }
+  };
+  const resolveWorkflowArg = (args) => {
+    if (args.workflowId) {
+      const wf = readWf(String(args.workflowId));
+      return wf ? { wf } : { error: `工作流 "${args.workflowId}" 不存在（可用 workflow_list 查看）` };
+    }
+    if (args.name) {
+      const hit = currentDatabase().listWorkflows().find((w) => w.name === args.name);
+      if (!hit) return { error: `未找到名为「${args.name}」的工作流（可用 workflow_list 查看）` };
+      return { wf: readWf(hit.id) };
+    }
+    return { error: '需要 workflowId 或 name 参数' };
+  };
+  const liveRunSummaries = () => runSummaries(100).filter((r) => r.live);
+
+  const workflowTools = {
+    workflow_list: {
+      description: '列出当前工作区全部工作流（id/名称/节点数/更新时间/各自运行中数量）。用户问「有哪些工作流」「什么在跑」先用这个。',
+      parameters: {},
+      async execute() {
+        const live = liveRunSummaries();
+        const rows = currentDatabase().listWorkflows().map((w) => ({
+          id: w.id, name: w.name, nodes: w.nodeCount, agents: w.agentCount,
+          updatedAt: w.updatedAt, liveRuns: live.filter((r) => r.workflowId === w.id).length,
+        }));
+        if (!rows.length) return '工作区还没有已保存的工作流。';
+        return JSON.stringify(rows, null, 2);
+      },
+    },
+    workflow_get: {
+      description: '读取单个工作流详情。默认返回省 token 的图概要 + 变量定义 + 输入 Schema（AI 据此构造 runInputs）；summary:false 返回完整图 JSON。',
+      parameters: {
+        workflowId: { type: 'string', description: '工作流 id（与 name 二选一）' },
+        name: { type: 'string', description: '工作流名称（与 workflowId 二选一）' },
+        summary: { type: 'boolean', description: '默认 true；false 返回完整图' },
+      },
+      async execute(args) {
+        const r = resolveWorkflowArg(args);
+        if (r.error) return r.error;
+        const { wf } = r;
+        const base = {
+          id: wf.id, name: wf.name, updatedAt: wf.updatedAt,
+          variables: wf.variables, inputSchema: wf.inputSchema,
+        };
+        if (args.summary === false) return JSON.stringify({ ...base, graph: wf.graph }, null, 2);
+        return JSON.stringify({ ...base, graph: summarizeGraphForAI(wf.graph) }, null, 2);
+      },
+    },
+    workflow_run: {
+      description: '运行一个已保存的工作流（异步：返回 runId，用 workflow_run_status 或 workflow_runs 轮询）。支持触发输入与结构化运行参数。',
+      parameters: {
+        workflowId: { type: 'string', description: '工作流 id（与 name 二选一）' },
+        name: { type: 'string', description: '工作流名称（与 workflowId 二选一）' },
+        triggerInput: { type: 'string', description: '触发输入文本（输入节点模板的 $trigger）' },
+        runInputs: { type: 'json', description: '结构化运行参数对象，键需匹配工作流 inputSchema 字段' },
+      },
+      async execute(args, exec) {
+        const r = resolveWorkflowArg(args);
+        if (r.error) return r.error;
+        const cv = exec.canvasId ? canvasOf(exec.canvasId) : null;
+        const canvasId = cv && cv.workflowId === r.wf.id ? exec.canvasId : null;
+        const started = startWorkflowRun(r.wf, {
+          triggerInput: args.triggerInput ?? '',
+          runInputs: args.runInputs || {},
+          canvasId,
+          source: 'assistant',
+        });
+        if (!started.ok) return started.error;
+        return JSON.stringify({ started: true, runId: started.runId });
+      },
+    },
+    workflow_runs: {
+      description: '查询运行列表（默认运行中优先 + 最近 20 条；可按工作流过滤）。回答「现在在跑什么、什么状态」用它。',
+      parameters: {
+        workflowId: { type: 'string', description: '按工作流过滤（可选）' },
+        limit: { type: 'number', description: '返回条数，默认 20，最大 100' },
+        onlyLive: { type: 'boolean', description: '只看运行中的' },
+      },
+      async execute(args) {
+        const limit = Math.min(Number(args.limit) || 20, 100);
+        let rows = runSummaries(limit);
+        if (args.onlyLive) rows = rows.filter((x) => x.live);
+        if (args.workflowId) rows = rows.filter((x) => x.workflowId === args.workflowId);
+        if (!rows.length) return args.onlyLive ? '当前没有运行中的工作流。' : '暂无运行记录。';
+        const order = (a, b) => (Number(b.live) - Number(a.live)) || String(b.startedAt || '').localeCompare(String(a.startedAt || ''));
+        return JSON.stringify(rows.sort(order).map((x) => ({
+          runId: x.runId, status: x.status, workflowName: x.workflowName, workflowId: x.workflowId,
+          source: x.source, startedAt: x.startedAt, durationMs: x.durationMs,
+          live: x.live, progress: `${x.progress.done}/${x.progress.total}`,
+        })), null, 2);
+      },
+    },
+    workflow_run_status: {
+      description: '查询一次运行的详情（节点状态/错误/输出摘要）。运行完成或失败后返回终态。',
+      parameters: { runId: { type: 'string', required: true, description: '运行 id（workflow_run / workflow_runs 获得）' } },
+      async execute(args) {
+        const entry = orch.runs.get(args.runId);
+        if (entry?.run?.workspaceRoot === currentStore().workspaceRoot) {
+          const run = entry.run;
+          return JSON.stringify({
+            status: run.status || 'running',
+            workflowName: run.workflowName, source: run.source, startedAt: run.startedAt,
+            durationMs: run.durationMs ?? null,
+            nodeStates: summarizeNodeStates(run.nodeStates),
+            outputs: summarizeOutputs(run.outputs, run.structuredOutputs),
+          });
+        }
+        const hist = readRun(args.runId);
+        if (!hist) return `运行 "${args.runId}" 不存在`;
+        return JSON.stringify({
+          status: hist.status,
+          workflowName: hist.workflowName, source: hist.source, startedAt: hist.startedAt,
+          durationMs: hist.durationMs ?? null,
+          nodeStates: summarizeNodeStates(hist.nodeStates),
+          outputs: summarizeOutputs(hist.outputs, hist.structuredOutputs),
+        });
+      },
+    },
+    workflow_run_cancel: {
+      description: '终止/取消运行。传 runId 取消单个；传 workflowId（或 all:true）取消该工作流/全部运行中的 run。已结束的运行不受影响。',
+      parameters: {
+        runId: { type: 'string', description: '要取消的运行 id（与 workflowId/all 二选一）' },
+        workflowId: { type: 'string', description: '取消该工作流全部运行中的 run' },
+        all: { type: 'boolean', description: 'true 取消全部运行中的 run' },
+      },
+      async execute(args) {
+        const targets = args.runId
+          ? [String(args.runId)]
+          : liveRunSummaries()
+            .filter((x) => (args.all ? true : x.workflowId === args.workflowId))
+            .map((x) => x.runId);
+        if (!targets.length) return '没有匹配的运行中 run。';
+        const results = [];
+        for (const id of targets) {
+          const entry = orch.runs.get(id);
+          const ok = entry?.run?.workspaceRoot === currentStore().workspaceRoot ? orch.cancel(id, '助手取消') : false;
+          results.push({ runId: id, canceled: ok });
+        }
+        return JSON.stringify({ canceled: results.filter((x) => x.canceled).length, results });
+      },
+    },
+    workflow_patch: {
+      description: '修改已保存工作流的图（批量 ops 原子生效，语义与 canvas_graph_patch 完全一致）。若目标工作流正被画布打开，画布实时同步。可选 name 字段改名。',
+      parameters: {
+        workflowId: { type: 'string', required: true, description: '目标工作流 id' },
+        ops: {
+          type: 'array', required: true,
+          items: {
+            type: 'object', additionalProperties: true,
+            properties: {
+              op: { type: 'string' }, type: { type: 'string' }, label: { type: 'string' },
+              data: { type: 'json' }, after: { type: 'string' }, connect: { type: 'boolean' },
+              branch: { type: 'string' }, id: { type: 'string' }, from: { type: 'string' }, to: { type: 'string' },
+              position: { type: 'json' },
+            },
+          },
+        },
+        name: { type: 'string', description: '新名称（可选，不改名不传）' },
+      },
+      async execute(args) {
+        const wf = readWf(String(args.workflowId));
+        if (!wf) return `工作流 "${args.workflowId}" 不存在（可用 workflow_list 查看）`;
+        const r = validateGraphOps(wf.graph, args.ops);
+        if (!r.ok) return `整批拒绝（未做任何修改）：\n${r.errors.join('\n')}\n请修正后重发整批 ops。`;
+        const saved = writeWf({
+          ...wf,
+          ...(args.name ? { name: String(args.name).slice(0, 60) } : {}),
+          graph: r.graph,
+          updatedAt: new Date().toISOString(),
+        });
+        syncCanvasForWorkflow(saved.id, r.graph, r.patch);
+        const check = checkPatchResult(r.graph);
+        return `已应用 ${r.patch.length} 个操作到「${saved.name}」。\nlint: ${check.lintOk ? '通过' : '有告警'}\n${check.issues.slice(0, 20).join('\n')}`;
+      },
+    },
+    workflow_create: {
+      description: '新建工作流。name 必填；可选 graph（{nodes,edges} 初始图）或 copyFrom（复制既有工作流 id）。草稿请让用户在画布保存，这里只建已命名工作流。',
+      parameters: {
+        name: { type: 'string', required: true, description: '工作流名称' },
+        graph: { type: 'json', description: '初始图 {nodes, edges}（可选）' },
+        copyFrom: { type: 'string', description: '复制来源工作流 id（可选）' },
+      },
+      async execute(args) {
+        const name = String(args.name || '').trim().slice(0, 60);
+        if (!name) return 'name 不能为空';
+        let graph = { nodes: [], edges: [] };
+        if (args.copyFrom) {
+          const src = readWf(String(args.copyFrom));
+          if (!src) return `复制来源 "${args.copyFrom}" 不存在`;
+          graph = src.graph;
+        } else if (args.graph && Array.isArray(args.graph.nodes)) {
+          graph = args.graph;
+        } else if (args.graph) {
+          return 'graph 必须是 {nodes, edges} 对象';
+        }
+        // 与 POST /workflows 同语义：不做 lint（空画布起步合法），运行时会再校验
+        const id = `wf_${Date.now().toString(36)}${randomUUID().slice(0, 4)}`;
+        const saved = writeWf(normalizeWorkflowDocument({ id, name, graph, updatedAt: new Date().toISOString() }));
+        return JSON.stringify({ created: true, id: saved.id, name: saved.name, nodes: saved.graph?.nodes?.length || 0 });
+      },
+    },
+    workflow_delete: {
+      description: '删除工作流（不可恢复）。必须传 confirm:true 才执行。有运行中 run、定时任务或 webhook 关联时拒绝并列出关联，引导先清理。',
+      parameters: {
+        workflowId: { type: 'string', required: true, description: '目标工作流 id' },
+        confirm: { type: 'boolean', description: '确认真删传 true' },
+      },
+      async execute(args) {
+        const wf = readWf(String(args.workflowId));
+        if (!wf) return `工作流 "${args.workflowId}" 不存在`;
+        if (args.confirm !== true) return `确认删除「${wf.name}」？此操作不可恢复。确认请带 confirm:true 重新调用。`;
+        const live = liveRunSummaries().filter((x) => x.workflowId === wf.id);
+        if (live.length) return `有 ${live.length} 个运行中的 run（${live.map((x) => x.runId).join(', ')}），请先等待完成或用 workflow_run_cancel 取消。`;
+        const hooks = [...currentHooks().values()].filter((h) => h.workflowId === wf.id);
+        if (hooks.length) return `有 ${hooks.length} 个 webhook 关联（${hooks.map((h) => h.id).join(', ')}），请先在画布删除 webhook。`;
+        const schedules = [...currentSchedulerMeta().values()].filter((m) => m.workflowId === wf.id);
+        if (schedules.length) return `有 ${schedules.length} 个定时任务关联（${schedules.map((m) => m.key).join(', ')}），请先在定时任务中心删除。`;
+        // 画布若正打开该工作流：退回草稿态（前端收到事件后回「未保存」空画布）
+        for (const [key, cv] of canvases) {
+          if (cv.workflowId !== wf.id || key.split('\0')[0] !== currentStore().workspaceRoot) continue;
+          cv.workflowId = null;
+          cv.graph = { nodes: [], edges: [] };
+          cv.version += 1;
+          broadcast('assistant-patch', {
+            canvasId: key.split('\0')[1], version: cv.version,
+            patch: [], graph: cv.graph, workflowId: null,
+          });
+        }
+        deleteWf(wf.id);
+        return JSON.stringify({ deleted: true, id: wf.id, name: wf.name });
+      },
+    },
+    workflow_open: {
+      description: '把绑定的画布切换到指定工作流（用户屏幕上打开它）。仅在绑定画布的会话里可用；画布有未保存修改时用户会收到确认弹窗。',
+      parameters: {
+        workflowId: { type: 'string', description: '目标工作流 id（与 name 二选一）' },
+        name: { type: 'string', description: '目标工作流名称（与 workflowId 二选一）' },
+      },
+      async execute(args, exec) {
+        const r = resolveWorkflowArg(args);
+        if (r.error) return r.error;
+        const cv = canvasOf(exec.canvasId);
+        cv.workflowId = r.wf.id;
+        cv.graph = r.wf.graph;
+        cv.version += 1;
+        broadcast('assistant-open-workflow', {
+          canvasId: exec.canvasId, workflowId: r.wf.id,
+        });
+        return `画布已切换到「${r.wf.name}」（若画布有未保存修改，用户确认后生效）。`;
+      },
+    },
+  };
+
+  // workflow_* 注册：与 canvas_* 相同的 defineTool 包装（spec→Schema 编译 + 工作区绑定运行），
+  // 但不做画布绑定门槛——按会话自己的 cwd 定工作区；workflow_open 例外，由 execute 内自行处理。
+  const registerAssistantTools = (tools, { requireCanvas = true } = {}) => {
+    for (const [name, def] of Object.entries(tools)) {
+      const needCanvas = requireCanvas && name !== 'workflow_open' ? true : (name === 'workflow_open');
+      const wrapped = defineTool({
+        name,
+        description: def.description,
+        parameters: def.parameters,
+        output: { schema: { type: 'string' }, render: (_a, v) => [{ type: 'text', text: String(v) }] },
+        async execute(args, exec) {
+          const sid = exec?.agent?.session?.id || exec?.sessionId || exec?.session?.id;
+          const canvasId = resolveCanvasId(exec);
+          if (needCanvas && (!sid || !canvasId)) {
+            return '此工具只在绑定了工作流画布的会话里可用（在画布「工作流」标签页发起对话）。';
+          }
+          if (!sid) return '当前会话无法定位工作区，请在聊天绑定工作目录后重试。';
+          try {
+            return await workspaceContext.run(sessionStore(String(sid)), () => def.execute(args, { ...exec, canvasId }));
+          } catch (error) {
+            return `工作区不可用：${String(error.message || error)}`;
+          }
+        },
+      });
+      try { ctx.tools.register(wrapped); } catch (e) { ctx.logger?.warn?.(`assistant tool ${name} 注册失败: ${e.message}`); }
+    }
+  };
+  registerAssistantTools(workflowTools, { requireCanvas: false });
 
 
   // ---- 运行历史（按工作区持久化 + 内存缓存）----
@@ -1416,34 +1740,61 @@ export function apply(ctx, config) {
   } });
 
   // ---- 运行历史 ----
-  register({ kind: 'exact', path: '/wf1/api/runs', handler(_req, res) {
+  // ---- 运行列表共享整形（/runs API 与 workflow_runs 助手工具同源，不双写）----
+  const runProgressOf = (r) => {
+    const nodeIds = r.graph?.nodes?.filter((node) => node.type !== 'notify').map((node) => node.id)
+      || Object.keys(r.nodeStates || {});
+    const states = nodeIds.map((nodeId) => r.nodeStates?.[nodeId]);
+    const total = nodeIds.length;
+    const done = states.filter((st) => ['success', 'error', 'canceled', 'skipped'].includes(st?.status)).length;
+    const succeeded = states.filter((st) => st?.status === 'success').length;
+    return { done, total, succeeded };
+  };
+  const resumableRun = (r, isLive) => !isLive
+    && ['error', 'canceled', 'interrupted'].includes(r.status)
+    && Boolean(r.graph?.nodes?.length)
+    && Object.values(r.nodeStates || {}).some((st) => st?.status === 'success')
+    && r.graph.nodes.some((node) => !['success', 'skipped'].includes(r.nodeStates?.[node.id]?.status));
+  const runSummaries = (limit = 20) => {
     const live = [...orch.runs.values()].filter((entry) => entry.run.workspaceRoot === currentStore().workspaceRoot).map((entry) => entry.run.runId);
-    const runProgress = (r) => {
-      const nodeIds = r.graph?.nodes?.filter((node) => node.type !== 'notify').map((node) => node.id)
-        || Object.keys(r.nodeStates || {});
-      const states = nodeIds.map((nodeId) => r.nodeStates?.[nodeId]);
-      const total = nodeIds.length;
-      const done = states.filter((st) => ['success', 'error', 'canceled', 'skipped'].includes(st?.status)).length;
-      const succeeded = states.filter((st) => st?.status === 'success').length;
-      return { done, total, succeeded };
-    };
-    const resumable = (r, isLive) => !isLive
-      && ['error', 'canceled', 'interrupted'].includes(r.status)
-      && Boolean(r.graph?.nodes?.length)
-      && Object.values(r.nodeStates || {}).some((st) => st?.status === 'success')
-      && r.graph.nodes.some((node) => !['success', 'skipped'].includes(r.nodeStates?.[node.id]?.status));
+    return recentRuns(limit).map((r) => {
+      const { structuredOutputs, graph, ...summary } = r;
+      const isLive = live.includes(r.runId);
+      return {
+        runId: summary.runId,
+        status: summary.status,
+        workflowId: summary.workflowId ?? null,
+        workflowName: summary.workflowName ?? null,
+        source: summary.source ?? null,
+        startedAt: summary.startedAt ?? null,
+        durationMs: summary.durationMs ?? null,
+        live: isLive,
+        progress: runProgressOf(r),
+        resumable: resumableRun(r, isLive),
+        outputs: summarizeOutputs(summary.outputs, structuredOutputs),
+        nodeStates: summarizeNodeStates(summary.nodeStates),
+        structuredOutputSummary: summarizeStructuredOutputs(structuredOutputs),
+      };
+    });
+  };
+
+  register({ kind: 'exact', path: '/wf1/api/runs', handler(req, res) {
+    const url = new URL(req.url, 'http://x');
+    const limit = Math.min(Number(url.searchParams.get('limit')) || 20, 100);
+    const liveIds = new Set([...orch.runs.values()].filter((entry) => entry.run.workspaceRoot === currentStore().workspaceRoot).map((entry) => entry.run.runId));
     json(res, 200, {
-      runs: recentRuns(20).map((r) => {
+      // 保持既有字段面（triggerInput/canvasId 等平铺），整形逻辑与 workflow_runs 工具同源
+      runs: recentRuns(limit).map((r) => {
         const { structuredOutputs, graph, ...summary } = r;
-        const isLive = live.includes(r.runId);
+        const isLive = liveIds.has(r.runId);
         return {
           ...summary,
           outputs: summarizeOutputs(summary.outputs, structuredOutputs),
           nodeStates: summarizeNodeStates(summary.nodeStates),
           structuredOutputSummary: summarizeStructuredOutputs(structuredOutputs),
           live: isLive,
-          progress: runProgress(r),
-          resumable: resumable(r, isLive),
+          progress: runProgressOf(r),
+          resumable: resumableRun(r, isLive),
         };
       }),
     });

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/workflow-tools.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/workflow-tools.integration.test.mjs
@@ -1,0 +1,261 @@
+// workflow_* 助手工具集成测试（假 webServer + 假 tools.register 直调工具，与 schedule-api 同模式）。
+// 覆盖：list/get/run/runs/status/cancel/patch/create/delete 守卫与画布同步、workflow_open 广播、
+// canvas_run_workflow 复用 startWorkflowRun（补齐工作流变量与 workflowName）。
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { apply } from '../lib/index.js';
+
+function responseCapture() {
+  const listeners = new Map();
+  return {
+    status: 0,
+    headers: {},
+    chunks: [],
+    writableEnded: false,
+    writeHead(status, headers = {}) { this.status = status; this.headers = headers; },
+    write(chunk) { this.chunks.push(Buffer.from(chunk)); },
+    end(chunk) { if (chunk) this.chunks.push(Buffer.from(chunk)); this.writableEnded = true; },
+    on(event, callback) { listeners.set(event, callback); return this; },
+    once(event, callback) { const inner = listeners.get(event); listeners.set(event, () => { inner?.(); callback(); }); return this; },
+    emit(event) { listeners.get(event)?.(); return true; },
+    destroy(error) { if (error) throw error; },
+    json() { return JSON.parse(Buffer.concat(this.chunks).toString('utf8') || '{}'); },
+  };
+}
+
+function request(method, url, body) {
+  const req = new EventEmitter();
+  req.method = method;
+  req.url = url;
+  req.headers = {};
+  queueMicrotask(() => {
+    if (body !== undefined) req.emit('data', Buffer.from(JSON.stringify(body)));
+    req.emit('end');
+  });
+  return req;
+}
+
+const withSession = (url, sessionId) => `${url}${url.includes('?') ? '&' : '?'}sessionId=${sessionId}`;
+const dshHome = mkdtempSync(join(tmpdir(), 'wf1-wft-home-'));
+const workspacesRoot = mkdtempSync(join(tmpdir(), 'wf1-wft-ws-'));
+const workspace = join(workspacesRoot, 'ws');
+mkdirSync(workspace, { recursive: true });
+process.env.DSH_HOME = dshHome;
+const packageLegacyDir = join(dshHome, 'package-legacy');
+mkdirSync(join(packageLegacyDir, 'state'), { recursive: true });
+process.env.WF1_LEGACY_DATA_DIR = packageLegacyDir;
+writeFileSync(join(packageLegacyDir, 'state', 'graph.json'), JSON.stringify({ nodes: [], edges: [] }));
+
+const disposers = [];
+const results = [];
+const test = async (name, fn) => {
+  try { await fn(); results.push(['✓', name]); }
+  catch (error) { results.push(['✗', name, error]); }
+};
+
+const registeredTools = new Map();
+const broadcasts = []; // broadcast() 经 onOrchestratorEvent 不经过 webServer；抓 SSE 需要真实连接，这里改抓 cv 状态即可
+
+const ctx = {
+  webServer: { register(route) { this.routes.push(route); }, routes: [] },
+  tools: { register(def) { registeredTools.set(def.name, def); }, schemas() { return []; } },
+  get(name) {
+    if (name === 'sessions') return { get: (id) => (String(id) === 'session-1' ? { header: { cwd: workspace } } : undefined), flush: async () => {} };
+    if (name === 'workspaceRegistry') return { list: () => [{ path: workspace }] };
+    return null;
+  },
+  skills: { async list() { return []; } },
+  llm: { listProviders() { return []; }, async listModels() { return []; } },
+  agentPresets: { async mount() {} },
+  logger: { info() {}, warn() {}, error() {} },
+  effect(setup) { const dispose = setup(); if (dispose) disposers.push(dispose); },
+};
+apply(ctx, {});
+const route = (path) => ctx.webServer.routes.find((entry) => entry.kind === 'exact' && entry.path === path)?.handler;
+const call = async (method, url, body) => {
+  const res = responseCapture();
+  await route(url.split('?')[0])(request(method, withSession(url, 'session-1'), body), res);
+  return { status: res.status, body: res.json() };
+};
+
+// 直调助手工具：exec 模拟 dsh agent 上下文（session-1 绑定画布 cv_test）
+const execOf = (canvasId) => ({ agent: { session: { id: 'session-1' } }, canvasId });
+const runTool = async (name, args, canvasId) => {
+  const def = registeredTools.get(name);
+  assert.ok(def, `工具 ${name} 应已注册`);
+  const out = await def.execute(args || {}, execOf(canvasId));
+  assert.equal(typeof out, 'string', `${name} 输出必须是文本`);
+  return out;
+};
+const maybeJson = (text) => { try { return JSON.parse(text); } catch { return null; } };
+
+// 绑定画布：复用 /assistant/bind 路由建立 session-1 ↔ cv_test
+const bound = await call('POST', '/wf1/api/assistant/bind', { sessionId: 'session-1', canvasId: 'cv_test', version: 0, graph: null });
+assert.equal(bound.status, 200, `bind 应成功，实际 ${bound.status} ${JSON.stringify(bound.body)}`);
+
+const wfGraph = {
+  nodes: [{ id: 'n_in', type: 'input', position: { x: 0, y: 0 }, data: { label: '输入', text: 'ok' } }],
+  edges: [],
+};
+const created = await call('POST', '/wf1/api/workflows', { id: 'wf_t1', name: '工具测试工作流', graph: wfGraph });
+assert.equal(created.status, 200);
+const created2 = await call('POST', '/wf1/api/workflows', { id: 'wf_t2', name: '另一个工作流', graph: wfGraph });
+assert.equal(created2.status, 200);
+
+await test('workflow_list：列出工作流含 id/名称/liveRuns', async () => {
+  const out = await runTool('workflow_list', {});
+  const rows = maybeJson(out);
+  assert.ok(Array.isArray(rows), '应返回 JSON 数组');
+  assert.ok(rows.some((r) => r.id === 'wf_t1' && r.name === '工具测试工作流' && r.liveRuns === 0));
+});
+
+await test('workflow_get：默认概要模式含变量/inputSchema，summary:false 返回完整图', async () => {
+  const byId = await runTool('workflow_get', { workflowId: 'wf_t1' });
+  const doc = maybeJson(byId);
+  assert.equal(doc.id, 'wf_t1');
+  assert.ok(doc.graph && Array.isArray(doc.graph.nodes));
+  assert.deepEqual(doc.inputSchema, { fields: [] });
+  const byName = await runTool('workflow_get', { name: '另一个工作流' });
+  assert.equal(maybeJson(byName).id, 'wf_t2');
+  const missing = await runTool('workflow_get', { workflowId: 'wf_no' });
+  assert.match(missing, /不存在/);
+});
+
+await test('workflow_run：返回 runId；workflow_runs 能看到该运行（source=assistant）', async () => {
+  const out = await runTool('workflow_run', { workflowId: 'wf_t1', triggerInput: 'go' });
+  const started = maybeJson(out);
+  assert.equal(started.started, true);
+  assert.match(started.runId, /^run_/);
+  const list = maybeJson(await runTool('workflow_runs', {}));
+  const hit = list.find((r) => r.runId === started.runId);
+  assert.ok(hit, '运行列表应包含新运行');
+  assert.equal(hit.source, 'assistant');
+  assert.equal(hit.workflowId, 'wf_t1');
+  globalThis.__runId = started.runId;
+});
+
+await test('workflow_runs：onlyLive 过滤 + workflowId 过滤', async () => {
+  const all = maybeJson(await runTool('workflow_runs', { limit: 50 }));
+  assert.ok(Array.isArray(all) && all.length >= 1);
+  const filtered = maybeJson(await runTool('workflow_runs', { workflowId: 'wf_t2' }));
+  assert.ok(filtered === null || filtered.every((r) => r.workflowId === 'wf_t2'), '过滤结果要么为空文本要么全部属于 wf_t2');
+  const liveOnly = await runTool('workflow_runs', { onlyLive: true });
+  if (maybeJson(liveOnly)) assert.ok(maybeJson(liveOnly).every((r) => r.live === true));
+});
+
+await test('workflow_run_status：按 runId 查详情（含 nodeStates/outputs）', async () => {
+  const out = await runTool('workflow_run_status', { runId: globalThis.__runId });
+  const st = maybeJson(out);
+  assert.ok(st, '应返回 JSON');
+  assert.ok(['running', 'success', 'error'].includes(st.status));
+  assert.ok(st.nodeStates);
+  const missing = await runTool('workflow_run_status', { runId: 'run_nope' });
+  assert.match(missing, /不存在/);
+});
+
+await test('workflow_run_cancel：无匹配 live run 时明确返回', async () => {
+  const out = await runTool('workflow_run_cancel', { workflowId: 'wf_t2' });
+  assert.match(out, /没有匹配的运行中 run/);
+});
+
+await test('workflow_patch：原子改图 + 落盘 + lint 回执；坏 ops 整批拒绝', async () => {
+  const ok = await runTool('workflow_patch', { workflowId: 'wf_t1', ops: [
+    { op: 'addNode', type: 'note', label: '说明', data: { text: 'AI 加的注释' }, after: 'n_in' },
+  ] });
+  assert.match(ok, /已应用 \d+ 个操作/);
+  const detail = await call('GET', '/wf1/api/workflows/detail?id=wf_t1');
+  assert.ok(detail.body.graph.nodes.some((n) => n.data?.label === '说明'), '改图应落盘');
+  const bad = await runTool('workflow_patch', { workflowId: 'wf_t1', ops: [{ op: 'addNode', type: 'nope' }] });
+  assert.match(bad, /整批拒绝/);
+});
+
+await test('workflow_patch：改名走 name 字段', async () => {
+  const out = await runTool('workflow_patch', { workflowId: 'wf_t2', name: '改名后的工作流', ops: [
+    { op: 'updateNode', id: 'n_in', data: { text: '改' } },
+  ] });
+  assert.match(out, /已应用 \d+ 个操作/);
+  const detail = await call('GET', '/wf1/api/workflows/detail?id=wf_t2');
+  assert.equal(detail.body.name, '改名后的工作流');
+});
+
+await test('workflow_create：新建（空图/复制来源），重复名允许（与 UI 一致）', async () => {
+  const out = await runTool('workflow_create', { name: 'AI 新建' });
+  const createdDoc = maybeJson(out);
+  assert.equal(createdDoc.created, true);
+  assert.match(createdDoc.id, /^wf_/);
+  const copy = await runTool('workflow_create', { name: 'AI 副本', copyFrom: 'wf_t1' });
+  const copyDoc = maybeJson(copy);
+  assert.equal(copyDoc.nodes >= 1, true, '副本应有节点');
+  const badGraph = await runTool('workflow_create', { name: '坏图', graph: { nodes: 'x' } });
+  assert.match(badGraph, /graph 必须是/);
+});
+
+await test('workflow_delete：缺 confirm 拒绝；有关联定时任务/webhook 拒绝并列出；confirm 后真删', async () => {
+  const noConfirm = await runTool('workflow_delete', { workflowId: 'wf_t1' });
+  assert.match(noConfirm, /确认删除/);
+  const sched = await call('POST', '/wf1/api/schedule', { workflowId: 'wf_t1', cron: '0 9 * * *' });
+  assert.equal(sched.status, 200);
+  const guarded = await runTool('workflow_delete', { workflowId: 'wf_t1', confirm: true });
+  assert.match(guarded, /定时任务关联/);
+  assert.match(guarded, /sch_/);
+  // 清理定时任务后可删
+  const del = await call('DELETE', `/wf1/api/schedule?key=${sched.body.key}`);
+  assert.equal(del.status, 200);
+  const done = maybeJson(await runTool('workflow_delete', { workflowId: 'wf_t1', confirm: true }));
+  assert.equal(done.deleted, true);
+  const gone = await call('GET', '/wf1/api/workflows/detail?id=wf_t1');
+  assert.equal(gone.status, 404);
+});
+
+await test('workflow_open：未绑定画布的会话被拒；绑定后切换', async () => {
+  // session-2 未绑定画布 → workflow_open 拒绝
+  const def = registeredTools.get('workflow_open');
+  const refused = await def.execute({ workflowId: 'wf_t2' }, { agent: { session: { id: 'session-2' } } });
+  assert.match(refused, /只在绑定了工作流画布的会话里可用/);
+  // session-1 绑定 cv_test：open 切换 cv 指向 wf_t2
+  const out = await runTool('workflow_open', { workflowId: 'wf_t2' }, 'cv_test');
+  assert.match(out, /画布已切换/);
+  // 再次 open 到另一目标（by name）也正常
+  const again = await runTool('workflow_open', { name: '改名后的工作流' }, 'cv_test');
+  assert.match(again, /画布已切换/);
+});
+
+await test('canvas_run_workflow 走 startWorkflowRun：命名工作流运行带 workflowName', async () => {
+  // open 已把 cv_test 切到 wf_t2：canvas_run_workflow 应走 startWorkflowRun（带 wf 名与变量）
+  const out = await runTool('canvas_run_workflow', { triggerInput: 'hi' }, 'cv_test');
+  const started = maybeJson(out);
+  assert.ok(started && started.started, `应返回 started，实际：${out}`);
+  const list = maybeJson(await runTool('workflow_runs', { limit: 10 }));
+  const hit = list.find((r) => r.runId === started.runId);
+  assert.ok(hit, '运行应出现在列表');
+  assert.equal(hit.workflowName, '改名后的工作流');
+  assert.equal(hit.source, 'assistant');
+});
+
+await test('未绑定画布的会话：canvas_* 拒绝、workflow_* 可用', async () => {
+  // exec 不带 canvasId → resolveCanvasId 靠 sessionCanvas；session-1 已绑定，需要另造 session
+  const def = registeredTools.get('canvas_get_graph');
+  const out = await def.execute({}, { agent: { session: { id: 'session-2' } } });
+  assert.match(out, /只在绑定了工作流画布的会话里可用/);
+  const wfDef = registeredTools.get('workflow_list');
+  const listOut = await wfDef.execute({}, { agent: { session: { id: 'session-1' } } });
+  assert.ok(maybeJson(listOut), 'workflow_list 不依赖画布绑定');
+});
+
+await test('workflow_run_cancel：all:true 可批量取消（无 live 时不误报）', async () => {
+  const out = await runTool('workflow_run_cancel', { all: true });
+  const parsed = maybeJson(out);
+  assert.ok(parsed === null || typeof parsed.canceled === 'number', '返回取消计数或不匹配提示');
+});
+
+for (const d of disposers) { try { await d(); } catch { /* 清理尽力 */ } }
+for (const [mark, name, error] of results) {
+  if (mark === '✗') console.error(`${mark} ${name}\n${error?.stack || error}`);
+}
+const failed = results.filter((r) => r[0] === '✗').length;
+console.log(results.map(([mark, name]) => `${mark} ${name}`).join('\n'));
+console.log(`workflow-tools.integration: ${results.length - failed}/${results.length} 通过`);
+process.exit(failed ? 1 : 0);

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -94,6 +94,10 @@ export default function App() {
   const assistantOpsRef = useRef(null); // SSE assistant-patch → applyAssistantOps 桥（定义在后段）
   const assistantGraphRef = useRef(null); // 漏失 patch 时用服务端权威完整图恢复
   const assistantVersionRef = useRef(0);
+  const openWorkflowRef = useRef(null); // SSE assistant-open-workflow → openWorkflow 桥（定义在后段）
+  const dirtyRef = useRef(dirty); // 脏草稿守卫：AI 请求切换前先静默保存，避免丢未存改动
+  const saveRef = useRef(null); // 同上：脏草稿先 save({silent}) 再切换
+  dirtyRef.current = dirty;
   // 画布 AI 助手：本画布实例标识（localStorage 持久；宿主 dsh-ccpg-canvasui 经 postMessage 绑定）
   const canvasIdRef = useRef(localStorage.getItem('wf1:canvasId') || '');
   if (!canvasIdRef.current) {
@@ -399,6 +403,23 @@ export default function App() {
       }
       assistantOpsRef.current?.(p.patch || [], version);
     });
+    es.addEventListener('assistant-open-workflow', (e) => {
+      // AI 请求把本画布切到指定工作流（workflow_open）：复用 openWorkflow 既有加载路径。
+      // 脏草稿先静默保存（自动保存 2.5s 间歇可能未触发），不丢用户未存改动。
+      const p = JSON.parse(e.data);
+      if (p.canvasId && p.canvasId !== canvasIdRef.current) return;
+      const targetId = String(p.workflowId || '');
+      if (!targetId || targetId === currentWfIdRef.current) return;
+      const open = async () => {
+        const res = await fetch(apiUrl(`/workflows/detail?id=${encodeURIComponent(targetId)}`));
+        if (!res.ok) { toast('AI 切换工作流：目标不存在或已删除', 'error'); return; }
+        const wf = await res.json();
+        await openWorkflowRef.current?.(wf);
+      };
+      if (dirtyRef.current) {
+        saveRef.current?.({ silent: true }).then(open).catch(() => open());
+      } else open();
+    });
     es.addEventListener('run-start', (e) => {
       const p = JSON.parse(e.data);
       // 任何运行起停都刷新切换器列表（不过画布闸门：定时/webhook 运行无 canvasId）
@@ -700,6 +721,8 @@ export default function App() {
     syncRunPanelToWorkflow(data.id);
     toast(`已打开「${data.name}」`);
   }, [setNodes, setEdges, toast, syncRunPanelToWorkflow, inspectRun]);
+  openWorkflowRef.current = openWorkflow; // SSE assistant-open-workflow 桥（effect 依赖不含它，经 ref 取最新）
+  saveRef.current = save;
 
   const newWorkflow = useCallback((created) => {
     const document = normalizeWorkflowDocument(created);


### PR DESCRIPTION
## 背景

多运行与定时任务上线后（#35 / #36 / #37），对话侧只有 canvas_* 工具（锚定当前画布、只管草稿），用户在聊天里问「现在在跑什么」「帮我跑一下那个巡检」「把画布切到 X」都做不到。本 PR 补齐 workflow_* 工具家族，canvas_* 原样保留负责当前画布快捷编辑。

## 方案

**10 个 workflow_* 工具**（按 id/name 操作，不依赖画布绑定，任意官方聊天会话可用；按会话 cwd 经 sessionStore 定工作区，解析失败不回退默认工作区）：

- 查询：workflow_list（清单+各 live 运行数）/ workflow_get（概要省 token 或完整图）/ workflow_runs（live 优先，可过滤 onlyLive/workflowId）/ workflow_run_status
- 运行：workflow_run（异步 runId，带 runInputs 校验）/ workflow_run_cancel（runId、按工作流、all 批量）
- 管理：workflow_patch（原子 ops + 改名，正打开的画布实时同步 assistant-patch）/ workflow_create / workflow_delete（confirm 门 + live/webhook/定时三重关联守卫）/ workflow_open（广播 assistant-open-workflow，前端复用 openWorkflow 路径，脏草稿先静默保存）

**共享 helper 抽取**：startWorkflowRun（启动已保存工作流统一组装变量+校验）修掉 canvas_run_workflow 两处既有缺陷（漏工作流变量、workflowName 传 null）；runProgressOf/resumableRun 让 /runs API 与 workflow_runs 同源整形。

**persona**：修掉陈旧 canvas_test_node 文案（该工具从未注册，AI 调了会失败），补两家族分工与「先查后动」引导。

## 验证（按 AGENTS.md 合并门槛三件套）

1. **代码审核**：完整 diff 自审两轮——修复 workflow_open 画布图与库文档别名问题（浅拷贝解耦）
2. **本地真实跑通**（真 dsh 4023 + 真 LLM agent + 真浏览器）：
   - workflow_list：agent 正确列出工作流与 live 计数
   - workflow_open 不存在→存在两次：失败路径明确报错；成功路径画布徽标实时切换、节点上屏
   - workflow_patch：AI备注节点+边实时出现在画布（无刷新）
   - workflow_run→cancel→runs：runId 返回；运行 1ms 即完成故 canceled:false（语义正确）；终态 success 1/1
3. **回归**：orchestrator 20/20（新增 workflow-tools.integration 14 例）、web 16/16、build-web.sh 双构建通过

Closes #35（对话管理运行部分）