### PR TITLE
docs(readme): 更新架构图并致谢 ZCode

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -10,6 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DeepSeek-Harness-4D6BFE?labelColor=0F0F1A" alt="DeepSeek Harness plugin"></a>
+  <a href="https://zcode.z.ai/cn"><img src="https://img.shields.io/badge/Built%20with-ZCode-14B8A6?labelColor=0F0F1A" alt="Built with ZCode"></a>
   <a href="https://www.npmjs.com/package/dsh-ccpg-one"><img src="https://img.shields.io/npm/v/dsh-ccpg-one" alt="npm version"></a>
   <a href="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml"><img src="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
   <a href="https://github.com/chumingjun/harness-one/releases/latest"><img src="https://img.shields.io/github/v/release/chumingjun/harness-one" alt="latest release"></a>
@@ -107,6 +108,14 @@ Cards show progress, duration, node counts, output summaries, and failure or can
 The default bundle contains `dsh-ccpg-tools`, `dsh-ccpg-orchestrator`, `dsh-ccpg-web`, `dsh-ccpg-canvasui`, `dsh-ccpg-document-preview`, `dsh-ccpg-larkauth`, and `dsh-ccpg-llm-guard`. `dsh-ccpg-brand` is an optional standalone package.
 
 See [dsh-plugins/README.md](dsh-plugins/README.md) for installation, packaging, architecture, and storage details.
