### PR TITLE
feat(orchestrator): 种子 workflow-one 技能进官方斜杠菜单

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,8 @@ Workflow One 嵌在 dsh 官方界面中，推荐从 AI 对话开始创建复杂�
 - 运行：`workflow_run`（异步返回 runId）/ `workflow_run_cancel`（按 runId、工作流或 all 批量）
 - 管理：`workflow_patch`（原子改图+可选改名，正打开的画布实时同步）/ `workflow_create` / `workflow_delete`（confirm 门 + live/webhook/定时关联守卫）/ `workflow_open`（把绑定画布切到指定工作流，SSE 联动）
 
+**workflow-one 技能**（orchestrator 种子到 dsh 原生技能根，同 feishu-cli 先例）：官方 `/` 菜单自动列出 `workflow-one`，选中即注入使用指南，模型按指南调上述工具干活；官方聊天 agent 与画布 agent 共用。
+
 ## 飞书
 
 - **账号登录**：官方 dsh Web UI 设置面板「飞书账号」扫码（lark-cli Device Flow，token 由 CLI 自管零落盘）；user token 后台自动续约（refresh 轮换，授权长期有效）

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -60,6 +60,7 @@ import { WorkflowSqliteStore } from './sqlite-store.js';
 import {
   canvasAssistantPersona, checkPatchResult, summarizeGraphForAI, validateGraphOps,
 } from './assistant.js';
