### PR TITLE
docs: 仓库改名 harness-one → dsh-harness-one，全量替换引用

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,7 +7,7 @@ body:
       value: |
         感谢反馈！请先确认：
         - 用的是 npm 安装（`dsh plugin add dsh-ccpg-one`）还是源码安装（`setup.sh`）
-        - 已在 [Releases](https://github.com/chumingjun/harness-one/releases) 确认不是已修复的旧版问题
+        - 已在 [Releases](https://github.com/chumingjun/dsh-harness-one/releases) 确认不是已修复的旧版问题
   - type: input
     id: version
     attributes:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: 💬 提问与用例讨论
-    url: https://github.com/chumingjun/harness-one/discussions
+    url: https://github.com/chumingjun/dsh-harness-one/discussions
     about: 安装/使用问题、工作流配置求助、想展示自己搭的工作流，请到 Discussions。

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,5 @@ dsh-plugins/dsh-ccpg-one/pnpm-lock.yaml
 dsh-plugins/vendor/
 .playwright-mcp/
 .codegraph/
+# ZCode CLI 会话本地目录（计划/状态，绝不提交）
+.zcode/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -15,6 +15,6 @@ Harassment, discrimination, threats, deliberate disruption, doxxing, and publish
 
 ## Enforcement
 
-Report conduct concerns privately through [GitHub's repository contact channel](https://github.com/chumingjun/harness-one/security/advisories/new). Maintainers may edit or remove contributions and temporarily or permanently restrict participation when necessary to protect the community.
+Report conduct concerns privately through [GitHub's repository contact channel](https://github.com/chumingjun/dsh-harness-one/security/advisories/new). Maintainers may edit or remove contributions and temporarily or permanently restrict participation when necessary to protect the community.
 
 This policy applies to repository Issues, Pull Requests, Discussions, and other spaces where someone represents the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # 参与贡献 / Contributing
 
-感谢你改进 Workflow One。提交前请先搜索现有 Issue；使用问题和工作流配置交流优先放到 [Discussions](https://github.com/chumingjun/harness-one/discussions)。
+感谢你改进 Workflow One。提交前请先搜索现有 Issue；使用问题和工作流配置交流优先放到 [Discussions](https://github.com/chumingjun/dsh-harness-one/discussions)。
 
 ## 开发环境
 

--- a/README.en.md
+++ b/README.en.md
@@ -13,9 +13,9 @@
   <a href="https://zcode.z.ai/cn"><img src="https://img.shields.io/badge/Built%20with-ZCode-14B8A6?labelColor=0F0F1A" alt="Built with ZCode"></a>
   <a href="https://github.com/bruc3van/awesome-dsh-plugin/blob/main/catalog/media-vision.md"><img src="https://img.shields.io/badge/listed%20in-awesome--dsh--plugin-2563EB?labelColor=0F0F1A" alt="Listed in awesome-dsh-plugin"></a>
   <a href="https://www.npmjs.com/package/dsh-ccpg-one"><img src="https://img.shields.io/npm/v/dsh-ccpg-one" alt="npm version"></a>
-  <a href="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml"><img src="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
-  <a href="https://github.com/chumingjun/harness-one/releases/latest"><img src="https://img.shields.io/github/v/release/chumingjun/harness-one" alt="latest release"></a>
-  <a href="./LICENSE"><img src="https://img.shields.io/github/license/chumingjun/harness-one" alt="MIT license"></a>
+  <a href="https://github.com/chumingjun/dsh-harness-one/actions/workflows/ci.yml"><img src="https://github.com/chumingjun/dsh-harness-one/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
+  <a href="https://github.com/chumingjun/dsh-harness-one/releases/latest"><img src="https://img.shields.io/github/v/release/chumingjun/dsh-harness-one" alt="latest release"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/chumingjun/dsh-harness-one" alt="MIT license"></a>
 </p>
 
 ## Turn real agents into observable workflows
@@ -51,10 +51,10 @@ dsh web
 
 ### Offline bundle
 
-Download the prebuilt bundle from [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest):
+Download the prebuilt bundle from [GitHub Releases](https://github.com/chumingjun/dsh-harness-one/releases/latest):
 
 ```sh
-curl -LO https://github.com/chumingjun/harness-one/releases/download/<tag>/dsh-ccpg-plugins-<tag>.tar.gz
+curl -LO https://github.com/chumingjun/dsh-harness-one/releases/download/<tag>/dsh-ccpg-plugins-<tag>.tar.gz
 tar -xzf dsh-ccpg-plugins-<tag>.tar.gz && cd dsh-plugins
 sh setup.sh --one wf1 4021
 sh start.sh wf1                         # http://127.0.0.1:4021/
@@ -63,7 +63,7 @@ sh start.sh wf1                         # http://127.0.0.1:4021/
 ### Build from source
 
 ```sh
-git clone https://github.com/chumingjun/harness-one.git
+git clone https://github.com/chumingjun/dsh-harness-one.git
 cd harness-one
 npm install
 npm --prefix web install
@@ -123,6 +123,6 @@ More than 90% of this project was developed using [ZCode](https://zcode.z.ai/cn)
 - [Contributing guide](CONTRIBUTING.md)
 - [Security policy](SECURITY.md)
 - [Code of conduct](CODE_OF_CONDUCT.md)
-- [Discussions](https://github.com/chumingjun/harness-one/discussions)
+- [Discussions](https://github.com/chumingjun/dsh-harness-one/discussions)
 
 Licensed under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@
   <a href="https://zcode.z.ai/cn"><img src="https://img.shields.io/badge/Built%20with-ZCode-14B8A6?labelColor=0F0F1A" alt="使用 ZCode 开发"></a>
   <a href="https://github.com/bruc3van/awesome-dsh-plugin/blob/main/catalog/media-vision.md"><img src="https://img.shields.io/badge/listed%20in-awesome--dsh--plugin-2563EB?labelColor=0F0F1A" alt="已被 awesome-dsh-plugin 收录"></a>
   <a href="https://www.npmjs.com/package/dsh-ccpg-one"><img src="https://img.shields.io/npm/v/dsh-ccpg-one" alt="npm 版本"></a>
-  <a href="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml"><img src="https://github.com/chumingjun/harness-one/actions/workflows/ci.yml/badge.svg" alt="CI 状态"></a>
-  <a href="https://github.com/chumingjun/harness-one/releases/latest"><img src="https://img.shields.io/github/v/release/chumingjun/harness-one" alt="最新版本"></a>
-  <a href="./LICENSE"><img src="https://img.shields.io/github/license/chumingjun/harness-one" alt="MIT 许可证"></a>
+  <a href="https://github.com/chumingjun/dsh-harness-one/actions/workflows/ci.yml"><img src="https://github.com/chumingjun/dsh-harness-one/actions/workflows/ci.yml/badge.svg" alt="CI 状态"></a>
+  <a href="https://github.com/chumingjun/dsh-harness-one/releases/latest"><img src="https://img.shields.io/github/v/release/chumingjun/dsh-harness-one" alt="最新版本"></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/chumingjun/dsh-harness-one" alt="MIT 许可证"></a>
 </p>
 
 ## 一句话，把真实 Agent 变成可观察的工作流
@@ -51,10 +51,10 @@ dsh web
 
 ### 离线包
 
-从 [GitHub Releases](https://github.com/chumingjun/harness-one/releases/latest) 下载聚合包，无需仓库源码：
+从 [GitHub Releases](https://github.com/chumingjun/dsh-harness-one/releases/latest) 下载聚合包，无需仓库源码：
 
 ```sh
-curl -LO https://github.com/chumingjun/harness-one/releases/download/<tag>/dsh-ccpg-plugins-<tag>.tar.gz
+curl -LO https://github.com/chumingjun/dsh-harness-one/releases/download/<tag>/dsh-ccpg-plugins-<tag>.tar.gz
 tar -xzf dsh-ccpg-plugins-<tag>.tar.gz && cd dsh-plugins
 sh setup.sh --one wf1 4021
 sh start.sh wf1                         # http://127.0.0.1:4021/
@@ -63,7 +63,7 @@ sh start.sh wf1                         # http://127.0.0.1:4021/
 ### 从源码构建
 
 ```sh
-git clone https://github.com/chumingjun/harness-one.git
+git clone https://github.com/chumingjun/dsh-harness-one.git
 cd harness-one
 npm install
 npm --prefix web install
@@ -220,6 +220,6 @@ cd web && npm test
 
 ## 反馈
 
-- 🐛 安装失败 / 运行报错：[提 Issue](https://github.com/chumingjun/harness-one/issues/new?template=bug_report.md)
-- 💡 功能建议：[提 Issue](https://github.com/chumingjun/harness-one/issues/new?template=feature_request.md)
-- 💬 使用提问、工作流配置求助、展示你搭的流程：[Discussions](https://github.com/chumingjun/harness-one/discussions)
+- 🐛 安装失败 / 运行报错：[提 Issue](https://github.com/chumingjun/dsh-harness-one/issues/new?template=bug_report.md)
+- 💡 功能建议：[提 Issue](https://github.com/chumingjun/dsh-harness-one/issues/new?template=feature_request.md)
+- 💬 使用提问、工作流配置求助、展示你搭的流程：[Discussions](https://github.com/chumingjun/dsh-harness-one/discussions)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,7 +6,7 @@ Security fixes target the latest published release and the `main` branch.
 
 ## Reporting a Vulnerability
 
-Please do not open a public Issue for an unpatched vulnerability. Use [GitHub's private vulnerability reporting](https://github.com/chumingjun/harness-one/security/advisories/new) and include:
+Please do not open a public Issue for an unpatched vulnerability. Use [GitHub's private vulnerability reporting](https://github.com/chumingjun/dsh-harness-one/security/advisories/new) and include:
 
 - affected version and environment;
 - reproduction steps or a minimal proof of concept;

--- a/docs/launch-kit.md
+++ b/docs/launch-kit.md
@@ -21,7 +21,7 @@ dsh plugin --profile web add dsh-ccpg-one
 dsh web
 ```
 
-仓库：https://github.com/chumingjun/harness-one
+仓库：https://github.com/chumingjun/dsh-harness-one
 
 欢迎分享实际工作流、安装问题和改进建议。仓库内已经提供报修工单整理、紧急度分流和多方并行评审三个可导入模板。
 
@@ -38,15 +38,15 @@ dsh plugin --profile web add dsh-ccpg-one
 dsh web
 ```
 
-Repository: https://github.com/chumingjun/harness-one
+Repository: https://github.com/chumingjun/dsh-harness-one
 
 Three importable examples are included for ticket normalization, urgency routing, and parallel review.
 
 ## Short Versions
 
-**中文：** Workflow One 把 dsh 智能体、脚本、条件和 HTTP 节点连成可视化 DAG，支持并行执行、实时状态、失败恢复和工作区 SQLite 存储。安装：`dsh plugin --profile web add dsh-ccpg-one`。https://github.com/chumingjun/harness-one
+**中文：** Workflow One 把 dsh 智能体、脚本、条件和 HTTP 节点连成可视化 DAG，支持并行执行、实时状态、失败恢复和工作区 SQLite 存储。安装：`dsh plugin --profile web add dsh-ccpg-one`。https://github.com/chumingjun/dsh-harness-one
 
-**English:** Workflow One adds visual, recoverable multi-agent DAGs to DeepSeek Harness: parallel execution, live node details, replay, and workspace-local SQLite storage. Install with `dsh plugin --profile web add dsh-ccpg-one`. https://github.com/chumingjun/harness-one
+**English:** Workflow One adds visual, recoverable multi-agent DAGs to DeepSeek Harness: parallel execution, live node details, replay, and workspace-local SQLite storage. Install with `dsh plugin --profile web add dsh-ccpg-one`. https://github.com/chumingjun/dsh-harness-one
 
 ## Suggested Media Order
 

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -35,7 +35,7 @@ Desktop 不要运行 `setup.sh`：它用于普通 dsh，会创建/修改 profile
 
 ```sh
 # 1. 下载 release 包（GitHub Releases 页拿最新 tag 的 asset）
-curl -LO https://github.com/chumingjun/harness-one/releases/download/<tag>/dsh-ccpg-plugins-<tag>.tar.gz
+curl -LO https://github.com/chumingjun/dsh-harness-one/releases/download/<tag>/dsh-ccpg-plugins-<tag>.tar.gz
 tar -xzf dsh-ccpg-plugins-<tag>.tar.gz   # 解出 dsh-plugins/ 目录（自带全部构建产物 + vendor 件）
 
 # 2. 一键安装（聚合模式：一个包装齐 7 插件 + better-sidebar，并建好独立 profile）
@@ -89,7 +89,7 @@ npm 渠道等价命令行（无需源码）：重跑一次 `npx dsh-ccpg-one <pr
 ### B. 开发者 · 源码（本仓库）
 
 ```sh
-git clone https://github.com/chumingjun/harness-one.git
+git clone https://github.com/chumingjun/dsh-harness-one.git
 cd harness-one/dsh-plugins
 
 npm test                                # （可选）先跑全量单测

--- a/dsh-plugins/dsh-ccpg-brand/package.json
+++ b/dsh-plugins/dsh-ccpg-brand/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chumingjun/harness-one.git",
+    "url": "git+https://github.com/chumingjun/dsh-harness-one.git",
     "directory": "dsh-plugins/dsh-ccpg-brand"
   },
   "engines": {

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chumingjun/harness-one.git",
+    "url": "git+https://github.com/chumingjun/dsh-harness-one.git",
     "directory": "dsh-plugins/dsh-ccpg-canvasui"
   },
   "engines": {

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chumingjun/harness-one.git",
+    "url": "git+https://github.com/chumingjun/dsh-harness-one.git",
     "directory": "dsh-plugins/dsh-ccpg-document-preview"
   },
   "engines": {

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chumingjun/harness-one.git",
+    "url": "git+https://github.com/chumingjun/dsh-harness-one.git",
     "directory": "dsh-plugins/dsh-ccpg-larkauth"
   },
   "engines": {

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chumingjun/harness-one.git",
+    "url": "git+https://github.com/chumingjun/dsh-harness-one.git",
     "directory": "dsh-plugins/dsh-ccpg-llm-guard"
   },
   "engines": {

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -5,12 +5,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chumingjun/harness-one.git",
+    "url": "git+https://github.com/chumingjun/dsh-harness-one.git",
     "directory": "dsh-plugins/dsh-ccpg-one"
   },
-  "homepage": "https://github.com/chumingjun/harness-one#readme",
+  "homepage": "https://github.com/chumingjun/dsh-harness-one#readme",
   "bugs": {
-    "url": "https://github.com/chumingjun/harness-one/issues"
+    "url": "https://github.com/chumingjun/dsh-harness-one/issues"
   },
   "keywords": [
     "deepseek",

--- a/dsh-plugins/dsh-ccpg-one/screenshots.json
+++ b/dsh-plugins/dsh-ccpg-one/screenshots.json
@@ -1,4 +1,4 @@
 [
-  "https://raw.githubusercontent.com/chumingjun/harness-one/main/images/workflow01.png",
-  "https://raw.githubusercontent.com/chumingjun/harness-one/main/images/workflow.png"
+  "https://raw.githubusercontent.com/chumingjun/dsh-harness-one/main/images/workflow01.png",
+  "https://raw.githubusercontent.com/chumingjun/dsh-harness-one/main/images/workflow.png"
 ]

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chumingjun/harness-one.git",
+    "url": "git+https://github.com/chumingjun/dsh-harness-one.git",
     "directory": "dsh-plugins/dsh-ccpg-orchestrator"
   },
   "engines": {

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chumingjun/harness-one.git",
+    "url": "git+https://github.com/chumingjun/dsh-harness-one.git",
     "directory": "dsh-plugins/dsh-ccpg-tools"
   },
   "engines": {

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chumingjun/harness-one.git",
+    "url": "git+https://github.com/chumingjun/dsh-harness-one.git",
     "directory": "dsh-plugins/dsh-ccpg-web"
   },
   "engines": {


### PR DESCRIPTION
## 背景
仓库已改名 chumingjun/dsh-harness-one（包名与仓库名统一为 dsh-harness-one 的第一步）。

## 改动
- README / README.en：CI、release、license 3 个徽标 URL + 安装/反馈/Discussions 链接
- 8 个插件 package.json 的 repository/homepage/bugs
- screenshots.json raw 链接、issue 模板、SECURITY、CONTRIBUTING、docs/launch-kit

## 验证
- 全仓 grep 无残留旧路径
- 旧 URL 由 GitHub 永久重定向兜底，徽标短期不断