### PR TITLE
docs(readme): sidebar 注释措辞「官方 UI」改「DSH UI」

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -42,7 +42,7 @@
 
 ```sh
 dsh plugin --profile web add dsh-harness-one
-dsh plugin --profile web add dsh-better-sidebar   # 官方 UI 侧栏宿主（画布 tab）
+dsh plugin --profile web add dsh-better-sidebar   # DSH UI 侧栏宿主（画布 tab）
 dsh web
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 
 ```sh
 dsh plugin --profile web add dsh-harness-one
-dsh plugin --profile web add dsh-better-sidebar   # 官方 UI 侧栏宿主（画布 tab）
+dsh plugin --profile web add dsh-better-sidebar   # DSH UI 侧栏宿主（画布 tab）
 dsh web
 ```
 


### PR DESCRIPTION
## 背景
npm 安装命令行注释「官方 UI 侧栏宿主」措辞与产品对外口径不一致。

## 方案
两处 README（中/英同一行）注释改为「DSH UI 侧栏宿主（画布 tab）」。

## 验证
纯文档单行改动。