### PR TITLE
docs(readme): 优化中英文说明并支持 Node 22.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24.15
+          node-version: 22.13.0
           cache: npm
           cache-dependency-path: |
             package-lock.json
@@ -48,7 +48,7 @@ jobs:
       - name: build
         run: sh dsh-plugins/build-web.sh
         env:
-          DSH_NODE: node # Workflow One 用 node:sqlite，要求 ≥24.15；CI 里就是 node 本身
+          DSH_NODE: node # Workflow One 用 node:sqlite，要求 ≥22.13.0；CI 里就是 node 本身
 
       - name: verify npm packages
         run: node scripts/verify-plugin-packages.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 24.15
+          node-version: 22.13.0
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## 环境前提
 
-- Node ≥ 24.15（Workflow One 使用内置 `node:sqlite`）。系统自带 Node 版本不够时，用 `DSH_NODE` 环境变量指向任意 ≥ 24.15 的 node 可执行文件（setup/start/pack 脚本都认它）
+- Node ≥ 22.13.0（Workflow One 使用内置 `node:sqlite`）。系统自带 Node 版本不够时，用 `DSH_NODE` 环境变量指向任意 ≥ 22.13.0 的 node 可执行文件（setup/start/pack 脚本都认它）
 - dsh 全局安装：`npm i -g @deepseek-ai/dsh`
 - LLM key 一律经环境变量注入：变量名由 dsh profile 的 provider 配置（`cordis.patch.yml` 的 `apiKeyEnv`）声明，配什么 provider 就用什么变量，文档与代码里不要写死某个 key 名；插件与仓库**不存任何 key**
 - 构建脚本为 POSIX sh：macOS / Linux 原生可用，Windows 走 WSL 或 Git Bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ## 开发环境
 
-- Node.js >= 24.15
+- Node.js >= 22.13.0
 - 全局安装 `@deepseek-ai/dsh`
 - macOS / Linux，Windows 使用 WSL 或 Git Bash
 

--- a/README.en.md
+++ b/README.en.md
@@ -1,43 +1,86 @@
+<p align="right">
+  <a href="./README.md">简体中文</a> · <strong>English</strong>
+</p>
+
 # Workflow One
 
-[简体中文](README.md) | English
+<p align="center">
+  <img src="./images/cover.png" width="100%" alt="Workflow One multi-agent workflows with fully transparent node outputs">
+</p>
 
