### PR TITLE
fix(web): 精简画布运行控件并更新安装指引

### DIFF
--- a/.codegraph/.gitignore
+++ b/.codegraph/.gitignore
@@ -1,5 +1,0 @@
-# CodeGraph data files — local to each machine, not for committing.
-# Ignore everything in .codegraph/ except this file itself, so transient
-# files (the database, daemon.pid, sockets, logs) never show up in git.
-*
-!.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ dsh-plugins/dsh-ccpg-one/pnpm-lock.yaml
 # 防本机手动 pack 时误提交二进制）
 dsh-plugins/vendor/
 .playwright-mcp/
+.codegraph/

--- a/README.en.md
+++ b/README.en.md
@@ -39,11 +39,13 @@
 ### npm
 
 ```sh
-dsh plugin --profile web add dsh-ccpg-one@latest
+dsh plugin --profile web add dsh-ccpg-one
 dsh web
 ```
 
-Harness Desktop users should open **Open DSH Terminal**, run `dsh plugin add dsh-ccpg-one@latest`, and restart Desktop. Do not run `setup.sh` in Desktop; it manages its own profile, Node/pnpm runtime, and loopback port. See [Desktop setup and troubleshooting](dsh-plugins/DESKTOP.md).
+[Harness Desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) users should open **Open DSH Terminal**, run `dsh plugin add dsh-ccpg-one`, and restart Desktop. Do not run `setup.sh` in Desktop; it manages its own profile, Node/pnpm runtime, and loopback port. See [Desktop setup and troubleshooting](dsh-plugins/DESKTOP.md).
+
+**UI dependency:** Workflow One's embedded canvas is hosted in the official dsh interface by the open-source [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) project. `dsh-ccpg-one` installs and depends on it automatically. If DSH-better-sidebar is missing or disabled, the embedded Workflow entry is unavailable, while the standalone `/wf1/` canvas remains accessible.
 
 ### Offline bundle
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,13 @@
 ### npm
 
 ```sh
-dsh plugin --profile web add dsh-ccpg-one@latest
+dsh plugin --profile web add dsh-ccpg-one
 dsh web
 ```
 
-Harness Desktop 用户从托盘打开 **Open DSH Terminal**，执行 `dsh plugin add dsh-ccpg-one@latest` 后重启 Desktop。不要在 Desktop 中运行 `setup.sh`，Desktop 会自行管理 profile、Node/pnpm 和随机 loopback 端口。详见 [Desktop 安装与排障](dsh-plugins/DESKTOP.md)。
+[Harness Desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) 用户从托盘打开 **Open DSH Terminal**，执行 `dsh plugin add dsh-ccpg-one` 后重启 Desktop。不要在 Desktop 中运行 `setup.sh`，Desktop 会自行管理 profile、Node/pnpm 和随机 loopback 端口。详见 [Desktop 安装与排障](dsh-plugins/DESKTOP.md)。
+
+**界面依赖说明**：Workflow One 在 dsh 官方界面中的「工作流」画布由开源项目 [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) 提供侧栏与标签页宿主，`dsh-ccpg-one` 会自动安装并依赖它。未安装或禁用 DSH-better-sidebar 时，官方界面内嵌的「工作流」入口不可用，但独立画布 `/wf1/` 仍可访问。
 
 ### 离线包
 

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -17,7 +17,7 @@ Workflow One 是运行在 DeepSeek Harness（dsh）里的可视化工作流编�
 安装：
 
 ```sh
-dsh plugin --profile web add dsh-ccpg-one@0.2.1
+dsh plugin --profile web add dsh-ccpg-one
 dsh web
 ```
 
@@ -34,7 +34,7 @@ Workflow One is a visual workflow orchestrator that runs inside DeepSeek Harness
 It supports parallel scheduling, retries, cancellation, replay, restart recovery, webhook and cron triggers, and optional Feishu writeback. Workflows and run history are stored in a workspace-local SQLite database.
 
 ```sh
-dsh plugin --profile web add dsh-ccpg-one@0.2.1
+dsh plugin --profile web add dsh-ccpg-one
 dsh web
 ```
 
