### PR TITLE
fix(one): npm 纯净安装 sidebar 兜底注册 + brand 退出 npm 渠道（0.5.1）

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -42,10 +42,11 @@
 
 ```sh
 dsh plugin --profile web add dsh-harness-one
+dsh plugin --profile web add dsh-better-sidebar   # 官方 UI 侧栏宿主（画布 tab）
 dsh web
 ```
 
-[Harness Desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) users should open **Open DSH Terminal**, run `dsh plugin add dsh-harness-one`, and restart Desktop. Do not run `setup.sh` in Desktop; it manages its own profile, Node/pnpm runtime, and loopback port. See [Desktop setup and troubleshooting](dsh-plugins/DESKTOP.md).
+[Harness Desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) users should open **Open DSH Terminal**, run `dsh plugin add dsh-harness-one && dsh plugin add dsh-better-sidebar`, and restart Desktop. Do not run `setup.sh` in Desktop; it manages its own profile, Node/pnpm runtime, and loopback port. See [Desktop setup and troubleshooting](dsh-plugins/DESKTOP.md).
 
 **UI dependency:** Workflow One's embedded canvas is hosted in the official dsh interface by the open-source [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) project. `dsh-harness-one` installs and depends on it automatically. If DSH-better-sidebar is missing or disabled, the embedded Workflow entry is unavailable, while the standalone `/wf1/` canvas remains accessible.
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,13 @@
 
 ```sh
 dsh plugin --profile web add dsh-harness-one
+dsh plugin --profile web add dsh-better-sidebar   # 官方 UI 侧栏宿主（画布 tab）
 dsh web
 ```
 
-> v0.5.0 起 Workflow One 合并为单包 `dsh-harness-one`（旧 `dsh-ccpg-one` 已停更）。老用户在设置面板「Workflow One → 检查更新」一键迁移，或手动：`dsh plugin --profile <name> remove dsh-ccpg-one && dsh plugin --profile <name> add dsh-harness-one`。
+> v0.5.0 起 Workflow One 合并为单包 `dsh-harness-one`（旧 `dsh-ccpg-one` 已停更）。老用户在设置面板「Workflow One → 检查更新」一键迁移，或手动：`dsh plugin --profile <name> remove dsh-ccpg-one && dsh plugin --profile <name> add dsh-harness-one && dsh plugin --profile <name> add dsh-better-sidebar`。
 
