### PR TITLE
docs(readme): Node 最低版本口径统一为 ≥22.15

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## 环境前提
 
-- Node ≥ 22.13.0（Workflow One 使用内置 `node:sqlite`）。系统自带 Node 版本不够时，用 `DSH_NODE` 环境变量指向任意 ≥ 22.13.0 的 node 可执行文件（setup/start/pack 脚本都认它）
+- Node ≥ 22.15.0（Workflow One 用内置 `node:sqlite`；dsh 本体用 `node:zlib` 的 zstd API，22.15 起才有——文档口径 ≥22.15，但 engines/脚本最低校验暂为 ≥22.13，抬版本待后续统一）。系统自带 Node 版本不够时，用 `DSH_NODE` 环境变量指向任意 ≥ 22.15.0 的 node 可执行文件（setup/start/pack 脚本都认它）
 - dsh 全局安装：`npm i -g @deepseek-ai/dsh`
 - LLM key 一律经环境变量注入：变量名由 dsh profile 的 provider 配置（`cordis.patch.yml` 的 `apiKeyEnv`）声明，配什么 provider 就用什么变量，文档与代码里不要写死某个 key 名；插件与仓库**不存任何 key**
 - 构建脚本为 POSIX sh：macOS / Linux 原生可用，Windows 走 WSL 或 Git Bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 
 ## 开发环境
 
-- Node.js >= 22.13.0
+- Node.js >= 22.15.0
 - 全局安装 `@deepseek-ai/dsh`
 - macOS / Linux，Windows 使用 WSL 或 Git Bash
 

--- a/README.en.md
+++ b/README.en.md
@@ -34,7 +34,7 @@
 ## Install
 
 > [!NOTE]
-> Requires Node.js >= 22.13.0 and [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness): `npm i -g @deepseek-ai/dsh`.
+> Requires Node.js >= 22.15.0 (dsh itself uses the zstd API from `node:zlib`, available since 22.15) and [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness): `npm i -g @deepseek-ai/dsh`.
 
 ### npm
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 ## 安装
 
 > [!NOTE]
-> 需要 Node.js >= 22.13.0，并已安装 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)：`npm i -g @deepseek-ai/dsh`。
+> 需要 Node.js >= 22.15.0（dsh 本体用到 `node:zlib` 的 zstd API，22.15 起提供），并已安装 [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness)：`npm i -g @deepseek-ai/dsh`。
 
 ### npm
 

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -15,7 +15,7 @@
 
 ## 安装与使用
 
-普通 dsh 有 release/源码两种路径，前提是 **Node ≥ 22.13.0**、`npm i -g @deepseek-ai/dsh`。Harness Desktop 自带运行时，走下面的原生插件命令。
+普通 dsh 有 release/源码两种路径，前提是 **Node ≥ 22.15.0**（dsh 本体需要 `node:zlib` 的 zstd API）、`npm i -g @deepseek-ai/dsh`。Harness Desktop 自带运行时，走下面的原生插件命令。
 
 ### Harness Desktop
 


### PR DESCRIPTION
## 背景

v0.3.1 发版（#44 修复过程中）实证：最新 `@deepseek-ai/dsh` 依赖 `dsh-session-persistence-jsonl`，从 `node:zlib` 导入 `createZstdDecompress`（zstd API，v23.8.0 加入、backport 到 v22.15.0）。Node 22.13 下 dsh boot 即 SyntaxError。用户装插件必跑 dsh，文档口径应跟实际可运行版本对齐。

## 变更

5 处文档 22.13 → 22.15，README 两处附原因说明：

- README.md / README.en.md（安装前提）
- CONTRIBUTING.md（开发环境）
- dsh-plugins/README.md（安装与使用）
- AGENTS.md（环境前提，注明 engines/脚本校验暂仍 22.13）

**仅文档**：engines、setup.sh 校验、ci.yml 均不动（仍 ≥22.13），抬版本待后续统一；不发版。

## 验证

纯文档改动，无代码路径变化；zstd 版本事实已经 Node 官方文档确认（Added in: v23.8.0, v22.15.0）。