@@ -44,9 +44,9 @@ Three importable examples are included for ticket normalization, urgency routing
 
 ## Short Versions
 
-**中文：** Workflow One 把 dsh 智能体、脚本、条件和 HTTP 节点连成可视化 DAG，支持并行执行、实时状态、失败恢复和工作区 SQLite 存储。安装：`dsh plugin --profile web add dsh-ccpg-one@0.2.1`。https://github.com/chumingjun/harness-one
+**中文：** Workflow One 把 dsh 智能体、脚本、条件和 HTTP 节点连成可视化 DAG，支持并行执行、实时状态、失败恢复和工作区 SQLite 存储。安装：`dsh plugin --profile web add dsh-ccpg-one`。https://github.com/chumingjun/harness-one
 
-**English:** Workflow One adds visual, recoverable multi-agent DAGs to DeepSeek Harness: parallel execution, live node details, replay, and workspace-local SQLite storage. Install with `dsh plugin --profile web add dsh-ccpg-one@0.2.1`. https://github.com/chumingjun/harness-one
+**English:** Workflow One adds visual, recoverable multi-agent DAGs to DeepSeek Harness: parallel execution, live node details, replay, and workspace-local SQLite storage. Install with `dsh plugin --profile web add dsh-ccpg-one`. https://github.com/chumingjun/harness-one
 
 ## Suggested Media Order
 

--- a/dsh-plugins/DESKTOP.md
+++ b/dsh-plugins/DESKTOP.md
@@ -13,7 +13,7 @@ TL;DR：**Desktop 不需要任何专用安装脚本或专用插件分支**——
 从 Desktop 托盘菜单打开 **Open DSH Terminal**（该终端已绑定当前 profile），执行：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.2.1
+dsh plugin add dsh-ccpg-one
 ```
 
 聚合包自带 `dsh.bundle.patch`：`dsh plugin add` 一步完成「装依赖 + 进 bundles 层 + 挂载」7 个默认插件与 better-sidebar。安装完成后**重启 Desktop**（新 bundle 要在下一次 Loader 组合中生效）。

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -22,7 +22,7 @@
 从 Desktop 托盘打开 **Open DSH Terminal**；该终端已绑定当前 profile：
 
 ```sh
