### PR TITLE
chore(release): v0.3.2——8 包升版

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-one",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.3.1",
-    "dsh-ccpg-document-preview": "0.3.1",
-    "dsh-ccpg-larkauth": "0.3.1",
-    "dsh-ccpg-llm-guard": "0.3.1",
-    "dsh-ccpg-orchestrator": "0.3.1",
-    "dsh-ccpg-tools": "0.3.1",
-    "dsh-ccpg-web": "0.3.1"
+    "dsh-ccpg-canvasui": "0.3.2",
+    "dsh-ccpg-document-preview": "0.3.2",
+    "dsh-ccpg-larkauth": "0.3.2",
+    "dsh-ccpg-llm-guard": "0.3.2",
+    "dsh-ccpg-orchestrator": "0.3.2",
+    "dsh-ccpg-tools": "0.3.2",
+    "dsh-ccpg-web": "0.3.2"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 背景

自 v0.3.1（#43）以来 main 上仅 1 个文档提交（#45，Node 口径 ≥22.15），无代码变更。按 v0.2.2 先例（docs-only 走补丁版）发 **v0.3.2**，让文档修正进入 npm 包描述与离线聚合包。

## 变更

7 个子插件 + 聚合包 `dsh-ccpg-one` 同步 0.3.1 → 0.3.2（跨依赖声明同步）。brand 无改动，保持 0.1.0。

## 验证

- `npm test` 全量 ✅（本会话实跑）
- `sh dsh-plugins/build-web.sh` 双构建 ✅
- `node scripts/verify-plugin-packages.mjs` 包契约 ✅
- diff 仅 8 个 package.json 版本行（16 处版本号）

合并后打 tag `v0.3.2` 触发 release（runner 已是 24.15，#44）。