+import { ensureWorkflowSkill } from './skill-seed.js';
 import {
   assertNonSensitiveVariableDefinitions, assertSafeContextObject, GlobalVariableStore, VariableStoreError,
   variableDefinitionsToValues,
@@ -109,6 +110,7 @@ const workspaceContext = new AsyncLocalStorage();
 
 export function apply(ctx, config) {
   ctxRef = ctx; // replayTrace 需要在路由 handler 里拿到 ctx.sessionPersistence
+  ensureWorkflowSkill({ log: (msg) => ctx.logger?.info?.(`[orchestrator] ${msg}`) }); // / 菜单入口：workflow-one 技能种子
   const stores = new Map();
   const publicHooks = new Map();
   const notificationChannels = new NotificationChannelRegistry();

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/skill-seed.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/skill-seed.js
@@ -1,0 +1,34 @@
+// workflow-one 技能种子：把 skills/workflow-one.md 写进 dsh 用户级技能发现根，
+// 官方 / 菜单自动列出（dsh-tool-skill 注入正文），机制沿 larkauth 种 feishu-cli 先例。
+// 幂等且不覆盖用户改动：目标存在且无管理标记（用户自己写的）→不碰；
+// 带标记且内容不同（插件发版更新）→覆盖；内容相同→跳过。
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const SKILL_ID = 'workflow-one';
+const SKILL_MARKER = 'managed-by: dsh-ccpg-orchestrator';
+const BUNDLED_SKILL = join(dirname(fileURLToPath(import.meta.url)), '..', 'skills', `${SKILL_ID}.md`);
+
+/** 种子到 DSH_HOME（未设置则 ~/.dsh）/skills/；返回写入的目标路径，未写返回 null */
+export function ensureWorkflowSkill({ log } = {}) {
+  const targetDir = join(process.env.DSH_HOME || join(homedir(), '.dsh'), 'skills');
+  const target = join(targetDir, `${SKILL_ID}.md`);
+  try {
+    const src = readFileSync(BUNDLED_SKILL, 'utf8');
+    if (existsSync(target)) {
+      const cur = readFileSync(target, 'utf8');
+      if (!cur.includes(SKILL_MARKER)) return null; // 用户改过，不覆盖
+      if (cur === src) return null;
+    }
+    mkdirSync(targetDir, { recursive: true });
+    writeFileSync(target, src);
+    log?.(`技能已种子: ${target}`);
+    return target;
+  } catch (e) {
+    log?.(`技能种子失败: ${e.message || e}`);
+    return null;
+  }
+}

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -47,6 +47,7 @@
   "files": [
     "lib",
     "src",
+    "skills",
     "cordis.patch.yml"
   ]
 }

--- a/dsh-plugins/dsh-ccpg-orchestrator/skills/workflow-one.md
+++ b/dsh-plugins/dsh-ccpg-orchestrator/skills/workflow-one.md
@@ -1,0 +1,56 @@
+---
+name: workflow-one
+description: "用 workflow_* 工具操作本工作区的节点式工作流：查列表/看详情/发起运行并跟踪进度/修改图/管理（新建、复制、改名、删除）。适合「帮我跑一下某工作流」「有哪些工作流」「现在在跑什么」「把某工作流的某节点改一下」这类诉求。"
+---
+
+<!-- managed-by: dsh-ccpg-orchestrator v1 -->
+
+# Workflow One 工作流对话指南
+
+本环境装有 Workflow One 编排工具族。用户口述需求，你按下面的映射调工具干活，
+不要让用户去翻文档或点界面。
+
+## 场景 → 工具
+
+| 用户想要 | 工具 |
+|---|---|
+| 有哪些工作流 / 各自在跑几个 | `workflow_list` |
+| 看某个工作流长什么样（节点/变量/输入） | `workflow_get`（默认概要省 token；`summary:false` 拿完整图） |
+| 跑一个工作流 | `workflow_run`（id 或 name 二选一） |
+| 现在在跑什么 / 跑得怎么样 | `workflow_runs`（`onlyLive:true` 只看运行中） |
+| 某次运行的节点状态与输出 | `workflow_run_status`（runId 从 run/runs 获得） |
+| 取消运行 | `workflow_run_cancel`（runId 单个 / workflowId 整个 / all 全部） |
+| 改已保存工作流的图 | `workflow_patch`（批量 ops 原子生效，语义同 canvas_graph_patch） |
+| 新建 / 复制工作流 | `workflow_create`（name 必填，可选 graph 或 copyFrom） |
+| 删除工作流 | `workflow_delete`（必须 confirm:true；有关联运行/定时/webhook 会拒绝并列出） |
+| 让用户屏幕切到某工作流 | `workflow_open`（仅绑定画布的会话） |
+
+## 运行约定
+
+1. **异步**：`workflow_run` 只返回 runId，用 `workflow_run_status` / `workflow_runs` 轮询到终态再汇报。
+2. **结构化输入**：工作流声明了 inputSchema 时，先 `workflow_get` 看清字段，再构造 `runInputs`；
+   纯文本触发的用 `triggerInput`。
+3. **工作区**：工具按当前会话绑定的工作目录定工作区。若返回「无法定位工作区」，
+   请用户在会话里绑定工作目录后重试；不同目录看到的工作流互不相通。
+
+## 画布会话
+
+绑定画布的会话（画布「工作流」标签页发起的对话）额外可用 `canvas_*` 家族
+（`canvas_get_graph` / `canvas_graph_summary` / `canvas_graph_patch` / `canvas_lint_graph` /
+`canvas_run_workflow` / `canvas_run_status`），作用于当前画布/草稿；
+普通聊天会话没有它们，改图一律走 `workflow_patch`。改完图 `canvas_lint_graph`
+或 patch 返回的 lint 有 error 必须修掉再回复用户。
+
+## 典型话术
+
+- 「帮我跑一下报修工单工作流」→ `workflow_list` 对名字 → `workflow_get` 看输入 →
+  `workflow_run` → 轮询 → 汇总节点产出
+- 「现在有什么在跑？」→ `workflow_runs`（onlyLive）→ 有异常的逐个 `workflow_run_status`
+- 「给工单分流工作流加一个紧急度判断节点」→ `workflow_get` 拿图 →
+  `workflow_patch`（addNode + connect 一批 ops）→ 看 lint 回执
+- 「删掉那个测试工作流」→ 先确认 → `workflow_delete`（confirm:true）
+
+## 回复风格
+
+简洁说明做了什么（启动了哪个工作流的 run、改了哪些节点/连线），不复述 JSON；
+运行失败的节点给出错误摘要和下一步建议（重跑 / 改图 / 取消）。

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/skill-seed.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/skill-seed.test.mjs
@@ -1,0 +1,40 @@
+// workflow-one 技能种子单测：写入/幂等/不覆盖用户文件/带标记升级，DSH_HOME 隔离不碰真实 ~/.dsh。
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+const dshHome = mkdtempSync(join(tmpdir(), 'wf1-skill-home-'));
+const originalDshHome = process.env.DSH_HOME;
+process.env.DSH_HOME = dshHome;
+const target = join(dshHome, 'skills', 'workflow-one.md');
+
+try {
+  const { ensureWorkflowSkill } = await import('../lib/skill-seed.js');
+  const bundled = readFileSync(new URL('../skills/workflow-one.md', import.meta.url), 'utf8');
+  const marker = 'managed-by: dsh-ccpg-orchestrator';
+
+  // 首次：写入
+  assert.equal(ensureWorkflowSkill(), target);
+  assert.equal(readFileSync(target, 'utf8'), bundled);
+
+  // 幂等：内容相同不再写
+  assert.equal(ensureWorkflowSkill(), null);
+  assert.equal(readFileSync(target, 'utf8'), bundled);
+
+  // 用户改过（无标记）：不覆盖
+  const userVersion = '---\nname: workflow-one\n---\n用户自己的内容\n';
+  writeFileSync(target, userVersion);
+  assert.equal(ensureWorkflowSkill(), null);
+  assert.equal(readFileSync(target, 'utf8'), userVersion);
+
+  // 带标记的旧内容：升级为当前版本
+  writeFileSync(target, `<!-- ${marker} v0 -->\n旧版正文\n`);
+  assert.equal(ensureWorkflowSkill(), target);
+  assert.equal(readFileSync(target, 'utf8'), bundled);
+
+  console.log('skill-seed: ok');
+} finally {
+  if (originalDshHome === undefined) delete process.env.DSH_HOME;
+  else process.env.DSH_HOME = originalDshHome;
+}


### PR DESCRIPTION
Closes #62

## 做了什么

把 **workflow-one 技能**种子到 dsh 原生技能根（`DSH_HOME || ~/.dsh`/skills/），机制完全复用 larkauth 种 feishu-cli 的先例。效果链路：

`/` 菜单的 `skill` 源自动列出 → 选中落 `/workflow-one ` 字面量 → host 端 `dsh-tool-skill` pre-step 把技能正文注入当轮模型 → 模型按指南调 `workflow_*` / `canvas_*` 工具干活。官方聊天 agent 与画布 agent 共用同一技能根，两处都可用。零 UI 代码。

### 改动

| 文件 | 内容 |
|---|---|
| `skills/workflow-one.md`（新） | 技能正文：场景→工具映射表、运行约定（异步轮询 / inputSchema 先读 / cwd 工作区）、canvas_* 画布门槛、典型话术 |
| `lib/skill-seed.js`（新，~40 行） | `ensureWorkflowSkill()`：幂等种子；无管理标记（用户改过）不覆盖；带标记且内容不同随插件发版升级 |
| `lib/index.js` | `apply()` 开头接线一行 |
| `package.json` | `files` 补 `"skills"` —— **npm 渠道此前会把技能文件裁掉**，装出来的插件启动时 `readFileSync` 直接抛错（tarball 渠道 rsync 整目录不受影响） |
| `test/skill-seed.test.mjs`（新） | 写入 / 幂等 / 用户文件保护 / 带标记升级；`DSH_HOME` 隔离不碰真实 `~/.dsh` |
| `README.md` | workflow_* 一节后补技能入口说明 |

### 与 issue 的两处偏差

- issue 提到的 `canvas_bind` 工具不存在：画布绑定由画布 UI 侧 `/wf1/api/assistant/bind` 完成，技能正文按「canvas_* 家族需绑定画布的会话」表述
- 「版本比对」用内容 diff（管理标记在场 + 内容不同即覆盖），无独立版本号文件

## 真机验证（隔离 DSH_HOME，完整链路）

1. 本 worktree 源码 `setup.sh` 装七插件到 `DSH_HOME=<tmp>` → dsh 启动 → **种子自动落盘** `<DSH_HOME>/skills/workflow-one.md`
2. `skill.list` RPC（带合法 session）：`workflow-one` 在列，确认来自种子根而非全局 `~/.agents/skills`
3. 源码确认宿主侧链路：slash 菜单 `ui-skill` 源 `onPick` 返回 `/workflow-one ` 字面量；`dsh-tool-skill` 的 `SKILL_GESTURE` 正则匹配 `/workflow-one` 并在 pre-step 注入正文
4. **端到端 LLM 验证**：`session.prompt` 发 `/workflow-one 有哪些工作流？` → 模型 reasoning 明确"skill workflow-one is already loaded"→ 调 `workflow_list` → 以中文表格汇报 2 个工作流并追问
5. 单测：`npm test` 全绿（含新增套件）；真实 `~/.dsh/skills` 未被测试污染

冒烟环境用完即焚，真实 `~/.dsh` 只在正式装插件后才会出现该技能。

## 风险

- `workflow-one` 名字与 host 内置 command 无冲突（本机 dsh 全量 command 名单核对过）；若上游未来加同名 command，slash 菜单 command 源（order 1）先于 skill 源（order 2）展示，届时需改名
- 技能升级依赖管理标记：用户手工删掉标记后不再自动升级（按设计，尊重用户改动）

🤖 Generated with [Claude Code](https://claude.com/claude-code)