### PR TITLE
build(node): engines 与脚本校验从 22.13 统一抬到 22.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22.13.0
+          node-version: 22.15.0
           cache: npm
           cache-dependency-path: |
             package-lock.json
@@ -48,7 +48,7 @@ jobs:
       - name: build
         run: sh dsh-plugins/build-web.sh
         env:
-          DSH_NODE: node # Workflow One 用 node:sqlite，要求 ≥22.13.0；CI 里就是 node 本身
+          DSH_NODE: node # Workflow One 用 node:sqlite，要求 ≥22.15.0；CI 里就是 node 本身
 
       - name: verify npm packages
         run: node scripts/verify-plugin-packages.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           # 发版 runner 用 24：boot-smoke 要真起最新 @deepseek-ai/dsh，
           # 其依赖 dsh-session-persistence-jsonl 用 node:zlib 的 zstd API（22.15+ 才有），
-          # 22.13 下 boot 即 SyntaxError。仓库 engines 最低支持仍为 >=22.13。
+          # 22.15 下 boot 即 SyntaxError。仓库 engines 最低支持为 >=22.15。
           node-version: 24.15
           registry-url: https://registry.npmjs.org
           cache: npm

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@
 
 ## 环境前提
 
-- Node ≥ 22.15.0（Workflow One 用内置 `node:sqlite`；dsh 本体用 `node:zlib` 的 zstd API，22.15 起才有——文档口径 ≥22.15，但 engines/脚本最低校验暂为 ≥22.13，抬版本待后续统一）。系统自带 Node 版本不够时，用 `DSH_NODE` 环境变量指向任意 ≥ 22.15.0 的 node 可执行文件（setup/start/pack 脚本都认它）
+- Node ≥ 22.15.0（Workflow One 用内置 `node:sqlite`；dsh 本体用 `node:zlib` 的 zstd API，22.15 起才有——engines 与脚本最低校验同口径 ≥22.15）。系统自带 Node 版本不够时，用 `DSH_NODE` 环境变量指向任意 ≥ 22.15.0 的 node 可执行文件（setup/start/pack 脚本都认它）
 - dsh 全局安装：`npm i -g @deepseek-ai/dsh`
 - LLM key 一律经环境变量注入：变量名由 dsh profile 的 provider 配置（`cordis.patch.yml` 的 `apiKeyEnv`）声明，配什么 provider 就用什么变量，文档与代码里不要写死某个 key 名；插件与仓库**不存任何 key**
 - 构建脚本为 POSIX sh：macOS / Linux 原生可用，Windows 走 WSL 或 Git Bash

--- a/dsh-plugins/boot-smoke.sh
+++ b/dsh-plugins/boot-smoke.sh
@@ -7,7 +7,7 @@
 #
 # 用法：sh boot-smoke.sh <tarball> [端口]
 # 环境隔离：DSH_HOME / HOME 之外的全局态不触碰；profile 与临时目录用完即删。
-# 依赖：node>=22.13.0、npm i -g @deepseek-ai/dsh、curl；模型不需要 key
+# 依赖：node>=22.15.0、npm i -g @deepseek-ai/dsh、curl；模型不需要 key
 #（smoke 只验证插件挂载与页面可服务，不发真实 LLM 请求）。
 set -e
 

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -28,7 +28,7 @@
     "cordis"
   ],
   "engines": {
-    "node": ">=22.13.0"
+    "node": ">=22.15.0"
   },
   "type": "module",
   "private": false,