-dsh plugin add dsh-ccpg-one@0.3.0
+dsh plugin add dsh-ccpg-one
 ```
 
 安装后重启 Desktop，让新 bundle 进入 Loader 组合。compatibility 与 advanced 模式都继续使用普通 DSH Web Client；画布、同源 `/wf1/api/*`、侧栏和预览无需 Desktop 专用注册。飞书账号页首次点击「自动安装」时，插件通过公开 `desktopPnpm` service 把固定版本 lark-cli 安装到当前 profile，并在 profile 切换或退出时取消仍在运行的操作。
@@ -135,7 +135,7 @@ npx dsh-ccpg-one myprofile        # 预写 pnpm 11 放行（node-pty/koffi 构�
 也可直接用官方命令：
 
 ```sh
-dsh plugin --profile myprofile add dsh-ccpg-one@0.3.0
+dsh plugin --profile myprofile add dsh-ccpg-one
 ```
 
 > **pnpm 11 注意（issue #24）**：`dsh plugin add` 是 profile 目录里裸跑 pnpm，聚合依赖链里的 `node-pty`（dsh-better-sidebar 传递依赖，原生模块）会被 strict-dep-builds 拦下：安装非零退出、且 pnpm 往 profile 的 `pnpm-workspace.yaml` 写非法占位符 `node-pty: set this to true or false`，把 `pnpm approve-builds` 与重跑 install 一起堵死——**重试无效**。0.2.2 起用 `npx dsh-ccpg-one` 安装即可（它先把放行写对再装，幂等，可反复重跑）；已中招的 profile 也能用它自愈。

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -30,7 +30,6 @@ import { AddNodeMenu, CanvasAddMenu, MoreMenu } from './ToolbarMenus.jsx';
 import { NodePanel } from './NodePanel.jsx';
 import { WorkflowList } from './WorkflowList.jsx';
 import { RunHistory } from './RunHistory.jsx';
-import { RunSwitcher } from './RunSwitcher.jsx';
 import { ResultPanel } from './ResultPanel.jsx';
 import { FeishuCredModal } from './FeishuCredModal.jsx';
 import { TestRunModal } from './TestRunModal.jsx';
@@ -1609,19 +1608,12 @@ export default function App() {
         )}
 
         <div className={`result-panel-shell ${logOpen ? '' : 'panel-collapsed'}`}>
-          <button className="btn btn-sm panel-toggle" onClick={() => setLogOpen((v) => !v)}
-            aria-label={logOpen ? '收起成果面板' : '展开成果面板'}>
-            {logOpen ? '▶ 收起' : '◀ 展开'}
-          </button>
-          {logOpen && (
-            <>
-              <RunSwitcher
-                runs={runList.filter((r) => (r.workflowId || null) === (currentWfIdRef.current || null) || !currentWfIdRef.current)}
-                inspectedRunId={inspectedRunId}
-                onSelect={selectRunForView}
-                onOpenHistory={() => setHistoryOpen(true)}
-              />
-              <ResultPanel
+          {!logOpen && (
+            <button className="btn btn-sm panel-toggle" onClick={() => setLogOpen(true)} aria-label="展开成果面板">
+              ◀ 展开
+            </button>
+          )}
+          {logOpen && <ResultPanel
             runDetail={runDetails[inspectedRunId]}
             events={eventsByRunId[inspectedRunId] || []}
             status={inspectedRunId === runStatus.runId ? runStatus : runDetails[inspectedRunId]}
@@ -1634,9 +1626,7 @@ export default function App() {
             onClose={() => setLogOpen(false)}
             onFocusNode={focusNode}
             onOpenNodeDetail={(runId, nodeId) => setNodeDetail({ runId, nodeId })}
-          />
-            </>
-          )}
+          />}
         </div>
           </>
         )}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -538,7 +538,6 @@ body {
 
 /* ============ 成果面板 ============ */
 .result-panel-shell { position: relative; display: flex; min-width: 0; transition: width var(--dur) var(--ease); }
-.result-panel-shell > .panel-toggle { position: absolute; z-index: 3; top: 8px; left: -62px; }
 .result-panel-shell.panel-collapsed { width: 38px; flex: 0 0 38px; border-left: 1px solid var(--border); background: var(--bg-panel); }
 .result-panel-shell.panel-collapsed > .panel-toggle { position: static; margin: 10px 4px; writing-mode: vertical-rl; letter-spacing: 3px; padding: 8px 2px; }
 .panel-toggle { white-space: nowrap; }


### PR DESCRIPTION
## 背景

画布重复展示运行切换与收起控件；安装文档写死聚合包版本且缺少相关开源项目入口；本地 CodeGraph 索引也被误纳入版本控制。

## 修改

- 移除画布运行切换胶囊与展开状态左侧收起按钮，保留成果面板右侧关闭按钮和收起后的展开入口
- 安装命令不再锁定 `dsh-ccpg-one` 版本，并补充 Harness Desktop、DSH-better-sidebar 开源链接与依赖说明
- 从版本控制移除 `.codegraph/` 并在根目录忽略

## 验证

- `npm test`
- `sh dsh-plugins/build-web.sh`
- 真实 `dsh web` + 浏览器验证：画布运行胶囊已移除，右侧关闭与收起后展开均正常