### PR TITLE
chore(release): v0.3.1——8 包升版

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-one",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.3.0",
-    "dsh-ccpg-document-preview": "0.3.0",
-    "dsh-ccpg-larkauth": "0.3.0",
-    "dsh-ccpg-llm-guard": "0.3.0",
-    "dsh-ccpg-orchestrator": "0.3.0",
-    "dsh-ccpg-tools": "0.3.0",
-    "dsh-ccpg-web": "0.3.0"
+    "dsh-ccpg-canvasui": "0.3.1",
+    "dsh-ccpg-document-preview": "0.3.1",
+    "dsh-ccpg-larkauth": "0.3.1",
+    "dsh-ccpg-llm-guard": "0.3.1",
+    "dsh-ccpg-orchestrator": "0.3.1",
+    "dsh-ccpg-tools": "0.3.1",
+    "dsh-ccpg-web": "0.3.1"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 背景

自 v0.3.0（#39）以来 main 上有 3 个提交：1 个前端 fix + 2 个文档提交，无新功能、无引擎改动，按补丁版发 **v0.3.1**。

## 变更内容

7 个子插件 + 聚合包 `dsh-ccpg-one` 同步 0.3.0 → 0.3.1（跨依赖声明同步）。brand 无改动、不在 npm 发布清单，保持 0.1.0。README 已在 #42 取消版本锁定，无文档版本号需同步。

## 验证

- `npm test` 全量（web 14 套 + orchestrator 17 套 + llm-guard/canvasui/larkauth/one/document-preview）✅
- `sh dsh-plugins/build-web.sh` 双构建 ✅
- `node scripts/verify-plugin-packages.mjs` 包契约（8 包 + brand）✅
- diff 形状与 v0.3.0 升版提交（6ac8c8a）一致：仅 8 个 package.json 版本行

合并后打 tag `v0.3.1` 触发 release（pack → boot-smoke → npm 8 包发布 → Release asset 上传）。