### PR TITLE
chore(one): 投稿截图改为插件目录内 screenshots.json 声明

### DIFF
--- a/dsh-plugins/dsh-ccpg-one/screenshots.json
+++ b/dsh-plugins/dsh-ccpg-one/screenshots.json
@@ -1,0 +1,4 @@
+[
+  "https://raw.githubusercontent.com/chumingjun/harness-one/main/images/workflow01.png",
+  "https://raw.githubusercontent.com/chumingjun/harness-one/main/images/workflow.png"
+]


### PR DESCRIPTION
## 背景

awesome-dsh-plugin 维护方在 PR awesome-dsh-plugin/awesome-dsh-plugin#3157 中要求切换截图声明方式：不再往共用 `data/screenshots.json` 加键（108 个在开 PR 抢同一文件，互相 rebase），改在各插件仓库 `package.json` 旁放 `screenshots.json`，推自己仓库即生效。

## 方案

- 新增 `dsh-plugins/dsh-ccpg-one/screenshots.json`，指向 `images/` 下两张已有截图
- 采用 raw.githubusercontent.com 绝对 URL：contributing.md 明确禁止相对路径离开插件目录（no `..`），而图片在仓库根 `images/`；复制进插件目录会让 pack.sh 打包带上 2MB 无用大图，绝对 URL 是两种合规方式中更合适的一种

## 验证

- JSON 语法有效（数组 + 绝对 https URL，均为 contributing.md 接受的格式）
- 两张图片已存在于 main：`images/workflow01.png`、`images/workflow.png`