### PR TITLE
fix(upgrade): 原地更新套件并修复失败状态误报

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -1038,7 +1038,13 @@ window.__ModuleLoader__.load({
         systemPost(SYSTEM_UPGRADE_API, { confirm: true })
           .then(function (r) {
             if (r.ok) {
-              setUpgradeState({ phase: "done", log: r.log || [] });
+              var resultLog = r.log || [];
+              var hasFailure = resultLog.some(function (line) { return /^\s*✗/.test(String(line)); });
+              if (hasFailure) {
+                setUpgradeState({ phase: "failed", message: resultLog.filter(function (line) { return /^\s*✗/.test(String(line)); }).join("；") || "升级失败" });
+                return;
+              }
+              setUpgradeState({ phase: "done", log: resultLog });
               load();
               setCheck(null);
             } else {

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/system-upgrade.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/system-upgrade.js
@@ -7,7 +7,7 @@
 // 不做业务判断——动作合法性全部在 planner 定型。
 
 import { execFile } from 'node:child_process';
-import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
+import { existsSync, lstatSync, readdirSync, readFileSync, realpathSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 
@@ -92,6 +92,15 @@ export function collectInstallReport({ profilesRoot: root = profilesRoot() } = {
         packages.push({ name: pkg, kind: 'registry', spec, version: spec.replace(/^[^\d]*/, '') || null });
       }
     }
+    // 残局探测：升级中断的 profile 被 dsh plugin remove 全量回收——依赖表与
+    // bundles 都不再挂聚合包，但 node_modules/.bin/dsh-ccpg-one 链接残留（悬空
+    // 软链，existsSync 会跟链判 false，须 lstat 看链接本身）。以它为「曾装过」
+    // 信号标记空壳，planner 走 up 自愈重装。
+    if (!packages.length) {
+      let binResidue = false;
+      try { binResidue = lstatSync(join(path, 'node_modules', '.bin', AGGREGATE)).isSymbolicLink(); } catch { /* 无残留 */ }
+      if (binResidue) packages.push({ name: AGGREGATE, kind: 'registry', spec: 'latest', version: null, broken: true });
+    }
     if (packages.length) report.push({ name, path, packages });
   }
   return report;
@@ -134,24 +143,25 @@ export function planUpgrade(report) {
         break;
       }
     }
-    // ---- npm 安装：聚合包整链 remove→add 最新 ----
+    // ---- npm 安装：聚合包原地更新到 latest ----
+    // 成熟包管理器的同款路径：pnpm up 原地覆盖，依赖表/bundles/.bin 全程不动——
+    // 没有 remove→install 的空窗，也就没有「卸完装不回去」的残局。
+    // installerDir 在场时顺带复用包内安装器做 pnpm11 放行预写（幂等，防 node-pty 拦截）。
     const hasRegistry = profile.packages.some((p) => p.kind === 'registry');
     if (hasRegistry) {
       const bundles = readProfileBundles(profile.path);
       const installerDir = locateInstalledInstaller(profile.path);
-      if (!installerDir) {
-        warnings.push(`profile ${profile.name}：registry 来源但未找到已装 ${AGGREGATE} 的安装器（node_modules/${AGGREGATE}/bin/install.js），跳过 npm 升级`);
-      } else {
-        registryProfiles.push(profile.name);
-        actions.push({
-          type: 'npm-reinstall',
-          title: `npm 更新 ${AGGREGATE}@${oneEntry?.spec || '?'} → latest（profile: ${profile.name}）`,
-          profile: profile.name,
-          profilePath: profile.path,
-          installerDir,
-          keepSidebarRemoved: bundles.includes(SIDEBAR) ? false : true,
-        });
-      }
+      registryProfiles.push(profile.name);
+      actions.push({
+        type: 'npm-reinstall',
+        title: oneEntry?.broken
+          ? `修复未完成的安装：重装 ${AGGREGATE}@latest（profile: ${profile.name}）`
+          : `npm 更新 ${AGGREGATE}@${oneEntry?.spec || '?'} → latest（profile: ${profile.name}）`,
+        profile: profile.name,
+        profilePath: profile.path,
+        installerDir,
+        keepSidebarRemoved: bundles.includes(SIDEBAR) ? false : true,
+      });
     }
   }
   if (!actions.length) {
@@ -257,14 +267,33 @@ export async function executePlan(plan, { dshBin, runCmd = run, runSh = sh } = {
         push('  ✗ 未找到 dsh 可执行文件');
         continue;
       }
-      const rm = await runCmd(dsh, ['plugin', '--profile', action.profile, 'remove', AGGREGATE]);
-      push(rm.ok ? '  已移除旧版聚合包' : `  ⚠ 移除旧版非零退出（首次安装？继续）`);
-      const installer = join(action.installerDir, 'bin', 'install.js');
-      const added = await runCmd(process.execPath, [installer, action.profile]);
-      push(added.ok ? `  ✓ ${AGGREGATE} 已更新` : `  ✗ 安装失败：${added.out}`);
+      // pnpm 11 放行预写（node-pty 原生构建，issue #24）：包内安装器只拿来做这一步，
+      // 版本老一点也无所谓——预写内容与包版本无关（幂等键名）。
+      if (action.installerDir) {
+        await runCmd(process.execPath, [join(action.installerDir, 'bin', 'install.js'), action.profile, '--prewrite']);
+        push('  pnpm 构建放行已预写');
+      }
+      // 原地更新到 latest 精确版本，失败时旧版仍在位（pnpm 原子性），无卸载空窗。
+      // 注意 pnpm up 对依赖表里没有的包是 no-op 且报成功——残局（依赖表被清）必须
+      // 用 add 重新落表；在装用户用 up 原地覆盖。up 前先核依赖表，不凭 planner 快照
+      //（探测与执行之间状态可能变了）。
+      const latest = await latestVersion();
+      if (!latest) {
+        push('  ✗ 查询 npm registry 最新版失败（网络？），跳过该 profile');
+        continue;
+      }
+      const currentSpec = readDep(action.profilePath, AGGREGATE);
+      const verb = currentSpec ? 'up' : 'add';
+      const up = await runCmd(dsh, ['plugin', '--profile', action.profile, verb, `${AGGREGATE}@${latest}`]);
+      push(up.ok ? `  ✓ ${AGGREGATE} → ${latest}（${verb === 'up' ? '原地更新' : '重装落表'}）` : `  ✗ ${verb} 失败：${up.out}`);
       if (action.keepSidebarRemoved) {
-        await runCmd(dsh, ['plugin', '--profile', action.profile, 'remove', SIDEBAR]);
-        push('  按先前配置保持 better-sidebar 关闭');
+        const sidebar = await readDep(action.profilePath, SIDEBAR);
+        if (sidebar) {
+          await runCmd(dsh, ['plugin', '--profile', action.profile, 'remove', SIDEBAR]);
+          push('  按先前配置保持 better-sidebar 关闭');
+        } else {
+          push('  better-sidebar 保持未安装（沿用先前配置）');
+        }
       }
     } else if (action.type === 'manual-overlay') {
       push(`  ${action.instruction}`);
@@ -283,4 +312,30 @@ async function resolveDshBin(runCmd = run) {
     if (r.ok) return probe[0];
   }
   return null;
+}
+
+// npm registry dist-tags（带 8s 超时；离线时 up 步骤直接跳过，不动现状）
+async function latestVersion() {
+  try {
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 8000);
+    const r = await fetch('https://registry.npmjs.org/dsh-ccpg-one', {
+      headers: { accept: 'application/vnd.npm.install-v1+json' },
+      signal: ctrl.signal,
+    });
+    clearTimeout(timer);
+    if (!r.ok) return null;
+    return (await r.json())['dist-tags']?.latest || null;
+  } catch {
+    return null;
+  }
+}
+
+// 读 profile 依赖表里某个包的 spec（不在则 null）
+function readDep(profilePath, name) {
+  try {
+    return JSON.parse(readFileSync(join(profilePath, 'package.json'), 'utf8')).dependencies?.[name] || null;
+  } catch {
+    return null;
+  }
 }

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -52,6 +52,11 @@ console.log('system-upgrade tests:');
     dependencies: { [AGGREGATE]: '0.3.0', [SIDEBAR]: '^0.15.2' },
     dsh: { profile: { bundles: ['@deepseek-ai/dsh-base'] } },
   }));