-[Harness Desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) 用户从托盘打开 **Open DSH Terminal**，执行 `dsh plugin add dsh-harness-one` 后重启 Desktop。不要在 Desktop 中运行 `setup.sh`，Desktop 会自行管理 profile、Node/pnpm 和随机 loopback 端口。详见 [Desktop 安装与排障](dsh-plugins/DESKTOP.md)。
+[Harness Desktop](https://github.com/anywhere-labs/deepseek-harness-desktop) 用户从托盘打开 **Open DSH Terminal**，执行 `dsh plugin add dsh-harness-one && dsh plugin add dsh-better-sidebar` 后重启 Desktop。不要在 Desktop 中运行 `setup.sh`，Desktop 会自行管理 profile、Node/pnpm 和随机 loopback 端口。详见 [Desktop 安装与排障](dsh-plugins/DESKTOP.md)。
 
 **界面依赖说明**：Workflow One 在 dsh 官方界面中的「工作流」画布由开源项目 [DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) 提供侧栏与标签页宿主，`dsh-harness-one` 会自动安装并依赖它。未安装或禁用 DSH-better-sidebar 时，官方界面内嵌的「工作流」入口不可用，但独立画布 `/wf1/` 仍可访问。
 

--- a/dsh-plugins/README.md
+++ b/dsh-plugins/README.md
@@ -159,7 +159,7 @@ dsh plugin --profile myprofile add dsh-harness-one
 需要 CCPG 品牌外观时，再显式安装独立插件：
 
 ```sh
-dsh plugin --profile myprofile add dsh-ccpg-brand
+dsh plugin --profile myprofile add <repo>/dsh-plugins/dsh-ccpg-brand  # brand 不在 npm，用源码/离线包路径装
 ```
 
 模型：dsh 默认模型栈（`deepseek-official`）开箱即用，key 在官方 UI「模型」页保存；自定义 provider 走 dsh 原生配置（profile `cordis.patch.yml` 的 `llm-pi-ai.providers`，key 由 `apiKeyEnv` 声明走环境变量）。插件自身不存任何 key。
@@ -177,9 +177,9 @@ dsh plugin --profile myprofile add dsh-ccpg-brand
 
 `pack.sh <tag>`：7 个默认插件 + 独立可选 brand 清单校验 → 画布双构建 → orchestrator 依赖 → canvasui bundle 重建并 `--check` → rsync 组装（清运行时数据）→ `dist-release/dsh-harness-one-plugins-<tag>.tar.gz`。通用发布归档仍携带 brand 源包供显式安装，但 `setup.sh` 和单包 `dsh-harness-one` 都不会自动安装它。CI（release.yml）同源执行并作为 release asset 上传。
 
-`sh publish-npm.sh --dry-run` 会装配并验证单包 `dsh-harness-one`（assemble-one.sh 把 7 个插件合并为一个 npm 包：单 loader entry + 合并 client bundle）与 `dsh-ccpg-brand`。老 8 包（dsh-ccpg-one + 7 子包）已停更，发布时统一 deprecate 指向新包。安装冒烟会校验「无 @deepseek-ai SDK 泄漏」（peer 自动安装会遮蔽 dsh 全局版本导致官方 UI 400）。去掉 `--dry-run` 才上传官方 npm registry；tag 必须与聚合包版本一致。GitHub `release.yml` 先上传 release 资产，再使用仓库 Actions Secret `NPM_TOKEN` 按子包→聚合包顺序发布，失败后可安全重跑（已存在版本会自动跳过）。
+`sh publish-npm.sh --dry-run` 会装配并验证单包 `dsh-harness-one`（assemble-one.sh 把 7 个插件合并为一个 npm 包：单 loader entry + 合并 client bundle）——这是唯一上 npm 的包；brand 不上 npm，仅随 GitHub Release 离线包分发。老 8 包（dsh-ccpg-one + 7 子包）已停更，发布时统一 deprecate 指向新包。安装冒烟会校验「无 @deepseek-ai SDK 泄漏」（peer 自动安装会遮蔽 dsh 全局版本导致官方 UI 400）。去掉 `--dry-run` 才上传官方 npm registry；tag 必须与聚合包版本一致。GitHub `release.yml` 先上传 release 资产，再使用仓库 Actions Secret `NPM_TOKEN` 按子包→聚合包顺序发布，失败后可安全重跑（已存在版本会自动跳过）。
 
 ## 已知边界
 
 - SDK 软链指向本机 dsh 安装——换机器重跑 `setup.sh` 自动重链
-- npm 首次发布需要仓库所有者配置具备 `dsh-harness-one` 与 `dsh-ccpg-brand` 发布权限的 granular token 为 Actions Secret `NPM_TOKEN`；代码与包内容不保存 token
+- npm 首次发布需要仓库所有者配置具备 `dsh-harness-one` 发布权限的 granular token 为 Actions Secret `NPM_TOKEN`（brand 不上 npm，仅随 Release 离线包）；代码与包内容不保存 token

--- a/dsh-plugins/assemble-one.sh
+++ b/dsh-plugins/assemble-one.sh
@@ -175,11 +175,31 @@ fi
 # 但 react.js / renderers 的外部 chunk 路径在 dist/react.js（web 画布用 file: 依赖直引，不走本路由）。
 
 # ---- 5. 安装器（pnpm11 预写，沿用 dsh-ccpg-one 的实现）：包名替换 + 清空 SUBPLUGINS ----
+# 安装器在主 add 后补一条 dsh plugin add dsh-better-sidebar（见下方注入）。
 # 先清空多行数组（单包无子包依赖；正则吃到数组结尾的 `];`），再全局换名。
 sed -E "s/^const SUBPLUGINS = \[[^]]*\];/const SUBPLUGINS = [];/" "$HERE/dsh-ccpg-one/bin/install.js" \
   | sed "s/dsh-ccpg-one/dsh-harness-one/g" > "$OUT/bin/install.js"
 "$NODE_BIN" --check "$OUT/bin/install.js" || { echo "✗ 生成的 install.js 语法错误"; exit 1; }
 chmod +x "$OUT/bin/install.js"
+# sidebar bundle 注册：dsh reconcile 只认直接依赖，纯净安装后侧栏 tab 不挂载——
+# 安装器在主包 add 成功后补一条（依赖表已有则 pnpm 去重，只做 bundle 注册）。
+python3 - "$OUT/bin/install.js" <<'PYI'
+import sys
+p = sys.argv[1]
+s = open(p).read()
+marker = "say('安装完成，重启 dsh 生效。独立画布: http://127.0.0.1:4021/wf1/');"
+inject_code = """if (!process.env.CCPG_NO_SIDEBAR && !process.env.CCPG_ONLY_CORE) {
+  say('注册 better-sidebar（官方 UI 工作流侧栏宿主）…');
+  const sb = spawnSync(dsh, ['plugin', '--profile', PROFILE, 'add', 'dsh-better-sidebar'], { stdio: 'inherit' });
+  if (sb.status !== 0) console.error('[dsh-harness-one] better-sidebar 注册失败（可手动：dsh plugin --profile ' + PROFILE + ' add dsh-better-sidebar）');
+}
+""" + marker
+assert marker in s, 'installer marker missing'
+s = s.replace(marker, inject_code)
+open(p, 'w').write(s)
+print('installer: sidebar add injected')
+PYI
+"$NODE_BIN" --check "$OUT/bin/install.js" || { echo "✗ installer 注入后语法错误"; exit 1; }
 
 # ---- 6. manifest 与 patch ----
 cat > "$OUT/package.json" <<EOF

--- a/dsh-plugins/dsh-ccpg-brand/package.json
+++ b/dsh-plugins/dsh-ccpg-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-brand",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-one",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.5.0",
-    "dsh-ccpg-document-preview": "0.5.0",
-    "dsh-ccpg-larkauth": "0.5.0",
-    "dsh-ccpg-llm-guard": "0.5.0",
-    "dsh-ccpg-orchestrator": "0.5.0",
-    "dsh-ccpg-tools": "0.5.0",
-    "dsh-ccpg-web": "0.5.0"
+    "dsh-ccpg-canvasui": "0.5.1",
+    "dsh-ccpg-document-preview": "0.5.1",
+    "dsh-ccpg-larkauth": "0.5.1",
+    "dsh-ccpg-llm-guard": "0.5.1",
+    "dsh-ccpg-orchestrator": "0.5.1",
+    "dsh-ccpg-tools": "0.5.1",
+    "dsh-ccpg-web": "0.5.1"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/system-upgrade.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/system-upgrade.js
@@ -162,6 +162,9 @@ export function planUpgrade(report) {
     if (hasRegistry) {
       const bundles = readProfileBundles(profile.path);
       const installerDir = locateInstalledInstaller(profile.path, hasNew ? PACKAGE : 'dsh-ccpg-one');
+      // keepSidebarRemoved 只对「依赖表曾有 sidebar 后来没了」（CCPG_NO_SIDEBAR 用户语义）生效；
+      // 纯净安装（表里从无 sidebar）升级时顺势补装，bundles 无它不构成拒绝信号。
+      const sidebarMissing = !profile.packages.some((p) => p.name === SIDEBAR);
       if ((legacyEntry || profile.packages.some((p) => p.broken)) && !hasNew) {
         actions.push({
           type: 'npm-migrate',
@@ -171,7 +174,7 @@ export function planUpgrade(report) {
           profile: profile.name,
           profilePath: profile.path,
           installerDir,
-          keepSidebarRemoved: bundles.includes(SIDEBAR) ? false : true,
+          bootstrapSidebar: sidebarMissing,
         });
       } else if (hasNew) {
         actions.push({
@@ -182,7 +185,7 @@ export function planUpgrade(report) {
           profile: profile.name,
           profilePath: profile.path,
           installerDir,
-          keepSidebarRemoved: bundles.includes(SIDEBAR) ? false : true,
+          bootstrapSidebar: sidebarMissing,
         });
         if (legacyEntry) {
           warnings.push(`profile ${profile.name} 同时装有 ${PACKAGE} 与旧包 dsh-ccpg-one，升级时建议移除旧包`);
@@ -334,14 +337,13 @@ export async function executePlan(plan, { dshBin, runCmd = run, runSh = sh } = {
         const up = await runCmd(dsh, ['plugin', '--profile', action.profile, verb, `${PACKAGE}@${latest}`]);
         push(up.ok ? `  ✓ ${PACKAGE} → ${latest}（${verb === 'up' ? '原地更新' : '重装落表'}）` : `  ✗ ${verb} 失败：${up.out}`);
       }
-      if (action.keepSidebarRemoved) {
-        const sidebar = await readDep(action.profilePath, SIDEBAR);
-        if (sidebar) {
-          await runCmd(dsh, ['plugin', '--profile', action.profile, 'remove', SIDEBAR]);
-          push('  按先前配置保持 better-sidebar 关闭');
-        } else {
-          push('  better-sidebar 保持未安装（沿用先前配置）');
-        }
+      // sidebar bundle 注册兜底：dsh reconcile 只认 profile 直接依赖，sidebar 作为
+      // 本包传递依赖即使解析到实体也不进 bundles 层——纯净安装（依赖表只有本包）
+      // 官方 UI 侧栏「工作流」tab 会缺。依赖表已有 sidebar（老安装/显式装过）跳过；
+      // 主动关闭走 CCPG_NO_SIDEBAR 环境变量（安装器语义），升级不再自动移除。
+      if (action.bootstrapSidebar && !readDep(action.profilePath, SIDEBAR)) {
+        const sb = await runCmd(dsh, ['plugin', '--profile', action.profile, 'add', SIDEBAR]);
+        push(sb.ok ? `  ✓ ${SIDEBAR} 已注册进 bundles（官方 UI 工作流侧栏）` : `  ⚠ better-sidebar 注册失败：${sb.out}（可手动 dsh plugin --profile ${action.profile} add ${SIDEBAR}）`);
       }
     } else if (action.type === 'manual-overlay') {
       push(`  ${action.instruction}`);

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
@@ -125,7 +125,7 @@ console.log('system-upgrade tests:');
     assert.equal(plan.actions[0].type, 'npm-migrate');
     assert.equal(plan.actions[0].installerDir, npmOneDir);
     assert.equal(plan.actions[0].profile, 'p-npm');
-    assert.equal(plan.actions[0].keepSidebarRemoved, true);
+    assert.equal(plan.actions[0].bootstrapSidebar, false, '依赖表已有 sidebar → 不需兜底');
   });
 
   await test('executePlan：脏工作树跳过该仓库且不重建，仍提示重启', async () => {
@@ -179,7 +179,7 @@ console.log('system-upgrade tests:');
     const plan = planUpgrade([residue]);
     assert.equal(plan.actions[0].type, 'npm-migrate');
     assert.equal(plan.actions[0].installerDir, null);
-    assert.equal(plan.actions[0].keepSidebarRemoved, true);
+    assert.equal(plan.actions[0].bootstrapSidebar, true);
     assert.match(plan.actions[0].title, /修复|迁移/);
   });
 
@@ -251,7 +251,10 @@ console.log('system-upgrade tests:');
     assert.ok(calls.some((c) => c.includes('remove') && c.includes('dsh-ccpg-one')), '老聚合包被移除');
     assert.ok(!depsState.has('dsh-ccpg-one'), '迁移后依赖表无老包');
     assert.ok(depsState.has(PACKAGE), '迁移后依赖表有新包');
-    assert.ok(calls.some((c) => c.includes('remove') && c.includes(SIDEBAR)), 'NO_SIDEBAR 配置需在迁移后保持关闭');
+    assert.ok(!depsState.has('dsh-ccpg-one'), '迁移后依赖表无老包');
+    assert.ok(depsState.has(PACKAGE), '迁移后依赖表有新包');
+    assert.ok(!calls.some((c) => c[4] === 'add' && String(c[5] || '').startsWith(SIDEBAR)), '依赖表已有 sidebar 不重复兜底 add');
+    assert.ok(!calls.some((c) => c[4] === 'remove' && c[5] === SIDEBAR), 'sidebar 不再被自动移除');
   });
 
   await test('executePlan：新包在场走 up 原地更新，不触发迁移', async () => {
@@ -283,7 +286,8 @@ console.log('system-upgrade tests:');
       const up = calls.find((c) => c[4] === 'up');
       assert.ok(up, '在装用户用 up 原地更新');
       assert.equal(up[5], `${PACKAGE}@0.5.1`);
-      assert.ok(!calls.some((c) => c[4] === 'remove' && c[5] !== SIDEBAR), 'up 路径不 remove 任何套件包');
+      assert.ok(!calls.some((c) => c[4] === 'remove'), 'up 路径不 remove 任何包');
+      assert.ok(calls.some((c) => c[4] === 'add' && String(c[5] || '').startsWith(SIDEBAR)), '纯净安装兜底：依赖表无 sidebar 时补 add 注册 bundle');
     } finally {
       rmSync(root2, { recursive: true, force: true });
     }

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/publish-npm.sh
+++ b/dsh-plugins/publish-npm.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # 发布 npm 包（v0.5.0 起单包模式）：
-#   dsh-harness-one —— 单包含全部 7 个插件（assemble-one.sh 装配）
-#   dsh-ccpg-brand  —— 独立可选插件（保留）
+#   dsh-harness-one —— 单包含全部 7 个插件（assemble-one.sh 装配），唯一 npm 发布物
+# brand 不上 npm（用户决策）：仅随 GitHub Release 离线包分发（pack.sh OPTIONAL_PLUGINS）。
 # 老 8 包（dsh-ccpg-one + 7 子包）已停更：deprecate 指向 dsh-harness-one。
 set -e
 HERE=$(cd "$(dirname "$0")" && pwd)
@@ -26,9 +26,8 @@ TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT INT TERM
 mkdir -p "$PACK_DIR"
 
-# npm pack：单包（装配目录，files 字段裁剪）+ brand
+# npm pack：单包（装配目录，files 字段裁剪）
 (cd "$HERE/dsh-harness-one" && npm pack --silent --ignore-scripts --pack-destination "$PACK_DIR" >/dev/null)
-(cd "$HERE/dsh-ccpg-brand" && npm pack --silent --ignore-scripts --pack-destination "$PACK_DIR" >/dev/null)
 TARBALL="$PACK_DIR/dsh-harness-one-$VERSION.tgz"
 [ -f "$TARBALL" ] || { echo "✗ 缺 $TARBALL"; exit 1; }
 
@@ -68,7 +67,6 @@ publish_one() {
 }
 
 publish_one dsh-harness-one "$VERSION"
-publish_one dsh-ccpg-brand "$(node -e "console.log(require(process.argv[1]).version)" "$HERE/dsh-ccpg-brand/package.json")"
 
 # 老 8 包 deprecate（幂等；本地 dry-run 跳过——没有 token 也不该碰线上元数据）
 if [ "$MODE" != "--dry-run" ]; then


### PR DESCRIPTION
## 背景
Desktop 形态验证发现真 bug：npm 渠道纯净安装（dsh plugin add dsh-harness-one）下 better-sidebar 作为传递依赖不进 bundles 层（dsh reconcile 只扫直接依赖），官方 UI 侧栏「工作流」tab 缺席。

## 修复
1. 升级器 bootstrapSidebar 兜底：migrate/reinstall 后依赖表无 sidebar 即补 add 注册；删除 keepSidebarRemoved 自动移除（主动关闭归 CCPG_NO_SIDEBAR）
2. 安装器（npx dsh-harness-one）主包 add 后补 sidebar 注册
3. README×2 npm 安装命令补第二条；Desktop/迁移指引同步
4. brand 退出 npm 渠道（用户决策）：publish-npm.sh 只发 dsh-harness-one

## 验证
- 升级器 12 测试全绿（含新增兜底断言）+ 全量单测 + verify + publish dry-run
- 端到端：纯净 Desktop 形态 0.5.0 → 升级路径 → sidebar 表/bundles 落位 → 真机 UI 引用 sidebar client.js → 侧栏工作流 tab → iframe 画布可见
- 版本列车 0.5.1