### PR TITLE
docs(readme): 补充 AI 自动创建工作流说明

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -20,7 +20,7 @@
 
 ## Turn real agents into observable workflows
 
-`Workflow One` is a visual AI workflow orchestrator for [DeepSeek Harness (dsh)](https://github.com/deepseek-ai/deepseek-harness). Build DAGs from real dsh agents, scripts, conditions, and HTTP nodes; start them from the canvas or chat; inspect every node's input, output, and artifacts; and resume interrupted runs without starting over.
+`Workflow One` is a visual AI workflow orchestrator for [DeepSeek Harness (dsh)](https://github.com/deepseek-ai/deepseek-harness). Describe what you need in natural language and the AI will plan and create a DAG of real dsh agents, scripts, conditions, and HTTP nodes. Fine-tune it on the canvas when needed, then start the flow, inspect every node's input, output, and artifacts, and resume interrupted runs without starting over.
 
 ## Why Workflow One?
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 ## 一句话，把真实 Agent 变成可观察的工作流
 
-`Workflow One` 是运行在 [DeepSeek Harness（dsh）](https://github.com/deepseek-ai/deepseek-harness) 中的可视化 AI 工作流编排器。用拖拽 DAG 组合真实 dsh agent、脚本、条件分支和 HTTP 节点，在画布或对话中启动流程，实时查看每个节点的输入、输出和产物，失败后从中断处恢复。
+`Workflow One` 是运行在 [DeepSeek Harness（dsh）](https://github.com/deepseek-ai/deepseek-harness) 中的可视化 AI 工作流编排器。只需用自然语言描述需求，AI 会自动规划并创建由真实 dsh agent、脚本、条件分支和 HTTP 节点组成的 DAG；也可在画布中微调后启动流程，实时查看每个节点的输入、输出和产物，失败后从中断处恢复。
 
 ## 为什么需要 Workflow One？
 

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -6,7 +6,7 @@
 
 ### 用 dsh 搭一个可恢复的多智能体可视化工作流
 
-Workflow One 是运行在 DeepSeek Harness（dsh）里的可视化工作流编排器。它把输入、智能体、QuickJS 脚本、条件分支、HTTP 请求和输出节点连成 DAG，并在同一界面展示实时执行状态、节点输入输出、产物和错误。
+Workflow One 是运行在 DeepSeek Harness（dsh）里的可视化工作流编排器。只需用自然语言描述需求，AI 就会自动规划并创建由输入、智能体、QuickJS 脚本、条件分支、HTTP 请求和输出节点组成的 DAG；随后可在画布中确认和微调，并在同一界面查看实时执行状态、节点输入输出、产物和错误。
 
 这次发布重点解决三个实际问题：
 
@@ -29,7 +29,7 @@ dsh web
 
 ### Workflow One: visual, recoverable multi-agent DAGs for DeepSeek Harness
 
-Workflow One is a visual workflow orchestrator that runs inside DeepSeek Harness (dsh). Connect input, agent, QuickJS script, condition, HTTP, output, and note nodes into a DAG; then inspect live status, real node inputs and outputs, artifacts, and failures from the same interface.
+Workflow One is a visual workflow orchestrator that runs inside DeepSeek Harness (dsh). Describe your needs in natural language and the AI will plan and create a DAG of input, agent, QuickJS script, condition, HTTP, output, and note nodes. Confirm and fine-tune it on the canvas, then inspect live status, real node inputs and outputs, artifacts, and failures from the same interface.
 
 It supports parallel scheduling, retries, cancellation, replay, restart recovery, webhook and cron triggers, and optional Feishu writeback. Workflows and run history are stored in a workspace-local SQLite database.
 

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -1,6 +1,6 @@
 # Workflow One — dsh 插件包（本地分发）
 
-7 个默认 Cordis 插件把物业智能体编排（拖拽画布 + 节点级真实 agent）装进任何 DeepSeek Harness (dsh)；brand 保留为独立可选插件：
+7 个默认 Cordis 插件把 AI 对话自动创建的物业智能体编排（可视化 DAG + 节点级真实 agent）装进任何 DeepSeek Harness (dsh)；brand 保留为独立可选插件：
 
 | 包 | 安装方式 | 职责 |
 |---|---|---|


### PR DESCRIPTION
## 背景
#49 合并后，补充产品简介、插件安装说明与发布素材中遗漏的 AI 自动创建工作流表达。

## 变更
- README 中英文简介突出自然语言描述需求、AI 自动规划与创建
- 插件包 README 与发布素材同步为 AI 创建优先
- 保留画布确认、微调和运行观察的补充定位

## 验证
- `git diff --check`
- `npm test`
- `sh dsh-plugins/build-web.sh`