-**A visual AI workflow orchestrator running inside [DeepSeek Harness (dsh)](https://github.com/deepseek-ai/deepseek-harness).** Build multi-agent DAGs with drag-and-drop nodes, watch live execution, recover interrupted runs, and send deliverables and run updates to Feishu.
+<p align="center">
+  <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DeepSeek-Harness-4D6BFE?labelColor=0F0F1A" alt="DeepSeek Harness plugin"></a>
+  <a href="https://www.npmjs.com/package/dsh-ccpg-one"><img src="https://img.shields.io/npm/v/dsh-ccpg-one" alt="npm version"></a>
+  <a href="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml"><img src="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
+  <a href="https://github.com/chumingjun/harness-one/releases/latest"><img src="https://img.shields.io/github/v/release/chumingjun/harness-one" alt="latest release"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/chumingjun/harness-one" alt="MIT license"></a>
+</p>
 
-[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek-Harness-4D6BFE?labelColor=0F0F1A&logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3hCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTEyIDJMMjIgMTJMMTIgMjJMMiAxMloiIGZpbGw9IiM0RDZCRkUiLz48L3N2Zz4)](https://github.com/deepseek-ai/deepseek-harness)
-[![npm](https://img.shields.io/npm/v/dsh-ccpg-one)](https://www.npmjs.com/package/dsh-ccpg-one)
-[![CI](https://github.com/chumingjun/harness-one/actions/workflows/ci.yml/badge.svg)](https://github.com/chumingjun/harness-one/actions/workflows/ci.yml)
-[![GitHub Release](https://img.shields.io/github/v/release/chumingjun/harness-one)](https://github.com/chumingjun/harness-one/releases/latest)
-[![MIT License](https://img.shields.io/github/license/chumingjun/harness-one)](LICENSE)
+## Turn real agents into observable workflows
 
-![Workflow One cover — multi-agent workflows with fully transparent node outputs](images/cover.png)
+`Workflow One` is a visual AI workflow orchestrator for [DeepSeek Harness (dsh)](https://github.com/deepseek-ai/deepseek-harness). Build DAGs from real dsh agents, scripts, conditions, and HTTP nodes; start them from the canvas or chat; inspect every node's input, output, and artifacts; and resume interrupted runs without starting over.
+
+## Why Workflow One?
+
+| Capability | What changes |
+| --- | --- |
+| **Visual orchestration** | Express sequential, parallel, and conditional paths as nodes and edges instead of hiding the process in a prompt. |
+| **Real dsh agents** | Each agent node uses dsh models, tools, and Skills, with different models and roles on the same canvas. |
+| **Observable runs** | Inspect live state, actual inputs, outputs, tokens, traces, and artifacts while concurrent runs stay isolated. |
+| **Recoverable execution** | Retry, timeout, continue after failure, or resume from an interruption instead of rerunning the whole workflow. |
+| **Multiple triggers** | Start from the canvas, chat, a webhook, or cron; the AI assistant can also inspect, edit, and run workflows. |
+| **Deliverable results** | Preview or download artifacts and send progress or final results to Feishu groups and users. |
 
 ## Install
 
-Requires Node.js >= 24.15 and an existing dsh installation:
+> [!NOTE]
+> Requires Node.js >= 22.13.0 and [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness): `npm i -g @deepseek-ai/dsh`.
+
+### npm
 
 ```sh
-dsh plugin --profile web add dsh-ccpg-one@0.3.0
+dsh plugin --profile web add dsh-ccpg-one@latest
 dsh web
 ```
 
-In Harness Desktop, run `dsh plugin add dsh-ccpg-one@0.3.0` from **Open DSH Terminal**, then restart Desktop. A prebuilt offline bundle is also available from [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest).
+Harness Desktop users should open **Open DSH Terminal**, run `dsh plugin add dsh-ccpg-one@latest`, and restart Desktop. Do not run `setup.sh` in Desktop; it manages its own profile, Node/pnpm runtime, and loopback port. See [Desktop setup and troubleshooting](dsh-plugins/DESKTOP.md).
 
-## What It Does
+### Offline bundle
 
-A full walkthrough — zooming from the complete canvas down to live node details:
+Download the prebuilt bundle from [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest):
+
+```sh
+curl -LO https://github.com/chumingjun/harness-one/releases/download/<tag>/dsh-ccpg-plugins-<tag>.tar.gz
+tar -xzf dsh-ccpg-plugins-<tag>.tar.gz && cd dsh-plugins
+sh setup.sh --one wf1 4021
+sh start.sh wf1                         # http://127.0.0.1:4021/
+```
+
+### Build from source
+
+```sh
+git clone https://github.com/chumingjun/harness-one.git
+cd harness-one
+npm test                                # Optional: run the complete test suite
+sh dsh-plugins/build-web.sh             # Required for source installs
+sh dsh-plugins/setup.sh --one dev 4021
+sh dsh-plugins/start.sh dev
+```
+
+Models and API keys are managed entirely by the dsh profile. This repository and its plugins never hard-code or store keys. See [`dsh-plugins/README.md`](dsh-plugins/README.md) for complete setup, configuration, and development details.
+
+## How it works
+
+Workflow One lives inside the official dsh interface: the conversation remains visible on the left, with a zoomable workflow canvas beside it.
+
+1. Open **Workflow** beside the dsh chat input, then create or load a workflow.
+2. Add input, agent, script, condition, HTTP, output, notification, or note nodes and configure their prompts, variables, tools, and models.
+3. Save and run from the canvas, or ask the AI assistant in chat to inspect, edit, and run the workflow.
+4. Select a running node to inspect its actual input and execution details, then review the timeline, final result, and artifacts in the result panel.
 
 ![Workflow One switching from the full canvas to live node details](images/workflow-one-demo.gif)
 
 [View the full-resolution screenshot](images/workflow01.png)
-
-- Eight node types: input, agent, QuickJS script, condition, HTTP, output, notification, and note.
-- Parallel DAG scheduling with retries, timeouts, branch isolation, cancellation, replay, and restart recovery.
-- Live SSE status, per-node inputs and outputs, token usage, traces, artifacts, and document previews.
-- Stable template variables, workflow inputs, global variables, and structured agent outputs.
-- AI-assisted canvas editing through native dsh tools.
-- Webhook and cron triggers, optional Feishu document writeback, and workflow notification cards.
-- Workspace-local SQLite storage for workflows and run history.
 
 ![Conversation, node configuration, and live run progress](images/workflow.png)
 
@@ -55,19 +98,6 @@ Cards show progress, duration, node counts, output summaries, and failure or can
 ## Importable Examples
 
 [`examples/workflows/`](examples/workflows/) contains three ready-to-import workflows: repair ticket normalization, urgency routing, and parallel review. Open the Workflow list, choose **Import**, and select a `.workflow-one.json` file.
-
-## Source Setup
-
-```sh
-git clone https://github.com/chumingjun/harness-one.git
-cd harness-one
-npm test
-sh dsh-plugins/build-web.sh
-sh dsh-plugins/setup.sh --one dev 4021
-sh dsh-plugins/start.sh dev
-```
-
-The plugin uses the model provider configured by dsh. This repository never stores API keys.
 
 ## Packages
 

--- a/README.en.md
+++ b/README.en.md
@@ -61,7 +61,8 @@ sh start.sh wf1                         # http://127.0.0.1:4021/
 ```sh
 git clone https://github.com/chumingjun/harness-one.git
 cd harness-one
-npm test                                # Optional: run the complete test suite
+npm install
+npm --prefix web install
 sh dsh-plugins/build-web.sh             # Required for source installs
 sh dsh-plugins/setup.sh --one dev 4021
 sh dsh-plugins/start.sh dev

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ sh start.sh wf1                         # http://127.0.0.1:4021/
 ```sh
 git clone https://github.com/chumingjun/harness-one.git
 cd harness-one
-npm test                                # 可选：全量单测
+npm install
+npm --prefix web install
 sh dsh-plugins/build-web.sh             # 源码安装必跑，构建产物不入库
 sh dsh-plugins/setup.sh --one dev 4021
 sh dsh-plugins/start.sh dev

--- a/README.md
+++ b/README.md
@@ -1,40 +1,84 @@
+<p align="right">
+  <strong>简体中文</strong> · <a href="./README.en.md">English</a>
+</p>
+
 # Workflow One
 
-简体中文 | [English](README.en.md)
+<p align="center">
+  <img src="./images/cover.png" width="100%" alt="Workflow One 多智能体工作流，节点输出全透明">
+</p>
 
-**运行在 [DeepSeek Harness（dsh）](https://github.com/deepseek-ai/deepseek-harness) 中的可视化 AI 工作流编排器。** 用拖拽 DAG 组合真实 dsh agent、脚本、条件分支和 HTTP 节点，实时查看运行进度，异常后从中断节点恢复，并将成果与运行进度推送到飞书。
+<p align="center">
+  <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DeepSeek-Harness-4D6BFE?labelColor=0F0F1A" alt="DeepSeek Harness 插件"></a>
+  <a href="https://www.npmjs.com/package/dsh-ccpg-one"><img src="https://img.shields.io/npm/v/dsh-ccpg-one" alt="npm 版本"></a>
+  <a href="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml"><img src="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml/badge.svg" alt="CI 状态"></a>
+  <a href="https://github.com/chumingjun/harness-one/releases/latest"><img src="https://img.shields.io/github/v/release/chumingjun/harness-one" alt="最新版本"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/chumingjun/harness-one" alt="MIT 许可证"></a>
+</p>
 
-[![DeepSeek Harness](https://img.shields.io/badge/DeepSeek-Harness-4D6BFE?labelColor=0F0F1A&logo=data:image/svg%2Bxml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3hCb3g9IjAgMCAyNCAyNCIgZmlsbD0ibm9uZSI+PHBhdGggZD0iTTEyIDJMMjIgMTJMMTIgMjJMMiAxMloiIGZpbGw9IiM0RDZCRkUiLz48L3N2Zz4)](https://github.com/deepseek-ai/deepseek-harness)
-[![npm](https://img.shields.io/npm/v/dsh-ccpg-one)](https://www.npmjs.com/package/dsh-ccpg-one)
-[![CI](https://github.com/chumingjun/harness-one/actions/workflows/ci.yml/badge.svg)](https://github.com/chumingjun/harness-one/actions/workflows/ci.yml)
-[![GitHub Release](https://img.shields.io/github/v/release/chumingjun/harness-one)](https://github.com/chumingjun/harness-one/releases/latest)
-[![MIT License](https://img.shields.io/github/license/chumingjun/harness-one)](LICENSE)
+## 一句话，把真实 Agent 变成可观察的工作流
 
-![Workflow One 封面——多智能体工作流，节点输出全透明](images/cover.png)
+`Workflow One` 是运行在 [DeepSeek Harness（dsh）](https://github.com/deepseek-ai/deepseek-harness) 中的可视化 AI 工作流编排器。用拖拽 DAG 组合真实 dsh agent、脚本、条件分支和 HTTP 节点，在画布或对话中启动流程，实时查看每个节点的输入、输出和产物，失败后从中断处恢复。
 
-## 立即安装
+## 为什么需要 Workflow One？
 
-Node.js >= 24.15 且已安装 `@deepseek-ai/dsh`：
+| 能力 | 带来的变化 |
+| --- | --- |
+| **可视化编排** | 用节点和连线表达串行、并行与条件分支，复杂流程不再藏在提示词里。 |
+| **真实 dsh Agent** | 每个智能体节点直接使用 dsh 的模型、工具和 Skill，同一张图可组合不同模型与职责。 |
+| **运行全透明** | 实时查看节点状态、实际输入、输出、token、trace 和产物，多次运行可并发且互不干扰。 |
+| **可恢复执行** | 节点支持超时、重试、失败继续和断点续跑，不必因单点异常从头执行。 |
+| **多入口触发** | 可从画布、对话、Webhook 或 cron 定时启动；AI 助手也能查询、修改和运行工作流。 |
+| **结果可交付** | 结果与文档产物可预览、下载，也可通过飞书群聊或私聊推送进度和最终结果。 |
+
+## 安装
+
+> [!NOTE]
+> 需要 Node.js >= 22.13.0，并已安装 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)：`npm i -g @deepseek-ai/dsh`。
+
+### npm
 
 ```sh
-dsh plugin --profile web add dsh-ccpg-one@0.3.0
+dsh plugin --profile web add dsh-ccpg-one@latest
 dsh web
 ```
 
-Harness Desktop 用户在 **Open DSH Terminal** 中执行 `dsh plugin add dsh-ccpg-one@0.3.0`，然后重启 Desktop。也可以从 [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest) 下载离线聚合包。
+Harness Desktop 用户从托盘打开 **Open DSH Terminal**，执行 `dsh plugin add dsh-ccpg-one@latest` 后重启 Desktop。不要在 Desktop 中运行 `setup.sh`，Desktop 会自行管理 profile、Node/pnpm 和随机 loopback 端口。详见 [Desktop 安装与排障](dsh-plugins/DESKTOP.md)。
+
+### 离线包
+
+从 [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest) 下载聚合包，无需仓库源码：
+
+```sh
+curl -LO https://github.com/chumingjun/harness-one/releases/download/<tag>/dsh-ccpg-plugins-<tag>.tar.gz
+tar -xzf dsh-ccpg-plugins-<tag>.tar.gz && cd dsh-plugins
+sh setup.sh --one wf1 4021
+sh start.sh wf1                         # http://127.0.0.1:4021/
+```
+
+### 从源码构建
+
+```sh
+git clone https://github.com/chumingjun/harness-one.git
+cd harness-one
+npm test                                # 可选：全量单测
+sh dsh-plugins/build-web.sh             # 源码安装必跑，构建产物不入库
+sh dsh-plugins/setup.sh --one dev 4021
+sh dsh-plugins/start.sh dev
+```
+
+模型和密钥完全由 dsh profile 管理。插件使用 dsh 默认模型栈，也支持在 `cordis.patch.yml` 或 `~/.dsh/settings.yaml` 中追加 provider；本仓库和插件不写死、不存储任何 key。完整安装、配置与开发循环见 [`dsh-plugins/README.md`](dsh-plugins/README.md)。
+
+> 普通 dsh 的 lark-cli 由 `setup.sh` 或插件自举安装；Desktop 仅在用户明确点击后通过受管 pnpm 安装。
 
 ## 界面与使用方式
 
-Workflow One 嵌在 dsh 官方界面中：左侧保留与智能体的对话，中间是可缩放的工作流画布。节点按连线组成 DAG，可以串行执行，也可以并行分组、条件分支和失败打回。紫色节点是智能体，橙色节点负责条件判定；运行时节点会直接显示排队、执行、成功或失败状态。
-
-典型使用流程：
+Workflow One 嵌在 dsh 官方界面中：左侧保留与智能体的对话，中间是可缩放的工作流画布。节点按连线组成 DAG，可以串行执行，也可以并行分组、条件分支和失败打回；运行时节点会直接显示排队、执行、成功或失败状态。
 
 1. 在 dsh 对话输入框旁打开「工作流」，新建工作流或载入已有流程。
-2. 从工具栏添加输入、智能体、脚本、条件、HTTP、输出、消息通知等节点，连线后在节点面板配置提示词、变量、工具和模型。
+2. 从工具栏添加输入、智能体、脚本、条件、HTTP、输出、消息通知等节点，连线后配置提示词、变量、工具和模型。
 3. 保存并从画布启动，也可以在左侧对话中让 AI 助手检查、修改和运行当前工作流。
-4. 运行卡实时显示已完成节点数和当前节点；点击节点查看实际输入与执行详情，在右侧「过程 / 成果 / 问题」中查看时间线、最终结果和产物。
-
-下面是画布与节点运行详情的完整演示（从全图缩放到节点详情）：
+4. 点击运行中的节点查看实际输入与执行详情，在右侧「过程 / 成果 / 问题」中查看时间线、最终结果和产物。
 
 ![Workflow One 从完整画布切换到节点运行详情](images/workflow-one-demo.gif)
 
@@ -47,42 +91,6 @@ Workflow One 嵌在 dsh 官方界面中：左侧保留与智能体的对话，�
 ## 可导入模板
 
 [`examples/workflows/`](examples/workflows/) 提供三套可直接导入的工作流：报修工单整理、紧急度分流和多方并行评审。打开「工作流」列表，点击「导入」并选择 `.workflow-one.json` 文件即可使用。
-
-## 快速开始
-
-**Harness Desktop（npm 包发布后）**：从 Desktop 托盘打开 **Open DSH Terminal**，对当前 profile 安装并重启 Desktop：
-
-```sh
-dsh plugin add dsh-ccpg-one@0.3.0
-```
-
-Desktop 使用官方 DSH/Cordis 插件组合，不需要另一套插件。不要在 Desktop 里运行 `setup.sh`：Desktop 自己管理 profile、Node/pnpm 和随机 loopback 端口；飞书账号页首次点击「自动安装」时，lark-cli 会通过 Desktop 的受管 pnpm 安装到当前 profile。安装使用细节、环境差异与常见问题排查见 [`dsh-plugins/DESKTOP.md`](dsh-plugins/DESKTOP.md)；Desktop 开发兼容契约（`desktopProfiles`/`desktopPnpm` 动态探测、跨环境插件写法）也在该文档第 2 节。
-
-**普通用户（release 包，无需本仓库源码）**：
-
-```sh
-# 前提：node>=24.15、npm i -g @deepseek-ai/dsh
-curl -LO https://github.com/chumingjun/harness-one/releases/download/<tag>/dsh-ccpg-plugins-<tag>.tar.gz
-tar -xzf dsh-ccpg-plugins-<tag>.tar.gz && cd dsh-plugins
-sh setup.sh --one wf1 4021               # 一键安装（自带全部构建产物）
-sh start.sh wf1                          # 启动 → http://127.0.0.1:4021/
-```
-
-**开发者（源码）**：
-
-```sh
-git clone https://github.com/chumingjun/harness-one.git && cd harness-one/dsh-plugins
-npm test                                 # （可选）全量单测
-sh build-web.sh                          # 构建画布（含 document-preview）——产物不入库，源码安装必跑
-sh setup.sh --one dev 4021               # 安装（或逐插件：sh setup.sh dev 4021）
-sh start.sh dev
-```
-
-详细安装/使用/开发循环见 [`dsh-plugins/README.md`](dsh-plugins/README.md)。
-
-**模型完全交给 dsh 自带配置**：插件里的 agent 走 dsh 默认模型栈（`deepseek-official`，默认模型在官方 UI「模型」页选择、key 保存进 dsh 用户级 credentials），也可以像 dsh 原生那样在 profile 的 `cordis.patch.yml` / `~/.dsh/settings.yaml` 里自行追加 provider。`setup.sh` 只写端口覆盖，不写任何模型 provider——本仓库与插件不写死、不存任何 key。
-
-> 普通 dsh 的 lark-cli 由 setup.sh/插件自举安装；Desktop 只在用户明确点击后通过受管 pnpm 安装。
 
 ## 画布能力
 
@@ -198,10 +206,10 @@ dsh-plugins/
 ## 测试
 
 ```sh
-cd dsh-plugins/dsh-ccpg-orchestrator && for t in test/*.test.mjs; do node "$t"; done  # 14 套
-node dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs                               # canvasui 客户端
-node dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs                        # 4/4
-cd web && npm test                                                                    # 10 套
+cd dsh-plugins/dsh-ccpg-orchestrator && for t in test/*.test.mjs; do node "$t"; done
+node dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+node dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs
+cd web && npm test
 ```
 
 ## 已知限制

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -15,7 +15,7 @@
 
 ## 安装与使用
 
-普通 dsh 有 release/源码两种路径，前提是 **Node ≥ 24.15**、`npm i -g @deepseek-ai/dsh`。Harness Desktop 自带运行时，走下面的原生插件命令。
+普通 dsh 有 release/源码两种路径，前提是 **Node ≥ 22.13.0**、`npm i -g @deepseek-ai/dsh`。Harness Desktop 自带运行时，走下面的原生插件命令。
 
 ### Harness Desktop
 

--- a/dsh-plugins/boot-smoke.sh
+++ b/dsh-plugins/boot-smoke.sh
@@ -7,7 +7,7 @@
 #
 # 用法：sh boot-smoke.sh <tarball> [端口]
 # 环境隔离：DSH_HOME / HOME 之外的全局态不触碰；profile 与临时目录用完即删。
-# 依赖：node>=24.15、npm i -g @deepseek-ai/dsh、curl；模型不需要 key
+# 依赖：node>=22.13.0、npm i -g @deepseek-ai/dsh、curl；模型不需要 key
 #（smoke 只验证插件挂载与页面可服务，不发真实 LLM 请求）。
 set -e
 

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -28,7 +28,7 @@
     "cordis"
   ],
   "engines": {
-    "node": ">=24.15"
+    "node": ">=22.13.0"
   },
   "type": "module",
   "private": false,

--- a/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
@@ -14,7 +14,7 @@
         "quickjs-emscripten": "0.32.0"
       },
       "engines": {
-        "node": ">=24.15"
+        "node": ">=22.13.0"
       },
       "peerDependencies": {
         "@deepseek-ai/dsh-llm": "*",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -12,7 +12,7 @@
     "directory": "dsh-plugins/dsh-ccpg-orchestrator"
   },
   "engines": {
-    "node": ">=24.15"
+    "node": ">=22.13.0"
   },
   "peerDependencies": {
     "@deepseek-ai/dsh-llm": "*",

--- a/dsh-plugins/pack.sh
+++ b/dsh-plugins/pack.sh
@@ -14,7 +14,7 @@
 #   sh pack.sh [tag]     # tag 默认取最近 git tag（无则 0.0.0）
 # 环境变量：
 #   PACK_DIR   打包根目录（默认 /tmp/dsh-ccpg-pack），结束后可删
-#   DSH_NODE   构建与打包用的 node（默认自动探测，要求 >=24.15；兼容旧名 WF1_NODE）
+#   DSH_NODE   构建与打包用的 node（默认自动探测，要求 >=22.13.0；兼容旧名 WF1_NODE）
 set -e
 HERE=$(cd "$(dirname "$0")" && pwd)
 REPO_ROOT=$(cd "$HERE/.." && pwd)
@@ -29,11 +29,11 @@ OPTIONAL_PLUGINS="dsh-ccpg-brand"
 # 聚合壳（bundle patch 挂载七插件 + better-sidebar，可选件 env 门控）；其 node_modules 是本地安装产物，不打包
 AGG="dsh-ccpg-one"
 
-# ---- 0. node（>=24.15，内置 node:sqlite）----
+# ---- 0. node（>=22.13.0，内置 node:sqlite）----
 NODE_BIN="${DSH_NODE:-${WF1_NODE:-}}"
-[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>24||(a===24&&b>=15)?process.execPath:'')" 2>/dev/null || true)
-if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>24||(a===24&&b>=15)?0:1)" 2>/dev/null; then
-  echo "✗ 需要 node>=24.15（或设 DSH_NODE 指向）"
+[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>22||(a===22&&b>=13)?process.execPath:'')" 2>/dev/null || true)
+if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>22||(a===22&&b>=13)?0:1)" 2>/dev/null; then
+  echo "✗ 需要 node>=22.13.0（或设 DSH_NODE 指向）"
   exit 1
 fi
 echo "✓ node: $("$NODE_BIN" -v)"

--- a/dsh-plugins/setup.sh
+++ b/dsh-plugins/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Workflow One 插件本地分发安装脚本（模拟别人拿到这个仓库后的完整安装）。
-# 前提：已 npm i -g @deepseek-ai/dsh，且 node >= 24.15（内置 node:sqlite）
+# 前提：已 npm i -g @deepseek-ai/dsh，且 node >= 22.13.0（内置 node:sqlite）
 # 用法：
 #   sh setup.sh                  # 安装到默认 profile dsh-ccpg（端口 4021，七插件逐个挂载）
 #   sh setup.sh <profile> <端口> # 安装到自定义 profile
@@ -15,9 +15,9 @@ PROFILE="${1:-dsh-ccpg}"
 PORT="${2:-4021}"
 HERE=$(cd "$(dirname "$0")" && pwd)
 NODE_BIN="${DSH_NODE:-}"
-[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>24||(a===24&&b>=15)?process.execPath:'')" 2>/dev/null || true)
-if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>24||(a===24&&b>=15)?0:1)" 2>/dev/null; then
-  echo "✗ 需要 node>=24.15（或设 DSH_NODE 指向）"
+[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>22||(a===22&&b>=13)?process.execPath:'')" 2>/dev/null || true)
+if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>22||(a===22&&b>=13)?0:1)" 2>/dev/null; then
+  echo "✗ 需要 node>=22.13.0（或设 DSH_NODE 指向）"
   exit 1
 fi
 PATH=$(dirname "$NODE_BIN"):$PATH
@@ -105,7 +105,7 @@ DSH_BIN=$("$NODE_BIN" -e "console.log(require.resolve('@deepseek-ai/dsh/lib/bin.
 [ -z "$DSH_BIN" ] && for c in "$HOME/.local/npm-global/lib/node_modules/@deepseek-ai/dsh/lib/bin.js" "/usr/local/lib/node_modules/@deepseek-ai/dsh/lib/bin.js"; do
   [ -f "$c" ] && DSH_BIN="$c" && break
 done
-[ -z "$DSH_BIN" ] && { echo "✗ 未找到 dsh（先 npm i -g @deepseek-ai/dsh，需要 node>=24.15）"; exit 1; }
+[ -z "$DSH_BIN" ] && { echo "✗ 未找到 dsh（先 npm i -g @deepseek-ai/dsh，需要 node>=22.13.0）"; exit 1; }
 DSH_BIN=$("$NODE_BIN" -e "console.log(require('fs').realpathSync(process.argv[1]))" "$DSH_BIN")
 
 # 1. 建_profile（已存在则跳过）

--- a/dsh-plugins/start.sh
+++ b/dsh-plugins/start.sh
@@ -3,11 +3,11 @@
 PROFILE="${1:-}"
 export DSH_HOME="${DSH_HOME:-$HOME/.dsh}"
 
-# 定位能跑 Workflow One 的 node（>=24.15，内置 node:sqlite）与 dsh bin
+# 定位能跑 Workflow One 的 node（>=22.13.0，内置 node:sqlite）与 dsh bin
 NODE_BIN="${DSH_NODE:-}"
-[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>24||(a===24&&b>=15)?process.execPath:'')" 2>/dev/null || true)
-if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>24||(a===24&&b>=15)?0:1)" 2>/dev/null; then
-  echo "✗ 需要 node>=24.15（或设 DSH_NODE 指向）"
+[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>22||(a===22&&b>=13)?process.execPath:'')" 2>/dev/null || true)
+if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>22||(a===22&&b>=13)?0:1)" 2>/dev/null; then
+  echo "✗ 需要 node>=22.13.0（或设 DSH_NODE 指向）"
   exit 1
 fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "engines": {
-        "node": ">=24.15"
+        "node": ">=22.13.0"
       },
       "dependencies": {
         "quickjs-emscripten": "0.32.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "description": "dsh 插件开发工作区（Workflow One 物业编排套件）",
   "engines": {
-    "node": ">=24.15"
+    "node": ">=22.13.0"
   },
   "scripts": {
     "test": "sh scripts/run-tests.sh",

--- a/scripts/verify-plugin-packages.mjs
+++ b/scripts/verify-plugin-packages.mjs
@@ -32,7 +32,7 @@ for (const name of packages) {
   assert.equal(pkg.private, false, `${name} must be publishable`);
   assert.equal(pkg.license, 'MIT');
   assert.equal(pkg.repository?.directory, `dsh-plugins/${name}`);
-  assert.equal(pkg.engines?.node, ['dsh-ccpg-orchestrator', 'dsh-ccpg-one'].includes(name) ? '>=24.15' : '>=20');
+  assert.equal(pkg.engines?.node, ['dsh-ccpg-orchestrator', 'dsh-ccpg-one'].includes(name) ? '>=22.13.0' : '>=20');
   assert.equal(pkg.dsh?.bundle?.patch, './cordis.patch.yml');
 
   // 聚合包的最终 bundle 由 publish-npm.sh 在干净 staging 中逐项校验；


### PR DESCRIPTION
## 背景

现有中英文 README 安装入口重复，产品核心价值不够突出；同时 npm engines 将 Node 下限设为 24.15，高于当前代码实际需要。

## 方案

- 参考 dsh-agent-teams 的信息层级，重构中英文 README 顶部、价值说明和安装章节
- 安装命令统一使用 `@latest`，移除易漂移的测试套数
- 将 Workflow One / orchestrator 的 Node 下限统一调整为 `>=22.13.0`
- 同步 setup/start/pack 门禁、CI、release、包契约与开发文档

Node 20 不提供 `node:sqlite`；Node 22.13 起该模块无需实验参数，覆盖当前 SQLite 用法。

## 验证

- Node.js 22.13.0: `npm test` 全量通过
- Node.js 22.13.0: `sh dsh-plugins/build-web.sh` 双构建通过
- `node scripts/verify-plugin-packages.mjs` 通过
- README 本地链接检查通过
- `git diff --check` 通过