### PR TITLE
fix(release): 发版 runner 回退 Node 24.15，修 boot-smoke 起不来

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,10 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.13.0
+          # 发版 runner 用 24：boot-smoke 要真起最新 @deepseek-ai/dsh，
+          # 其依赖 dsh-session-persistence-jsonl 用 node:zlib 的 zstd API（22.15+ 才有），
+          # 22.13 下 boot 即 SyntaxError。仓库 engines 最低支持仍为 >=22.13。
+          node-version: 24.15
           registry-url: https://registry.npmjs.org
           cache: npm
           cache-dependency-path: |


### PR DESCRIPTION
## 背景

v0.3.1 tag 的 release 工作流在 boot-smoke 失败（run 32874988802）：官方 UI 60s 内未就绪。

## 根因

29c6280 把 release runner 从 24.15 降到 22.13.0。boot-smoke 安装的最新 `@deepseek-ai/dsh`（0.1.1-rc.2，8-21 发布）依赖 `dsh-session-persistence-jsonl`，从 `node:zlib` 导入 `createZstdDecompress`（zstd API，Node 22.15 才引入）——22.13 下 dsh boot 即 SyntaxError。

本地实证：22.13.0 上 `createZstdDecompress` 为 undefined，24.18.0 上为 function。v0.3.0 发版装同一版 dsh、在 24.15 runner 全绿。

## 方案

仅回退 release.yml 的 runner 至 24.15（v0.3.0 验证过的值）+ 注释说明。ci.yml 保持 22.13（只跑测试+构建，#43 已实证通过）；仓库 engines 最低支持 >=22.13 的用户契约不变——插件运行不依赖 zstd，只有最新 dsh 本体需要。

## 验证

- 本地 22.13.0 / 24.18.0 zstd API 实证（见上）
- 无代码改动，release 工作流将在修复后的 v0.3.1 tag 重跑中验证

合并后重打 v0.3.1 tag（删旧 tag 重推）重新触发发版。