--- a/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
@@ -14,7 +14,7 @@
         "quickjs-emscripten": "0.32.0"
       },
       "engines": {
-        "node": ">=22.13.0"
+        "node": ">=22.15.0"
       },
       "peerDependencies": {
         "@deepseek-ai/dsh-llm": "*",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -12,7 +12,7 @@
     "directory": "dsh-plugins/dsh-ccpg-orchestrator"
   },
   "engines": {
-    "node": ">=22.13.0"
+    "node": ">=22.15.0"
   },
   "peerDependencies": {
     "@deepseek-ai/dsh-llm": "*",

--- a/dsh-plugins/pack.sh
+++ b/dsh-plugins/pack.sh
@@ -14,7 +14,7 @@
 #   sh pack.sh [tag]     # tag 默认取最近 git tag（无则 0.0.0）
 # 环境变量：
 #   PACK_DIR   打包根目录（默认 /tmp/dsh-ccpg-pack），结束后可删
-#   DSH_NODE   构建与打包用的 node（默认自动探测，要求 >=22.13.0；兼容旧名 WF1_NODE）
+#   DSH_NODE   构建与打包用的 node（默认自动探测，要求 >=22.15.0；兼容旧名 WF1_NODE）
 set -e
 HERE=$(cd "$(dirname "$0")" && pwd)
 REPO_ROOT=$(cd "$HERE/.." && pwd)
@@ -29,11 +29,11 @@ OPTIONAL_PLUGINS="dsh-ccpg-brand"
 # 聚合壳（bundle patch 挂载七插件 + better-sidebar，可选件 env 门控）；其 node_modules 是本地安装产物，不打包
 AGG="dsh-ccpg-one"
 
-# ---- 0. node（>=22.13.0，内置 node:sqlite）----
+# ---- 0. node（>=22.15.0，内置 node:sqlite）----
 NODE_BIN="${DSH_NODE:-${WF1_NODE:-}}"
-[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>22||(a===22&&b>=13)?process.execPath:'')" 2>/dev/null || true)
-if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>22||(a===22&&b>=13)?0:1)" 2>/dev/null; then
-  echo "✗ 需要 node>=22.13.0（或设 DSH_NODE 指向）"
+[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>22||(a===22&&b>=15)?process.execPath:'')" 2>/dev/null || true)
+if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>22||(a===22&&b>=15)?0:1)" 2>/dev/null; then
+  echo "✗ 需要 node>=22.15.0（或设 DSH_NODE 指向）"
   exit 1
 fi
 echo "✓ node: $("$NODE_BIN" -v)"

--- a/dsh-plugins/setup.sh
+++ b/dsh-plugins/setup.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Workflow One 插件本地分发安装脚本（模拟别人拿到这个仓库后的完整安装）。
-# 前提：已 npm i -g @deepseek-ai/dsh，且 node >= 22.13.0（内置 node:sqlite）
+# 前提：已 npm i -g @deepseek-ai/dsh，且 node >= 22.15.0（内置 node:sqlite）
 # 用法：
 #   sh setup.sh                  # 安装到默认 profile dsh-ccpg（端口 4021，七插件逐个挂载）
 #   sh setup.sh <profile> <端口> # 安装到自定义 profile
@@ -15,9 +15,9 @@ PROFILE="${1:-dsh-ccpg}"
 PORT="${2:-4021}"
 HERE=$(cd "$(dirname "$0")" && pwd)
 NODE_BIN="${DSH_NODE:-}"
-[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>22||(a===22&&b>=13)?process.execPath:'')" 2>/dev/null || true)
-if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>22||(a===22&&b>=13)?0:1)" 2>/dev/null; then
-  echo "✗ 需要 node>=22.13.0（或设 DSH_NODE 指向）"
+[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>22||(a===22&&b>=15)?process.execPath:'')" 2>/dev/null || true)
+if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>22||(a===22&&b>=15)?0:1)" 2>/dev/null; then
+  echo "✗ 需要 node>=22.15.0（或设 DSH_NODE 指向）"
   exit 1
 fi
 PATH=$(dirname "$NODE_BIN"):$PATH
