### PR TITLE
chore(release): v0.3.0 8 包升版

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@
 Node.js >= 24.15 且已安装 `@deepseek-ai/dsh`：
 
 ```sh
-dsh plugin --profile web add dsh-ccpg-one@0.2.2
+dsh plugin --profile web add dsh-ccpg-one@0.3.0
 dsh web
 ```
 
-Harness Desktop 用户在 **Open DSH Terminal** 中执行 `dsh plugin add dsh-ccpg-one@0.2.2`，然后重启 Desktop。也可以从 [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest) 下载离线聚合包。
+Harness Desktop 用户在 **Open DSH Terminal** 中执行 `dsh plugin add dsh-ccpg-one@0.3.0`，然后重启 Desktop。也可以从 [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest) 下载离线聚合包。
 
 ## 界面与使用方式
 
@@ -48,7 +48,7 @@ Workflow One 嵌在 dsh 官方界面中：左侧保留与智能体的对话，�
 **Harness Desktop（npm 包发布后）**：从 Desktop 托盘打开 **Open DSH Terminal**，对当前 profile 安装并重启 Desktop：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.2.2
+dsh plugin add dsh-ccpg-one@0.3.0
 ```
 
 Desktop 使用官方 DSH/Cordis 插件组合，不需要另一套插件。不要在 Desktop 里运行 `setup.sh`：Desktop 自己管理 profile、Node/pnpm 和随机 loopback 端口；飞书账号页首次点击「自动安装」时，lark-cli 会通过 Desktop 的受管 pnpm 安装到当前 profile。安装使用细节、环境差异与常见问题排查见 [`dsh-plugins/DESKTOP.md`](dsh-plugins/DESKTOP.md)；Desktop 开发兼容契约（`desktopProfiles`/`desktopPnpm` 动态探测、跨环境插件写法）也在该文档第 2 节。

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -22,7 +22,7 @@
 从 Desktop 托盘打开 **Open DSH Terminal**；该终端已绑定当前 profile：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.2.2
+dsh plugin add dsh-ccpg-one@0.3.0
 ```
 
 安装后重启 Desktop，让新 bundle 进入 Loader 组合。compatibility 与 advanced 模式都继续使用普通 DSH Web Client；画布、同源 `/wf1/api/*`、侧栏和预览无需 Desktop 专用注册。飞书账号页首次点击「自动安装」时，插件通过公开 `desktopPnpm` service 把固定版本 lark-cli 安装到当前 profile，并在 profile 切换或退出时取消仍在运行的操作。
@@ -135,7 +135,7 @@ npx dsh-ccpg-one myprofile        # 预写 pnpm 11 放行（node-pty/koffi 构�
 也可直接用官方命令：
 
 ```sh
-dsh plugin --profile myprofile add dsh-ccpg-one@0.2.2
+dsh plugin --profile myprofile add dsh-ccpg-one@0.3.0
 ```
 
 > **pnpm 11 注意（issue #24）**：`dsh plugin add` 是 profile 目录里裸跑 pnpm，聚合依赖链里的 `node-pty`（dsh-better-sidebar 传递依赖，原生模块）会被 strict-dep-builds 拦下：安装非零退出、且 pnpm 往 profile 的 `pnpm-workspace.yaml` 写非法占位符 `node-pty: set this to true or false`，把 `pnpm approve-builds` 与重跑 install 一起堵死——**重试无效**。0.2.2 起用 `npx dsh-ccpg-one` 安装即可（它先把放行写对再装，幂等，可反复重跑）；已中招的 profile 也能用它自愈。

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-one",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.2.2",
-    "dsh-ccpg-document-preview": "0.2.2",
-    "dsh-ccpg-larkauth": "0.2.2",
-    "dsh-ccpg-llm-guard": "0.2.2",
-    "dsh-ccpg-orchestrator": "0.2.2",
-    "dsh-ccpg-tools": "0.2.2",
-    "dsh-ccpg-web": "0.2.2"
+    "dsh-ccpg-canvasui": "0.3.0",
+    "dsh-ccpg-document-preview": "0.3.0",
+    "dsh-ccpg-larkauth": "0.3.0",
+    "dsh-ccpg-llm-guard": "0.3.0",
+    "dsh-ccpg-orchestrator": "0.3.0",
+    "dsh-ccpg-tools": "0.3.0",
+    "dsh-ccpg-web": "0.3.0"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 内容

- 8 个 npm 包（7 子插件 + 聚合壳）0.2.2 → 0.3.0；聚合壳 dependencies 同步钉 0.3.0（better-sidebar 0.16.1 保持不动）
- README / dsh-plugins/README 安装命令同步 @0.3.0

## 版本内容（自 v0.2.2）

- #36 工作流并发运行、运行切换与定时任务管理（RunSwitcher 胶囊 + ScheduleCenter + schedule 引擎）
- #37 定时统计属主修复（meta Map 单一事实源，触发即落盘）
- #38 workflow_* 助手工具家族（对话查询/运行/终止/修改/切画布 10 工具）+ AGENTS 合并门槛

## 验证

- 本地 pack.sh v0.3.0 + verify-plugin-packages 全过
- boot-smoke 全过（安装+启动+better-sidebar 挂载）
- CI 绿后 squash 合并，随后打 tag v0.3.0 触发 release（8 包 npm + GitHub Release asset）