+  // p-residue：remove 中断后依赖表和实体都没了，但 .bin 留下悬空软链。
+  const residueDir = join(profilesDir, 'p-residue');
+  mkdirSync(join(residueDir, 'node_modules', '.bin'), { recursive: true });
+  writeFileSync(join(residueDir, 'package.json'), JSON.stringify({ name: 'dsh-profile-p-residue' }));
+  symlinkSync('../../nowhere', join(residueDir, 'node_modules', '.bin', AGGREGATE));
   // p-src：link 进 git 仓库
   mkdirSync(join(profilesDir, 'p-src'), { recursive: true });
   writeFileSync(join(profilesDir, 'p-src', 'package.json'), JSON.stringify({
@@ -73,7 +78,7 @@ console.log('system-upgrade tests:');
   await test('来源探测：三种形态逐包分类、无关 profile 排除', () => {
     const report = collectInstallReport({ profilesRoot: profilesDir });
     const byName = new Map(report.map((p) => [p.name, p]));
-    assert.deepEqual([...byName.keys()].sort(), ['p-npm', 'p-rel', 'p-src']);
+    assert.deepEqual([...byName.keys()].sort(), ['p-npm', 'p-rel', 'p-residue', 'p-src']);
 
     assert.equal(gitRootOf(join(srcRepo, 'dsh-plugins')), srcRepo);
     assert.equal(gitRootOf(join(releaseTree)), null);
@@ -163,7 +168,39 @@ console.log('system-upgrade tests:');
     assert.ok(log.some((l) => l.includes('画布双构建完成')));
   });
 
-  await test('executePlan：npm 路径 remove→install.js→按先前配置补移 sidebar', async () => {
+  await test('planner：残局（.bin 残留但依赖表空）同样产出重装动作', () => {
+    const report = collectInstallReport({ profilesRoot: profilesDir });
+    const residue = report.find((p) => p.name === 'p-residue');
+    assert.ok(residue);
+    assert.equal(residue.packages[0].name, AGGREGATE);
+    assert.equal(residue.packages[0].broken, true);
+    const plan = planUpgrade([residue]);
+    assert.equal(plan.actions[0].type, 'npm-reinstall');
+    assert.equal(plan.actions[0].installerDir, null);
+    assert.equal(plan.actions[0].keepSidebarRemoved, true);
+    assert.match(plan.actions[0].title, /修复|重装/);
+  });
+
+  await test('executePlan：残局依赖表为空时使用 add 重新落表', async () => {
+    const report = collectInstallReport({ profilesRoot: profilesDir });
+    const residue = report.find((p) => p.name === 'p-residue');
+    const calls = [];
+    const realFetch = globalThis.fetch;
+    globalThis.fetch = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '0.4.0' } }) });
+    try {
+      await executePlan(planUpgrade([residue]), {
+        dshBin: '/fake/dsh',
+        runCmd: async (cmd, args) => { calls.push([cmd, ...args]); return { ok: true, out: '', err: null }; },
+      });
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+    assert.deepEqual(calls[0].slice(0, 5), ['/fake/dsh', 'plugin', '--profile', 'p-residue', 'add']);
+    assert.equal(calls[0][5], `${AGGREGATE}@0.4.0`);
+    assert.ok(!calls.some((c) => c.includes('remove') && c.includes(AGGREGATE)), '残局修复不先 remove 聚合包');
+  });
+
+  await test('executePlan：npm 路径 prewrite→up latest 原地更新，全程无 remove', async () => {
     const report = collectInstallReport({ profilesRoot: profilesDir });
     const npmProfile = report.find((p) => p.name === 'p-npm');
     const calls = [];
@@ -171,11 +208,17 @@ console.log('system-upgrade tests:');
       dshBin: '/fake/dsh',
       runCmd: async (cmd, args) => { calls.push([cmd, ...args]); return { ok: true, out: '', err: null }; },
     });
-    assert.ok(calls[0].join(' ').includes(`remove ${AGGREGATE}`));
-    assert.equal(calls[1][0], process.execPath);
-    assert.equal(calls[1][1], join(npmOneDir, 'bin', 'install.js'));
-    assert.equal(calls[1][2], 'p-npm');
-    assert.ok(calls[2].join(' ').includes(`remove ${SIDEBAR}`), 'bundles 无 sidebar ⇒ 升级后补移');
+    const prewrite = calls[0];
+    assert.equal(prewrite[0], process.execPath);
+    assert.equal(prewrite[1], join(npmOneDir, 'bin', 'install.js'));
+    assert.equal(prewrite[2], 'p-npm');
+    assert.equal(prewrite[3], '--prewrite');
+    const up = calls[1];
+    assert.deepEqual(up.slice(0, 3), ['/fake/dsh', 'plugin', '--profile']);
+    assert.equal(up[4], 'up');
+    assert.match(up[5], new RegExp(`^${AGGREGATE}@\\d+\\.\\d+\\.\\d+$`));
+    assert.ok(!calls.some((c) => c.includes('remove') && c.includes(AGGREGATE)), '聚合包绝不 remove');
+    assert.ok(calls.some((c) => c.includes('remove') && c.includes(SIDEBAR)), 'NO_SIDEBAR 配置需在升级后保持关闭');
   });
 
   await test('compareSemver 数字段比较、容忍前缀与缺参', () => {


### PR DESCRIPTION
## 背景

v0.4.0 设置面板升级实测暴露两个问题：npm 路径先 remove 聚合包，随后包内安装器已经消失；接口动作失败时，前端仍会把 HTTP 200 显示为升级完成。

## 方案

- npm 安装改为 pnpm `up` 原地覆盖，依赖表缺失的中断残局使用 `add` 重新落表
- 通过悬空 `.bin/dsh-ccpg-one` 软链识别历史升级中断的 profile
- 保持用户原有 better-sidebar 开关状态
- 设置面板检测升级日志中的失败行，不再误报成功
- 补充正常 npm、残局自愈、源码与离线包回归测试

## 验证

- `npm test`
- `sh dsh-plugins/build-web.sh`
- `sh dsh-plugins/build-canvasui.sh --check`
- `node dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs`（10/10）
- 真实设置菜单：v0.3.2 检查到 v0.4.0，执行器原地更新后实体与 profile 依赖表均为 0.4.0
- 隔离 Desktop profile：0.3.2 原地升级到 0.4.0，未触碰真实 Desktop 数据