@@ -105,7 +105,7 @@ DSH_BIN=$("$NODE_BIN" -e "console.log(require.resolve('@deepseek-ai/dsh/lib/bin.
 [ -z "$DSH_BIN" ] && for c in "$HOME/.local/npm-global/lib/node_modules/@deepseek-ai/dsh/lib/bin.js" "/usr/local/lib/node_modules/@deepseek-ai/dsh/lib/bin.js"; do
   [ -f "$c" ] && DSH_BIN="$c" && break
 done
-[ -z "$DSH_BIN" ] && { echo "✗ 未找到 dsh（先 npm i -g @deepseek-ai/dsh，需要 node>=22.13.0）"; exit 1; }
+[ -z "$DSH_BIN" ] && { echo "✗ 未找到 dsh（先 npm i -g @deepseek-ai/dsh，需要 node>=22.15.0）"; exit 1; }
 DSH_BIN=$("$NODE_BIN" -e "console.log(require('fs').realpathSync(process.argv[1]))" "$DSH_BIN")
 
 # 1. 建_profile（已存在则跳过）

--- a/dsh-plugins/start.sh
+++ b/dsh-plugins/start.sh
@@ -3,11 +3,11 @@
 PROFILE="${1:-}"
 export DSH_HOME="${DSH_HOME:-$HOME/.dsh}"
 
-# 定位能跑 Workflow One 的 node（>=22.13.0，内置 node:sqlite）与 dsh bin
+# 定位能跑 Workflow One 的 node（>=22.15.0，内置 node:sqlite）与 dsh bin
 NODE_BIN="${DSH_NODE:-}"
-[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>22||(a===22&&b>=13)?process.execPath:'')" 2>/dev/null || true)
-if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>22||(a===22&&b>=13)?0:1)" 2>/dev/null; then
-  echo "✗ 需要 node>=22.13.0（或设 DSH_NODE 指向）"
+[ -z "$NODE_BIN" ] && NODE_BIN=$(node -e "const [a,b]=process.versions.node.split('.').map(Number); console.log(a>22||(a===22&&b>=15)?process.execPath:'')" 2>/dev/null || true)
+if [ -z "$NODE_BIN" ] || ! "$NODE_BIN" -e "const [a,b]=process.versions.node.split('.').map(Number); process.exit(a>22||(a===22&&b>=15)?0:1)" 2>/dev/null; then
+  echo "✗ 需要 node>=22.15.0（或设 DSH_NODE 指向）"
   exit 1
 fi
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "engines": {
-        "node": ">=22.13.0"
+        "node": ">=22.15.0"
       },
       "dependencies": {
         "quickjs-emscripten": "0.32.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "description": "dsh 插件开发工作区（Workflow One 物业编排套件）",
   "engines": {
-    "node": ">=22.13.0"
+    "node": ">=22.15.0"
   },
   "scripts": {
     "test": "sh scripts/run-tests.sh",

--- a/scripts/verify-plugin-packages.mjs
+++ b/scripts/verify-plugin-packages.mjs
@@ -32,7 +32,7 @@ for (const name of packages) {
   assert.equal(pkg.private, false, `${name} must be publishable`);
   assert.equal(pkg.license, 'MIT');
   assert.equal(pkg.repository?.directory, `dsh-plugins/${name}`);
-  assert.equal(pkg.engines?.node, ['dsh-ccpg-orchestrator', 'dsh-ccpg-one'].includes(name) ? '>=22.13.0' : '>=20');
+  assert.equal(pkg.engines?.node, ['dsh-ccpg-orchestrator', 'dsh-ccpg-one'].includes(name) ? '>=22.15.0' : '>=20');
   assert.equal(pkg.dsh?.bundle?.patch, './cordis.patch.yml');
 
   // 聚合包的最终 bundle 由 publish-npm.sh 在干净 staging 中逐项校验；


### PR DESCRIPTION
背景与方案见 commit；落点清单来自 #54 全仓 grep，另补了一处 issue 清单外漏网：`scripts/verify-plugin-packages.mjs:35` 对 orchestrator/one 的 engines 断言（CI/发版都会炸）。

验证：
- 全仓 grep `22.13|b>=13` 仅剩 document-preview lock 里第三方依赖的 engines（不动）
- node scripts/verify-plugin-packages.mjs 本地通过
- pre-push 全量单测通过；document-preview lock 第三方 engines 不在改动面

Closes #54