### PR TITLE
feat(orchestrator): 定时任务 per-schedule 时区支持 (#58)

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -67,7 +67,8 @@ import {
   variableDefinitionsToValues,
 } from './variable-store.js';
 import {
-  createScheduler, hasLiveRunForWorkflow, isValidCron, normalizeScheduleMeta,
+  createScheduler, hasLiveRunForWorkflow, isValidCron,
+  normalizeScheduleMeta, normalizeTimezoneInput,
   persistableScheduleMeta, upcomingFireTimes,
 } from './schedule.js';
 
@@ -2231,7 +2232,7 @@ export function apply(ctx, config) {
   } }, { scoped: false });
 
   // ---- 定时触发 ----
-  // POST /wf1/api/schedule { workflowId, cron, input?, runInputs?, overlap? }
+  // POST /wf1/api/schedule { workflowId, cron, input?, runInputs?, overlap?, timezone? }
   // 调度核心在 lib/schedule.js（computeNextDelay + 链式 setTimeout + overlap 策略）
   const scheduleStoreRoot = () => currentStore().workspaceRoot;
   const scheduleBusy = (workflowId) => hasLiveRunForWorkflow(orch.runs, scheduleStoreRoot(), workflowId);
@@ -2336,6 +2337,8 @@ export function apply(ctx, config) {
       if (!wf) return json(res, 404, { error: '工作流不存在' });
       if (!body?.cron) return json(res, 400, { error: '需要 cron 表达式（5 段）' });
       if (!isValidCron(body.cron)) return json(res, 400, { error: 'cron 表达式无效' });
+      let timezone;
+      try { timezone = normalizeTimezoneInput(body?.timezone); } catch (error) { return json(res, 400, { error: error.message }); }
       let runInputs = {};
       try { runInputs = assertSafeContextObject(body?.runInputs, 'runInputs'); } catch (error) { return routeError(res, error); }
       if (body?.overlap && !['skip', 'parallel'].includes(body.overlap)) {
@@ -2350,6 +2353,7 @@ export function apply(ctx, config) {
         input: body.input || '',
         runInputs,
         overlap: body.overlap || 'skip',
+        timezone,
         enabled: true,
         createdAt: new Date().toISOString(),
       });
@@ -2373,6 +2377,9 @@ export function apply(ctx, config) {
       if (hasOwn(body, 'overlap')) {
         if (!['skip', 'parallel'].includes(body.overlap)) return json(res, 400, { error: 'overlap 仅支持 skip / parallel' });
         patch.overlap = body.overlap;
+      }
+      if (hasOwn(body, 'timezone')) {
+        try { patch.timezone = normalizeTimezoneInput(body.timezone); } catch (error) { return json(res, 400, { error: error.message }); }
       }
       if (hasOwn(body, 'runInputs')) {
         try { patch.runInputs = assertSafeContextObject(body?.runInputs, 'runInputs'); } catch (error) { return routeError(res, error); }
@@ -2405,13 +2412,15 @@ export function apply(ctx, config) {
     json(res, 405, { error: 'method' });
   } });
 
-  // cron 预览：创建/编辑表单实时显示接下来几次触发时间
+  // cron 预览：创建/编辑表单实时显示接下来几次触发时间（按请求所选时区）
   register({ kind: 'exact', path: '/wf1/api/schedule/preview', async handler(req, res) {
     if (req.method !== 'POST') return json(res, 405, { error: 'method' });
     const body = await readBody(req);
     if (!body?.cron) return json(res, 400, { error: '需要 cron 表达式' });
+    let tz;
+    try { tz = normalizeTimezoneInput(body?.timezone); } catch (error) { return json(res, 400, { error: error.message }); }
     try {
-      return json(res, 200, { ok: true, times: upcomingFireTimes(body.cron, 3) });
+      return json(res, 200, { ok: true, times: upcomingFireTimes(body.cron, 3, Date.now(), tz) });
     } catch (e) {
       return json(res, 400, { error: `cron 表达式无效：${e.message}` });
     }

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/schedule.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/schedule.js
@@ -10,28 +10,50 @@ export const OVERLAP_POLICIES = ['skip', 'parallel'];
 // setTimeout 上限 2^31-1 ms（约 24.8 天）：远期任务链式分段等待，避免溢出成 1ms 风暴
 const MAX_WAIT = 2 ** 31 - 1;
 
-export function isValidCron(cron) {
+export function isValidCron(cron, tz) {
   // cron-parser 宽松模式把空串/缺段当 *（空串 = 每分钟），先拒绝空值
   if (typeof cron !== 'string' || !cron.trim()) return false;
   try {
-    parseCronExpression(cron, { currentDate: new Date() });
+    parseCronExpression(cron, { currentDate: new Date(), tz: tz || undefined });
     return true;
   } catch {
     return false;
   }
 }
 
-// 距下次触发的毫秒数（≥1）；cron 无效抛错（空串同上视为无效）
-export function computeNextDelay(cron, now = Date.now()) {
+// 合法 IANA 时区名（含 UTC / 旧别名）；空值不算合法时区
+export function isValidTimezone(tz) {
+  if (typeof tz !== 'string' || !tz.trim()) return false;
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: tz.trim() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// 请求侧 timezone 归一化：空值 = null（跟随主机时区）；非法名抛错。
+// 必须在入口拦：cron-parser 对非法 tz 静默回退本地时区，不抛错。
+export function normalizeTimezoneInput(value) {
+  if (value === undefined || value === null) return null;
+  const tz = String(value).trim();
+  if (!tz) return null;
+  if (!isValidTimezone(tz)) throw new Error(`时区无效：${tz}`);
+  return tz;
+}
+
+// 距下次触发的毫秒数（≥1）；cron 无效抛错（空串同上视为无效）。
+// tz 为空按主机本地时区解释，等价旧行为
+export function computeNextDelay(cron, now = Date.now(), tz) {
   if (typeof cron !== 'string' || !cron.trim()) throw new Error('cron 表达式为空');
-  const interval = parseCronExpression(cron, { currentDate: new Date(now) });
+  const interval = parseCronExpression(cron, { currentDate: new Date(now), tz: tz || undefined });
   return Math.max(1, interval.next().getTime() - now);
 }
 
 // 接下来 count 次触发时间（ISO 字符串），供创建表单实时预览；cron 无效抛错
-export function upcomingFireTimes(cron, count = 3, now = Date.now()) {
+export function upcomingFireTimes(cron, count = 3, now = Date.now(), tz) {
   if (typeof cron !== 'string' || !cron.trim()) throw new Error('cron 表达式为空');
-  const interval = parseCronExpression(cron, { currentDate: new Date(now) });
+  const interval = parseCronExpression(cron, { currentDate: new Date(now), tz: tz || undefined });
   const times = [];
   for (let i = 0; i < count; i += 1) times.push(interval.next().toISOString());
   return times;
@@ -48,7 +70,8 @@ export function hasLiveRunForWorkflow(runsMap, workspaceRoot, workflowId) {
   return false;
 }
 
-// 兼容旧 triggers.json：无新字段时补默认值（overlap=skip、enabled=true）
+// 兼容旧 triggers.json：无新字段时补默认值（overlap=skip、enabled=true）。
+// timezone=null = 跟随主机时区（旧行为）；非法值回落 null，绝不带病起调度
 export function normalizeScheduleMeta(raw) {
   const overlap = OVERLAP_POLICIES.includes(raw?.overlap) ? raw.overlap : 'skip';
   return {
@@ -59,6 +82,7 @@ export function normalizeScheduleMeta(raw) {
     input: raw?.input || '',
     runInputs: raw?.runInputs && typeof raw?.runInputs === 'object' ? raw.runInputs : {},
     overlap,
+    timezone: isValidTimezone(raw?.timezone) ? raw.timezone.trim() : null,
     enabled: raw?.enabled !== false,
     createdAt: raw?.createdAt || null,
     nextAt: raw?.nextAt || null,
@@ -77,6 +101,7 @@ export function persistableScheduleMeta(meta) {
     input: meta.input,
     runInputs: meta.runInputs || {},
     overlap: meta.overlap || 'skip',
+    timezone: meta.timezone || null,
     enabled: meta.enabled !== false,
     createdAt: meta.createdAt,
     nextAt: meta.nextAt || null,
@@ -112,7 +137,7 @@ export function createScheduler({ meta, fire, isBusy, logger, now = () => Date.n
     if (state.stopped) return;
     let nextMs = 1;
     try {
-      nextMs = computeNextDelay(normalized.cron, now());
+      nextMs = computeNextDelay(normalized.cron, now(), normalized.timezone);
     } catch (error) {
       state.stopped = true;
       state.nextAt = null;

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/schedule-api.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/schedule-api.integration.test.mjs
@@ -126,6 +126,42 @@ await test('POST /schedule/preview：返回 3 次触发时间；非法 cron 400'
   assert.equal(bad.status, 400);
 });
 
+await test('timezone：preview 按所选时区计算；创建落盘；非法名 400；PATCH 可改', async () => {
+  // preview 用真实「现在」起算，绝对值不定；验证接受 timezone 且返回 3 个合法 ISO
+  // （tz 对触发点的实际影响已在 schedule.test.mjs 用锚定时刻验证）
+  const utc = await call('POST', '/wf1/api/schedule/preview', { cron: '0 9 * * *', timezone: 'UTC' });
+  assert.equal(utc.status, 200);
+  for (const t of utc.body.times) assert.ok(!Number.isNaN(Date.parse(t)));
+  const badTz = await call('POST', '/wf1/api/schedule/preview', { cron: '0 9 * * *', timezone: 'Not/AZone' });
+  assert.equal(badTz.status, 400);
+  assert.match(badTz.body.error, /时区无效/);
+  // 空串/null = 跟随主机，不报错
+  const hostTz = await call('POST', '/wf1/api/schedule/preview', { cron: '0 9 * * *', timezone: '' });
+  assert.equal(hostTz.status, 200);
+
+  const created = await call('POST', '/wf1/api/schedule', { workflowId: 'wf_sch', cron: '0 9 * * *', timezone: 'UTC' });
+  assert.equal(created.status, 200);
+  const key = created.body.key;
+  let disk = readTriggers().schedules.find((s) => s.key === key);
+  assert.equal(disk.timezone, 'UTC', '创建时 timezone 应落盘');
+  const listed = await call('GET', '/wf1/api/schedule');
+  assert.equal(listed.body.schedules.find((s) => s.key === key).timezone, 'UTC');
+
+  const patched = await call('PATCH', '/wf1/api/schedule', { key, timezone: 'America/New_York' });
+  assert.equal(patched.status, 200);
+  disk = readTriggers().schedules.find((s) => s.key === key);
+  assert.equal(disk.timezone, 'America/New_York');
+
+  const badPatch = await call('PATCH', '/wf1/api/schedule', { key, timezone: 'Mars/Olympus' });
+  assert.equal(badPatch.status, 400);
+  const backToHost = await call('PATCH', '/wf1/api/schedule', { key, timezone: null });
+  assert.equal(backToHost.status, 200);
+  assert.equal(readTriggers().schedules.find((s) => s.key === key).timezone, null, 'null = 跟随主机');
+
+  const del = await call('DELETE', `/wf1/api/schedule?key=${key}`);
+  assert.equal(del.status, 200);
+});
+
 await test('POST /schedule/run：立即触发返回 runId 并计入 fireCount；来源为 schedule', async () => {
   const fired = await call('POST', '/wf1/api/schedule/run', { key: globalThis.__schKey });
   assert.equal(fired.status, 200);

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/schedule.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/schedule.test.mjs
@@ -1,8 +1,8 @@
 // lib/schedule.js 单测：cron 计算、重叠判定、调度器策略（短真实等待驱动）。
 import { strict as assert } from 'node:assert';
 import {
-  computeNextDelay, createScheduler, hasLiveRunForWorkflow, isValidCron,
-  normalizeScheduleMeta, persistableScheduleMeta, upcomingFireTimes,
+  computeNextDelay, createScheduler, hasLiveRunForWorkflow, isValidCron, isValidTimezone,
+  normalizeScheduleMeta, normalizeTimezoneInput, persistableScheduleMeta, upcomingFireTimes,
 } from '../lib/schedule.js';
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -48,6 +48,52 @@ await test('upcomingFireTimes：返回递增 ISO 时间、条数正确（本地�
   assert.deepEqual(times, expected);
 });
 
+await test('isValidTimezone：IANA 名与 UTC 合法、垃圾名/空值非法', () => {
+  assert.equal(isValidTimezone('Asia/Shanghai'), true);
+  assert.equal(isValidTimezone('UTC'), true);
+  assert.equal(isValidTimezone('America/New_York'), true);
+  assert.equal(isValidTimezone('Not/AZone'), false);
+  assert.equal(isValidTimezone(''), false);
+  assert.equal(isValidTimezone(null), false);
+  assert.equal(isValidTimezone(undefined), false);
+  assert.equal(isValidTimezone(42), false);
+});
+
+await test('normalizeTimezoneInput：空值归一为 null；非法名抛错；两侧空白裁剪', () => {
+  assert.equal(normalizeTimezoneInput(undefined), null);
+  assert.equal(normalizeTimezoneInput(null), null);
+  assert.equal(normalizeTimezoneInput(''), null);
+  assert.equal(normalizeTimezoneInput('   '), null);
+  assert.equal(normalizeTimezoneInput('Asia/Shanghai'), 'Asia/Shanghai');
+  assert.equal(normalizeTimezoneInput('  UTC  '), 'UTC');
+  assert.throws(() => normalizeTimezoneInput('Not/AZone'), /时区无效/);
+});
+
+await test('时区透传：tz=UTC 的 0 9 * * * 触发点是 09:00Z；与主机时区解释可不同', () => {
+  // 以 UTC 锚定：2026-01-01T00:00Z，UTC 时区下 0 9 * * * 首个触发是当天 09:00Z
+  const base = Date.parse('2026-01-01T00:00:00Z');
+  assert.equal(upcomingFireTimes('0 9 * * *', 1, base, 'UTC')[0], '2026-01-01T09:00:00.000Z');
+  // 同一时刻按纽约（1 月 EST=UTC-5）解释：本地 9 点 = 14:00Z
+  assert.equal(upcomingFireTimes('0 9 * * *', 1, base, 'America/New_York')[0], '2026-01-01T14:00:00.000Z');
+  // 不传 tz = 主机本地时区（旧行为）：按本地 9 点计算，可与 UTC 结果不同
+  const local = upcomingFireTimes('0 9 * * *', 1, base);
+  const hostTz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+  if (hostTz !== 'UTC') assert.notEqual(local[0], '2026-01-01T09:00:00.000Z');
+  // computeNextDelay 同样吃 tz：从 08:59Z 起 UTC 9 点 cron 下一跳约 60s
+  const delay = computeNextDelay('0 9 * * *', Date.parse('2026-01-01T08:59:00Z'), 'UTC');
+  assert.ok(Math.abs(delay - 60_000) < 50, `expect ~60000ms got ${delay}`);
+  // isValidCron 同样接受 tz 参数；非法 tz 在带 currentDate 时 cron-parser 直接抛错 → fail-closed 判非法
+  assert.equal(isValidCron('0 9 * * *', 'UTC'), true);
+  assert.equal(isValidCron('0 9 * * *', 'Not/AZone'), false);
+});
+
+await test('时区跨夏令时：纽约 3 月 DST 切换，本地 9 点绝对时间前移 1 小时', () => {
+  // 2026-03-08 02:00 EST → EDT：切换前本地 9 点 = 14:00Z，切换后 = 13:00Z
+  const times = upcomingFireTimes('0 9 * * *', 2, Date.parse('2026-03-07T12:00:00Z'), 'America/New_York');
+  assert.equal(times[0], '2026-03-07T14:00:00.000Z');
+  assert.equal(times[1], '2026-03-08T13:00:00.000Z');
+});
+
 await test('hasLiveRunForWorkflow：按 workflowId+workspaceRoot 匹配，其他工作区/工作流不算', () => {
   const runs = new Map([
     ['r1', { run: { workflowId: 'wf_a', workspaceRoot: '/ws1' } }],
@@ -70,27 +116,35 @@ await test('normalizeScheduleMeta：旧 triggers.json 字段补默认 skip/enabl
   assert.equal(legacy.fireCount, 0);
   assert.equal(legacy.skippedCount, 0);
 
-  const full = normalizeScheduleMeta({ key: 'sch_y', workflowId: 'wf', cron: '0 9 * * *', overlap: 'parallel', enabled: false, runInputs: { a: 1 }, fireCount: 3, skippedCount: 2 });
+  const full = normalizeScheduleMeta({ key: 'sch_y', workflowId: 'wf', cron: '0 9 * * *', overlap: 'parallel', enabled: false, runInputs: { a: 1 }, fireCount: 3, skippedCount: 2, timezone: 'Asia/Shanghai' });
   assert.equal(full.overlap, 'parallel');
   assert.equal(full.enabled, false);
   assert.deepEqual(full.runInputs, { a: 1 });
   assert.equal(full.fireCount, 3);
   assert.equal(full.skippedCount, 2);
+  assert.equal(full.timezone, 'Asia/Shanghai');
+
+  // 旧数据无 timezone = 跟随主机（null），非法值回落 null，不做迁移
+  assert.equal(legacy.timezone, null);
+  assert.equal(normalizeScheduleMeta({ cron: '0 9 * * *', timezone: 'Not/AZone' }).timezone, null);
 
   assert.equal(normalizeScheduleMeta({ overlap: 'whatever' }).overlap, 'skip');
 });
 
-await test('persistableScheduleMeta：落盘含全部统计与配置字段', () => {
+await test('persistableScheduleMeta：落盘含全部统计与配置字段（含 timezone）', () => {
   const disk = persistableScheduleMeta(normalizeScheduleMeta({
     key: 'sch_z', workflowId: 'wf', workflowName: 'n', cron: '0 9 * * *', input: 'x',
-    runInputs: { k: 'v' }, overlap: 'parallel', enabled: false, createdAt: 't',
+    runInputs: { k: 'v' }, overlap: 'parallel', timezone: 'UTC', enabled: false, createdAt: 't',
     nextAt: '2026-01-16T09:00:00.000Z', fireCount: 5, skippedCount: 1,
   }));
   assert.deepEqual(disk, {
     key: 'sch_z', workflowId: 'wf', workflowName: 'n', cron: '0 9 * * *', input: 'x',
-    runInputs: { k: 'v' }, overlap: 'parallel', enabled: false, createdAt: 't',
+    runInputs: { k: 'v' }, overlap: 'parallel', timezone: 'UTC', enabled: false, createdAt: 't',
     nextAt: '2026-01-16T09:00:00.000Z', fireCount: 5, skippedCount: 1,
   });
+  // 无 timezone 时落盘 null（不缺字段，便于下游区分「跟随主机」）
+  const noTz = persistableScheduleMeta(normalizeScheduleMeta({ key: 'sch_n', workflowId: 'wf', cron: '0 9 * * *' }));
+  assert.equal(noTz.timezone, null);
 });
 
 await test('createScheduler：每秒 cron 到点触发 fire 并回调 onFire', async () => {

--- a/web/src/ScheduleCenter.jsx
+++ b/web/src/ScheduleCenter.jsx
@@ -1,16 +1,9 @@
 // 定时任务面板：列表（下次触发/触发统计/启停/立即运行/删除）+ 创建/编辑表单
 // （cron 预设 + 实时预览下 3 次触发 + 重叠策略）。风格对齐 VariableCenter 的 Modal。
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { apiUrl } from './api.js';
 import { Modal } from './ui.jsx';
-import { CRON_PRESETS, describeCron, presetOfCron } from './schedule-center.js';
-
-function formatNext(iso) {
-  if (!iso) return '—';
-  const date = new Date(iso);
-  if (Number.isNaN(date.getTime())) return '—';
-  return date.toLocaleString('zh-CN', { hour12: false, month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
-}
+import { CRON_PRESETS, describeCron, formatNextInZone, hostTimezone, presetOfCron, supportedTimezones, timezoneOffsetLabel } from './schedule-center.js';
 
 function validateRunInputsJson(text) {
   if (!text.trim()) return { ok: true, value: {} };
@@ -31,9 +24,17 @@ function ScheduleForm({ workflows, initial, onSubmit, onCancel, submitting }) {
   const [input, setInput] = useState(initial?.input || '');
   const [runInputsText, setRunInputsText] = useState(initial?.runInputs && Object.keys(initial.runInputs).length ? JSON.stringify(initial.runInputs, null, 2) : '');
   const [overlap, setOverlap] = useState(initial?.overlap || 'skip');
+  // timezone=null 跟随主机；时区候选按使用频率把常见区排前
+  const [timezone, setTimezone] = useState(initial?.timezone || '');
   const [preview, setPreview] = useState({ state: 'idle' }); // idle | loading | ok | error
   const preset = presetOfCron(cron);
   const debounceRef = useRef(null);
+  const timezoneOptions = useMemo(() => {
+    const all = supportedTimezones();
+    const common = ['Asia/Shanghai', 'UTC', 'Asia/Hong_Kong', 'Asia/Taipei', 'Asia/Tokyo', 'America/New_York', 'Europe/London'];
+    const head = common.filter((tz) => all.includes(tz));
+    return [...head, ...all.filter((tz) => !head.includes(tz))];
+  }, []);
 
   useEffect(() => {
     if (debounceRef.current) clearTimeout(debounceRef.current);
@@ -42,14 +43,14 @@ function ScheduleForm({ workflows, initial, onSubmit, onCancel, submitting }) {
     debounceRef.current = setTimeout(() => {
       fetch(apiUrl('/schedule/preview'), {
         method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ cron }),
+        body: JSON.stringify({ cron, timezone: timezone || null }),
       })
         .then((r) => r.json().then((data) => ({ ok: r.ok, data })))
         .then(({ ok, data }) => setPreview(ok ? { state: 'ok', times: data.times || [] } : { state: 'error', error: data.error || 'cron 表达式无效' }))
         .catch(() => setPreview({ state: 'error', error: '预览请求失败' }));
     }, 300);
     return () => clearTimeout(debounceRef.current);
-  }, [cron]);
+  }, [cron, timezone]);
 
   const runInputsCheck = validateRunInputsJson(runInputsText);
   const cronValid = preview.state === 'ok';
@@ -63,6 +64,7 @@ function ScheduleForm({ workflows, initial, onSubmit, onCancel, submitting }) {
       input,
       runInputs: runInputsCheck.value,
       overlap,
+      timezone: timezone || null,
     });
   };
 
@@ -93,9 +95,23 @@ function ScheduleForm({ workflows, initial, onSubmit, onCancel, submitting }) {
         {preview.state === 'ok' && (
           <p className="sch-preview">
             <strong>{describeCron(cron) || '自定义周期'}</strong>
-            接下来：{preview.times.map((t) => formatNext(t)).join('、')}
+            接下来：{preview.times.map((t) => formatNextInZone(t, timezone)).join('、')}
           </p>
         )}
+        <div className="sch-tz">
+          <select
+            className="sch-input sch-tz-select"
+            value={timezone}
+            onChange={(e) => setTimezone(e.target.value)}
+            title="cron 表达式按所选时区解释"
+          >
+            <option value="">跟随主机（{hostTimezone()}）</option>
+            {timezoneOptions.map((tz) => (
+              <option key={tz} value={tz}>{tz}（{timezoneOffsetLabel(tz)}）</option>
+            ))}
+          </select>
+          {timezone && <p className="sec-hint">cron 按所选时区 {timezone} 解释；改回「跟随主机」即恢复旧行为</p>}
+        </div>
       </section>
       <section className="panel-sec">
         <h4>触发输入 <span className="sec-hint">可选，模板里用 {'{{$trigger}}'} 引用</span></h4>
@@ -249,7 +265,8 @@ export function ScheduleCenter({ currentWorkflowId, onRan, onClose, toast }) {
                     </div>
                     <div className="sch-row-meta">
                       <span title={row.cron}>{describeCron(row.cron) || row.cron}</span>
-                      <span>下次 {formatNext(row.nextAt)}</span>
+                      <span>下次 {formatNextInZone(row.nextAt, row.timezone)}</span>
+                      <span>{row.timezone ? `时区 ${row.timezone}` : `跟随主机（${hostTimezone()}）`}</span>
                       <span>已触发 {row.fireCount ?? 0} 次{row.skippedCount ? `（跳过 ${row.skippedCount} 次）` : ''}</span>
                       <span>{row.overlap === 'parallel' ? '重叠并行' : '重叠跳过'}</span>
                     </div>

--- a/web/src/result-panel.css
+++ b/web/src/result-panel.css
@@ -257,6 +257,8 @@
 .sch-err { color: var(--danger-fg, #ef4444); font-size: 11px; margin: 4px 0 0; }
 .sch-preview { margin: 6px 0 0; font-size: 11px; color: var(--fg-muted); }
 .sch-preview strong { color: var(--fg); margin-right: 8px; }
+.sch-tz { margin-top: 8px; display: flex; flex-direction: column; gap: 4px; }
+.sch-tz-select { max-width: 360px; }
 .sch-overlap { display: flex; flex-direction: column; gap: 8px; margin: 6px 0; }
 .sch-radio { display: flex; gap: 8px; align-items: flex-start; padding: 8px 10px; border: 1px solid var(--border); border-radius: 10px; cursor: pointer; }
 .sch-radio-on { border-color: var(--accent, #6d8cff); }

--- a/web/src/schedule-center.js
+++ b/web/src/schedule-center.js
@@ -95,3 +95,47 @@ export function describeCron(cron) {
 export function presetOfCron(cron) {
   return CRON_PRESETS.find((p) => p.cron === String(cron || '').trim()) || null;
 }
+
+// 主机时区名（浏览器端展示「跟随主机」选项时提示具体值）
+export function hostTimezone() {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || '本地时区';
+}
+
+// 时区选择器候选：完整 IANA 列表 + 字面量 UTC 去重置顶（ICU 列表常只有 Etc/UTC，
+// 而服务端/直觉都认 'UTC'）；旧浏览器没有 supportedValuesOf 时退到常见几个
+export function supportedTimezones() {
+  try {
+    const all = Intl.supportedValuesOf('timeZone');
+    return all.includes('UTC') ? all : ['UTC', ...all];
+  } catch {
+    return ['UTC', 'Asia/Shanghai', 'Asia/Hong_Kong', 'Asia/Tokyo', 'America/New_York', 'Europe/London'];
+  }
+}
+
+// 时区偏移提示：Asia/Shanghai → UTC+08:00（按当前时刻，DST 期偏移随之变化，仅作选择提示）。
+// 零偏移统一显示 UTC（部分 ICU 对字面量 UTC 返回 GMT+00:00）
+export function timezoneOffsetLabel(tz, now = new Date()) {
+  try {
+    const name = new Intl.DateTimeFormat('en-US', { timeZone: tz, timeZoneName: 'longOffset' })
+      .formatToParts(now)
+      .find((p) => p.type === 'timeZoneName')?.value;
+    if (!name) return '';
+    const label = name.replace(/^GMT/, 'UTC');
+    return label === 'UTC+00:00' ? 'UTC' : label;
+  } catch {
+    return '';
+  }
+}
+
+// 把 ISO 时间按指定 IANA 时区格式化；tz 为空按浏览器本地时区（与旧行为一致）。
+// 非法 tz 名（如手改数据塞入垃圾值）兜底回本地时区，不让面板渲染崩掉
+export function formatNextInZone(iso, tz) {
+  if (!iso) return '—';
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return '—';
+  try {
+    return date.toLocaleString('zh-CN', { hour12: false, month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', timeZone: tz || undefined });
+  } catch {
+    return date.toLocaleString('zh-CN', { hour12: false, month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' });
+  }
+}

--- a/web/src/schedule-center.test.mjs
+++ b/web/src/schedule-center.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { CRON_PRESETS, describeCron, presetOfCron } from './schedule-center.js';
+import { CRON_PRESETS, describeCron, formatNextInZone, hostTimezone, presetOfCron, supportedTimezones, timezoneOffsetLabel } from './schedule-center.js';
 
 let passed = 0;
 function test(name, fn) {
@@ -51,6 +51,38 @@ test('presetOfCron：命中返回预设，未命中 null', () => {
   assert.equal(presetOfCron('  0 9 * * *  ')?.key, 'daily-9');
   assert.equal(presetOfCron('13 13 * * *'), null);
   assert.equal(CRON_PRESETS.length, 4);
+});
+
+test('hostTimezone：返回非空 IANA 名', () => {
+  assert.ok(hostTimezone());
+  assert.equal(typeof hostTimezone(), 'string');
+});
+
+test('supportedTimezones：返回列表且含常见区', () => {
+  const zones = supportedTimezones();
+  assert.ok(Array.isArray(zones) && zones.length > 0);
+  // 部分运行时 supportedValuesOf 不含字面量 'UTC'，选择器需自行补——这里只验证常见 IANA 区在列
+  assert.ok(zones.includes('Asia/Shanghai'));
+});
+
+test('timezoneOffsetLabel：上海 UTC+08:00、UTC 字面量；非法名空串', () => {
+  // 用固定时刻避免依赖「当前」：DST 期个别区会漂移，但这几个区全年固定
+  const at = new Date('2026-01-15T00:00:00Z');
+  assert.equal(timezoneOffsetLabel('Asia/Shanghai', at), 'UTC+08:00');
+  assert.equal(timezoneOffsetLabel('UTC', at), 'UTC');
+  assert.equal(timezoneOffsetLabel('Not/AZone', at), '');
+  assert.equal(timezoneOffsetLabel('', at), '');
+});
+
+test('formatNextInZone：同一 ISO 按不同时区格式化为不同墙钟；空值占位 —', () => {
+  const iso = '2026-01-01T09:00:00Z';
+  assert.equal(formatNextInZone(iso, 'UTC'), '01/01 09:00');
+  assert.equal(formatNextInZone(iso, 'Asia/Shanghai'), '01/01 17:00');
+  // tz 为空按浏览器本地时区（旧行为）：不抛错且非占位符
+  assert.notEqual(formatNextInZone(iso, ''), '—');
+  assert.equal(formatNextInZone('', 'UTC'), '—');
+  assert.equal(formatNextInZone(null, 'UTC'), '—');
+  assert.equal(formatNextInZone('garbage', 'UTC'), '—');
 });
 
 console.log(process.exitCode ? `${passed} tests passed with failures` : `ALL PASS (${passed})`);


### PR DESCRIPTION
## 背景

Closes #58。cron 表达式此前全程按**服务器本地时间**解释：`schedule.js` 所有 `parseCronExpression` 调用都没传 `tz`，调度元数据也没有 timezone 字段。本机部署无感，但 dsh 装进 UTC 时区的容器/云主机后，「0 9 * * *」实际在下午 5 点触发，且界面无任何提示能发现这一点。

## 方案

**引擎（schedule.js，纯逻辑闭环）**
- `isValidCron` / `computeNextDelay` / `upcomingFireTimes` 三处透传 cron-parser 的 `tz` 选项；`tz` 为空 = 主机本地时区，等价旧行为
- 新增 `isValidTimezone`（Intl 校验 IANA 名）与 `normalizeTimezoneInput`（空值归一 null、非法名抛错）。必须在入口拦非法值：实测 cron-parser 对非法 `tz` 会**静默回退本地时区**（无 `currentDate` 时），带病数据不可见
- `createScheduler` 按 `meta.timezone` 计算触发链

**元数据兼容层**
- `normalizeScheduleMeta` / `persistableScheduleMeta` 新增 `timezone` 字段：旧 triggers.json 无字段 = null（跟随主机，旧行为），非法值回落 null，不做迁移。已落盘旧 schedule 行为完全不变 ✅（约束达成）

**HTTP（index.js）**
- `POST /wf1/api/schedule` 接受 `timezone`（非法 400 `时区无效：X`）
- `PATCH` 支持 `hasOwn` 语义改/清 timezone（`null` = 回到跟随主机）
- `/wf1/api/schedule/preview` 按请求时区返回下 3 次触发

**前端（ScheduleCenter.jsx + schedule-center.js 纯逻辑）**
- 表单新增时区选择器：`Intl.supportedValuesOf('timeZone')` 全量 + 字面量 `UTC` 补位（ICU 列表常缺）、常见区置顶、默认「跟随主机（显示主机时区名）」、选项带 UTC 偏移提示（DST 感知）
- 预览与列表「下次触发」按所选时区格式化（`Intl timeZone` 选项）；列表行明示「时区 X / 跟随主机（…）」——解决 issue 里「界面无任何提示能发现」
- 时间格式化兜底：手改数据塞入非法 tz 名时回退浏览器本地时区，不崩面板

## 验证

- **单测**：schedule.test.mjs 16 例（新增 UTC/纽约锚定断言 `0 9 * * *`→`09:00Z`/`14:00Z`、纽约 3 月 DST 跨越 `14:00Z`→`13:00Z`、非法 tz fail-closed、兼容层 null 回落）；schedule-api.integration.test.mjs 10 例（preview 400/创建落盘/PATCH 改与清/非法 400）；schedule-center.test.mjs 9 例（offset 标签、跨时区格式化、占位符）
- **全量**：`npm test` 全绿（web 14 套 + orchestrator 17 套 + 其余插件）；`build-web.sh` 双构建通过
- **真机**：scratch profile 起 dsh（本机 Asia/Shanghai），实测
  - preview `{"cron":"0 9 * * *","timezone":"UTC"}` → `09:00Z`（旧行为会是 `01:00Z`）
  - 非法 timezone → `{"error":"时区无效：Mars/Base"}`
  - 创建带 `timezone:"UTC"` → triggers.json 落盘 `timezone` 字段，列表 `nextAt: 2026-08-28T09:00:00.000Z`
  - PATCH 改 `America/New_York` → `nextAt: 2026-08-28T13:00:00Z`（8 月末 EDT=UTC-4，正确）
  - PATCH `null` → 回跟随主机；测试数据已清理

## 备注

- timezoneOffsetLabel 零偏移统一显示 `UTC`（部分 ICU 对字面量 UTC 返回 `GMT+00:00`）
- 前端选择器候选含 `Etc/*` 别名，服务端 Intl 全部接受，两端校验口径一致