+
+## Architecture
+
+![Workflow One system architecture](images/architecture.svg)
+
+## Acknowledgements
+
+More than 90% of this project was developed using [ZCode](https://zcode.z.ai/cn). We thank ZCode for providing the development platform and support.
 
 ## Contributing and Security
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 
 <p align="center">
   <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DeepSeek-Harness-4D6BFE?labelColor=0F0F1A" alt="DeepSeek Harness 插件"></a>
+  <a href="https://zcode.z.ai/cn"><img src="https://img.shields.io/badge/Built%20with-ZCode-14B8A6?labelColor=0F0F1A" alt="使用 ZCode 开发"></a>
   <a href="https://www.npmjs.com/package/dsh-ccpg-one"><img src="https://img.shields.io/npm/v/dsh-ccpg-one" alt="npm 版本"></a>
   <a href="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml"><img src="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml/badge.svg" alt="CI 状态"></a>
   <a href="https://github.com/chumingjun/harness-one/releases/latest"><img src="https://img.shields.io/github/v/release/chumingjun/harness-one" alt="最新版本"></a>
@@ -183,17 +184,7 @@ Workflow One 嵌在 dsh 官方界面中：左侧保留与智能体的对话，�
 
 ## 架构
 
-```text
-web/                    前端（Vite + React 18 + @xyflow/react + CodeMirror）
-  src/App.jsx           画布 + 工具栏 + SSE 订阅
-  src/NodePanel.jsx     节点属性面板（脚本参数/Schema/模板编辑器）
-  src/registry.jsx      节点注册表（icon/色/preset/summary/badges）
-  src/result-adapter.js 运行结果适配（拓扑时间线/最终结果/产物分组）
-dsh-plugins/
-  dsh-ccpg-orchestrator/  引擎：NodeKind 注册表（execute/lint/edgeTaken/wantsSink）
-                          + agent 进程内驱动 + QuickJS 脚本运行器 + HTTP/SSE
-  dsh-ccpg-canvasui/      官方对话输入按钮 + better-sidebar 工作流画布
-```
+![Workflow One 系统架构](images/architecture.svg)
 
 双端节点注册表：引擎 NodeKind（调度/超时/重试）+ 前端 registry（图标/表单/徽标），新节点两处注册即得全部能力。agent 节点 = `ctx.agents.create` 进程内真实 dsh agent（followup → whenIdle → session events 聚合，同官方 headless 驱动）。
 
@@ -219,6 +210,10 @@ cd web && npm test
 
 - 飞书写回为追加段落块，不保留富文本格式
 - 工作流与运行记录按工作区存入 `.workflow-one/workflow-one.sqlite`；state、附件与运行产物仍为本地文件
+
+## 致谢
+
+本项目 90% 以上的开发工作使用 [ZCode](https://zcode.z.ai/cn) 完成，感谢 ZCode 提供的开发平台与支持。
 
 ## 反馈
 

--- a/images/architecture.svg
+++ b/images/architecture.svg
@@ -1,0 +1,154 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="1000" viewBox="0 0 1600 1000" role="img" aria-labelledby="title desc">
+  <title id="title">Workflow One system architecture</title>
+  <desc id="desc">Architecture diagram showing entry points, dsh plugins, orchestration services, workflow nodes, dsh capabilities, and workspace-local storage.</desc>
+  <defs>
+    <pattern id="grid" width="32" height="32" patternUnits="userSpaceOnUse">
+      <circle cx="1" cy="1" r="1" fill="#34312e" opacity="0.65"/>
+    </pattern>
+    <linearGradient id="titleAccent" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0" stop-color="#8b7cf6"/>
+      <stop offset="0.5" stop-color="#4da4ff"/>
+      <stop offset="1" stop-color="#2dd4bf"/>
+    </linearGradient>
+    <marker id="arrowBlue" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0 0 10 5 0 10Z" fill="#4da4ff"/>
+    </marker>
+    <marker id="arrowGreen" markerWidth="10" markerHeight="10" refX="8" refY="5" orient="auto" markerUnits="strokeWidth">
+      <path d="M0 0 10 5 0 10Z" fill="#2dd4bf"/>
+    </marker>
+    <style>
+      .label { font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #f4f1ed; letter-spacing: 0; }
+      .muted { fill: #aaa49e; }
+      .eyebrow { font-size: 17px; font-weight: 700; }
+      .heading { font-size: 24px; font-weight: 750; }
+      .body { font-size: 17px; font-weight: 600; }
+      .small { font-size: 14px; font-weight: 550; }
+      .panel { fill: #181715; stroke: #3b3733; stroke-width: 1.5; }
+      .box { fill: #211f1d; stroke-width: 1.5; }
+      .line { fill: none; stroke-width: 2; }
+    </style>
+  </defs>
+
+  <rect width="1600" height="1000" fill="#11100f"/>
+  <rect width="1600" height="1000" fill="url(#grid)"/>
+
+  <text class="label eyebrow" x="72" y="66" fill="#8b7cf6">DEEPSEEK HARNESS PLUGIN</text>
+  <text class="label" x="72" y="116" font-size="42" font-weight="800">Workflow One</text>
+  <text x="362" y="116" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="42" font-weight="800" fill="url(#titleAccent)">System Architecture</text>
+  <text class="label muted body" x="72" y="151">Visual workflow orchestration on native dsh agents, tools, models, and skills</text>
+
+  <!-- Entry points -->
+  <rect class="panel" x="72" y="190" width="1456" height="130" rx="8"/>
+  <text class="label eyebrow muted" x="96" y="222">ENTRY POINTS</text>
+
+  <rect class="box" x="96" y="240" width="324" height="56" rx="8" stroke="#8b7cf6"/>
+  <circle cx="120" cy="268" r="7" fill="#8b7cf6"/>
+  <text class="label body" x="139" y="274">dsh Web UI + Better Sidebar</text>
+
+  <rect class="box" x="450" y="240" width="324" height="56" rx="8" stroke="#4da4ff"/>
+  <circle cx="474" cy="268" r="7" fill="#4da4ff"/>
+  <text class="label body" x="493" y="274">AI Chat Assistant</text>
+
+  <rect class="box" x="804" y="240" width="324" height="56" rx="8" stroke="#f6b84a"/>
+  <circle cx="828" cy="268" r="7" fill="#f6b84a"/>
+  <text class="label body" x="847" y="274">Webhook + Cron Schedule</text>
+
+  <rect class="box" x="1158" y="240" width="346" height="56" rx="8" stroke="#2dd4bf"/>
+  <circle cx="1182" cy="268" r="7" fill="#2dd4bf"/>
+  <text class="label body" x="1201" y="274">Standalone Canvas /wf1/</text>
+
+  <!-- Plugin layer -->
+  <rect class="panel" x="72" y="356" width="1456" height="142" rx="8"/>
+  <text class="label eyebrow muted" x="96" y="389">DSH PLUGIN LAYER</text>
+
+  <rect class="box" x="96" y="407" width="250" height="66" rx="8" stroke="#8b7cf6"/>
+  <text class="label body" x="116" y="435">dsh-ccpg-canvasui</text>
+  <text class="label muted small" x="116" y="458">official UI integration</text>
+
+  <rect class="box" x="366" y="407" width="250" height="66" rx="8" stroke="#2dd4bf"/>
+  <text class="label body" x="386" y="435">dsh-ccpg-web</text>
+  <text class="label muted small" x="386" y="458">canvas static host</text>
+
+  <rect class="box" x="636" y="407" width="304" height="66" rx="8" stroke="#4da4ff"/>
+  <text class="label body" x="656" y="435">dsh-ccpg-orchestrator</text>
+  <text class="label muted small" x="656" y="458">engine + HTTP + SSE</text>
+
+  <rect class="box" x="960" y="407" width="250" height="66" rx="8" stroke="#f6b84a"/>
+  <text class="label body" x="980" y="435">tools + larkauth</text>
+  <text class="label muted small" x="980" y="458">dsh tools + Feishu login</text>
+
+  <rect class="box" x="1230" y="407" width="274" height="66" rx="8" stroke="#ef6461"/>
+  <text class="label body" x="1250" y="435">preview + llm-guard</text>
+  <text class="label muted small" x="1250" y="458">artifacts + call safety</text>
+
+  <!-- Core -->
+  <rect x="186" y="540" width="1228" height="188" rx="8" fill="#171819" stroke="#4da4ff" stroke-width="2"/>
+  <text class="label eyebrow" x="214" y="575" fill="#4da4ff">ORCHESTRATION CORE</text>
+  <text class="label heading" x="214" y="611">One run-isolated engine, shared by every entry point</text>
+
+  <rect class="box" x="214" y="636" width="214" height="64" rx="8" stroke="#4da4ff"/>
+  <text class="label body" x="234" y="663">HTTP + SSE API</text>
+  <text class="label muted small" x="234" y="685">/wf1/api/*</text>
+
+  <rect class="box" x="448" y="636" width="214" height="64" rx="8" stroke="#8b7cf6"/>
+  <text class="label body" x="468" y="663">Workflow Engine</text>
+  <text class="label muted small" x="468" y="685">DAG + retry + resume</text>
+
+  <rect class="box" x="682" y="636" width="214" height="64" rx="8" stroke="#f6b84a"/>
+  <text class="label body" x="702" y="663">Run Scheduler</text>
+  <text class="label muted small" x="702" y="685">concurrency + triggers</text>
+
+  <rect class="box" x="916" y="636" width="214" height="64" rx="8" stroke="#2dd4bf"/>
+  <text class="label body" x="936" y="663">Assistant Tools</text>
+  <text class="label muted small" x="936" y="685">canvas_* + workflow_*</text>
+
+  <rect class="box" x="1150" y="636" width="236" height="64" rx="8" stroke="#ef6461"/>
+  <text class="label body" x="1170" y="663">Notifications</text>
+  <text class="label muted small" x="1170" y="685">channel registry</text>
+
+  <!-- Nodes -->
+  <rect class="panel" x="72" y="770" width="970" height="162" rx="8"/>
+  <text class="label eyebrow muted" x="96" y="803">NODE EXECUTION</text>
+  <text class="label muted small" x="271" y="803">dual registry: engine behavior + canvas presentation</text>
+
+  <g class="label body" text-anchor="middle">
+    <rect class="box" x="96" y="827" width="102" height="66" rx="8" stroke="#4da4ff"/>
+    <text x="147" y="867">Input</text>
+    <rect class="box" x="214" y="827" width="102" height="66" rx="8" stroke="#8b7cf6"/>
+    <text x="265" y="867">Agent</text>
+    <rect class="box" x="332" y="827" width="102" height="66" rx="8" stroke="#f6b84a"/>
+    <text x="383" y="867">Script</text>
+    <rect class="box" x="450" y="827" width="118" height="66" rx="8" stroke="#f6b84a"/>
+    <text x="509" y="867">Condition</text>
+    <rect class="box" x="584" y="827" width="102" height="66" rx="8" stroke="#4da4ff"/>
+    <text x="635" y="867">HTTP</text>
+    <rect class="box" x="702" y="827" width="102" height="66" rx="8" stroke="#2dd4bf"/>
+    <text x="753" y="867">Output</text>
+    <rect class="box" x="820" y="827" width="102" height="66" rx="8" stroke="#ef6461"/>
+    <text x="871" y="867">Notify</text>
+    <rect class="box" x="938" y="827" width="80" height="66" rx="8" stroke="#aaa49e"/>
+    <text x="978" y="867">Note</text>
+  </g>
+
+  <!-- Foundation -->
+  <rect class="panel" x="1070" y="770" width="458" height="162" rx="8"/>
+  <text class="label eyebrow muted" x="1094" y="803">FOUNDATION</text>
+
+  <rect class="box" x="1094" y="827" width="190" height="78" rx="8" stroke="#8b7cf6"/>
+  <text class="label body" x="1114" y="855">Native dsh</text>
+  <text class="label muted small" x="1114" y="878">agents / models / tools</text>
+  <text class="label muted small" x="1114" y="896">skills / credentials</text>
+
+  <rect class="box" x="1304" y="827" width="200" height="78" rx="8" stroke="#2dd4bf"/>
+  <text class="label body" x="1324" y="855">Local Workspace</text>
+  <text class="label muted small" x="1324" y="878">SQLite / state / files</text>
+  <text class="label muted small" x="1324" y="896">isolated by session cwd</text>
+
+  <!-- Main flow arrows -->
+  <path class="line" d="M800 320V348" stroke="#4da4ff" marker-end="url(#arrowBlue)"/>
+  <path class="line" d="M788 498V532" stroke="#4da4ff" marker-end="url(#arrowBlue)"/>
+  <path class="line" d="M800 728V762" stroke="#2dd4bf" marker-end="url(#arrowGreen)"/>
+  <path class="line" d="M1298 728V762" stroke="#2dd4bf" marker-end="url(#arrowGreen)"/>
+
+  <text class="label muted small" x="72" y="972">All workflow data stays in the active dsh workspace; models and credentials remain managed by the dsh profile.</text>
+</svg>


### PR DESCRIPTION
## 修改

- 用可编辑的深色 SVG 系统架构图替换中文 README 的目录树，并同步到英文 README
- 在中英文 README 顶部增加 `Built with ZCode` 徽标
- 增加 ZCode 致谢，说明项目 90% 以上的开发工作使用 ZCode 完成

## 验证

- `xmllint --noout images/architecture.svg`
- SVG 以 1600x1000 实际渲染检查，无文字溢出或遮挡
- `npm test`
- `sh dsh-plugins/build-web.sh`