### PR TITLE
chore(release): v0.4.1

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-one",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.4.0",
-    "dsh-ccpg-document-preview": "0.4.0",
-    "dsh-ccpg-larkauth": "0.4.0",
-    "dsh-ccpg-llm-guard": "0.4.0",
-    "dsh-ccpg-orchestrator": "0.4.0",
-    "dsh-ccpg-tools": "0.4.0",
-    "dsh-ccpg-web": "0.4.0"
+    "dsh-ccpg-canvasui": "0.4.1",
+    "dsh-ccpg-document-preview": "0.4.1",
+    "dsh-ccpg-larkauth": "0.4.1",
+    "dsh-ccpg-llm-guard": "0.4.1",
+    "dsh-ccpg-orchestrator": "0.4.1",
+    "dsh-ccpg-tools": "0.4.1",
+    "dsh-ccpg-web": "0.4.1"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 发版

同步 Workflow One 8 个 npm 包至 `0.4.1`，包含升级执行器原地更新、残局自愈和设置面板失败状态修复。

## 验证

- `node scripts/verify-plugin-packages.mjs`
- `npm test`
- `sh dsh-plugins/build-web.sh`
- `sh dsh-plugins/publish-npm.sh --dry-run`
- `sh dsh-plugins/pack.sh 0.4.1`
