### PR TITLE
feat(orchestrator): 运行中节点详情弹窗实时显示执行轨迹 (#52)

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
@@ -286,7 +286,12 @@ export class Orchestrator {
         throw error;
       }
       result = normalizeExecutionResult(await kind.execute(execCtx), { meta: { nodeType: node.type } });
-      if (timedOut) throw new Error(`节点超时（${Math.round(timeoutMs / 1000)}s）`);
+      if (timedOut) {
+        // 超时但 execute 已产出结果：把轨迹等 extra 带进错误，详情弹窗超时后仍可复盘
+        const timeoutError = new Error(`节点超时（${Math.round(timeoutMs / 1000)}s）`);
+        if (result?.extra && typeof result.extra === 'object') timeoutError.nodeDetails = result.extra;
+        throw timeoutError;
+      }
       if (run.canceled) throw new Error('运行已取消');
       // 输出后处理（飞书写回等）：sink 结果增量合并，保留原节点 data/meta/extra。
       if (kind?.wantsSink && this.outputSink) {

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -828,6 +828,7 @@ export function apply(ctx, config) {
 
   // ---- 运行历史（按工作区持久化 + 内存缓存）----
   const pendingRunIds = new Set();
+  const liveTracesByRun = new Map(); // 运行中节点的实时轨迹：runId → (nodeId → trace)；节点完成后落盘、运行结束释放
   const recoverInterruptedRun = (run, interruptedAt) => {
     const startedAtMs = run.startedAt ? new Date(run.startedAt).getTime() : NaN;
     const states = (run.graph?.nodes || []).map((node) => run.nodeStates?.[node.id]);
@@ -942,8 +943,11 @@ export function apply(ctx, config) {
   const onOrchestratorEvent = (event, payload) => {
     if (event === 'node-status' && TERMINAL_NODE_STATUSES.has(payload?.status)) {
       notifications.onNodeStatus(payload, orch?.runs.get(payload.runId)?.run);
+      liveTracesByRun.get(payload.runId)?.delete(payload.nodeId); // 完成轨迹已随 run 落盘，实时版即时释放
       try { checkpointRun(payload.runId); }
       catch (error) { ctx.logger?.error?.(`dsh-ccpg 运行检查点写入失败（${payload?.runId || 'unknown'}）：${error.message}`); }
+    } else if (event === 'run-end') {
+      liveTracesByRun.delete(payload?.runId);
     }
     broadcast(event, payload);
   };
@@ -1195,6 +1199,20 @@ export function apply(ctx, config) {
       let watchDone;
       const watchReady = new Promise((r) => { watchDone = r; });
       const watchState = { stop: false, timer: null };
+      // 实时轨迹：watchTick 逐事件扫描时同步折叠进 liveTracesByRun（详情弹窗运行中即可读）；
+      // 水位 lastSeqRef 只处理新到事件；完成后仍走 buildTrace 落盘路径，节点终态即释放。
+      let liveTrace = null;
+      if (runId) {
+        if (!liveTracesByRun.has(runId)) liveTracesByRun.set(runId, new Map());
+        const liveTraces = liveTracesByRun.get(runId);
+        if (!liveTraces.has(node.id)) {
+          liveTraces.set(node.id, { model: `${provider}:${model}`, entries: [{ kind: 'input', text: userPrompt }] });
+        }
+        liveTrace = liveTraces.get(node.id);
+      }
+      const metaHint = { input: userPrompt, model: `${provider}:${model}` };
+      const lastSeqRef = { value: firstSeq }; // 增量折叠水位：只处理新到事件
+      const pendingByCallId = new Map(); // callId → entries 下标（配对跨轮询到达的 tool/call 与 tool/result）
       const scanEvents = () => {
         let turns = 0; let preview = ''; let turnEnded = false;
         try {
@@ -1205,6 +1223,10 @@ export function apply(ctx, config) {
             if (ev.type === 'assistant/message') {
               const joined = (ev.data.message?.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
               if (joined) preview = joined;
+            }
+            if (liveTrace && ev.seq >= lastSeqRef.value) {
+              foldTraceEvent(liveTrace, ev, pendingByCallId, metaHint);
+              lastSeqRef.value = ev.seq + 1;
             }
           }
         } catch { /* session 已释放 */ }
@@ -1934,7 +1956,8 @@ export function apply(ctx, config) {
       schemaVersion: run.schemaVersion || 1,
       variables: run.graph?.nodes ? describeNodeOutput(node) : null,
       input: inputDetail,
-      trace: state?.trace ?? null,
+      // 运行中节点的实时轨迹（内存折叠，2s 刷新）；完成节点读落盘快照
+      trace: state?.status === 'running' ? (liveTracesByRun.get(runId)?.get(nodeId) ?? null) : state?.trace ?? null,
       sessionId: state?.sessionId || null,
     };
     if (!out.trace && state?.sessionId) {
@@ -2686,43 +2709,55 @@ function buildTrace(events, firstSeq, meta = {}) {
   try {
     for (const ev of events) {
       if (ev.seq < firstSeq) continue;
-      if (ev.type === 'user/message') {
-        // followup 之外还有 agent.inject 合成消息（技能加载/文件变更等），一并列出
-        const text = (ev.data?.message?.content || ev.data?.content || [])
-          .filter((b) => b?.type === 'text').map((b) => b.text).join('');
-        if (text && text !== meta.input) {
-          entries.push({ kind: 'inject', text: text.slice(0, 2000) });
-        }
-      } else if (ev.type === 'assistant/message') {
-        const text = (ev.data?.message?.content || [])
-          .filter((b) => b.type === 'text').map((b) => b.text).join('');
-        if (text) entries.push({ kind: 'assistant', text: text.slice(0, 6000), usage: ev.data?.usage });
-      } else if (ev.type === 'tool/call') {
-        pending.set(ev.data.callId, entries.length);
-        entries.push({
-          kind: 'tool', name: ev.data.name,
-          args: String(ev.data.arguments || '').slice(0, 4000),
-          turn: ev.data.turn, step: ev.data.step,
-        });
-      } else if (ev.type === 'tool/result') {
-        // ToolResultMessage.content = [{ type:'tool-result', toolCallId, content, isError }]
-        const blocks = ev.data?.message?.content || [];
-        for (const b of blocks) {
-          const i = pending.get(b?.toolCallId);
-          if (i !== undefined && entries[i]?.result === undefined) {
-            entries[i].result = {
-              ok: b.isError !== true && !ev.data?.error,
-              text: (b.content || []).filter((c) => c?.type === 'text').map((c) => c.text).join('').slice(0, 4000),
-              ...(ev.data?.error ? { error: `${ev.data.error.name}: ${ev.data.error.code}` } : {}),
-            };
-          }
-        }
-      } else if (ev.type === 'turn/end') {
-        entries.push({ kind: 'turn-end', reason: ev.data?.reason?.kind || String(ev.data?.reason || '') });
-      }
+      foldTraceEvent({ entries }, ev, pending, meta);
     }
   } catch { /* session 已释放时保留已折叠部分 */ }
-  // 旧会话回放没有 meta.input：第一条非系统注入就是实际用户输入，归位到 input。
+  finalizeTrace({ entries }, meta);
+  return { model: meta.model, entries };
+}
+
+// 折叠单个 session 事件进 entries（buildTrace 全量与实时轨迹增量共用同一套语义）
+export function foldTraceEvent(trace, ev, pending, meta = {}) {
+  const entries = trace.entries;
+  if (ev.type === 'user/message') {
+    // followup 之外还有 agent.inject 合成消息（技能加载/文件变更等），一并列出
+    const text = (ev.data?.message?.content || ev.data?.content || [])
+      .filter((b) => b?.type === 'text').map((b) => b.text).join('');
+    if (text && text !== meta.input) {
+      entries.push({ kind: 'inject', text: text.slice(0, 2000) });
+    }
+  } else if (ev.type === 'assistant/message') {
+    const text = (ev.data?.message?.content || [])
+      .filter((b) => b.type === 'text').map((b) => b.text).join('');
+    if (text) entries.push({ kind: 'assistant', text: text.slice(0, 6000), usage: ev.data?.usage });
+  } else if (ev.type === 'tool/call') {
+    pending.set(ev.data.callId, entries.length);
+    entries.push({
+      kind: 'tool', name: ev.data.name,
+      args: String(ev.data.arguments || '').slice(0, 4000),
+      turn: ev.data.turn, step: ev.data.step,
+    });
+  } else if (ev.type === 'tool/result') {
+    // ToolResultMessage.content = [{ type:'tool-result', toolCallId, content, isError }]
+    const blocks = ev.data?.message?.content || [];
+    for (const b of blocks) {
+      const i = pending.get(b?.toolCallId);
+      if (i !== undefined && entries[i]?.result === undefined) {
+        entries[i].result = {
+          ok: b.isError !== true && !ev.data?.error,
+          text: (b.content || []).filter((c) => c?.type === 'text').map((c) => c.text).join('').slice(0, 4000),
+          ...(ev.data?.error ? { error: `${ev.data.error.name}: ${ev.data.error.code}` } : {}),
+        };
+      }
+    }
+  } else if (ev.type === 'turn/end') {
+    entries.push({ kind: 'turn-end', reason: ev.data?.reason?.kind || String(ev.data?.reason || '') });
+  }
+}
+
+// 旧会话回放没有 meta.input：第一条非系统注入就是实际用户输入，归位到 input。
+export function finalizeTrace(trace, meta = {}) {
+  const { entries } = trace;
   if (!entries[0].text) {
     const i = entries.findIndex((e, idx) => idx > 0 && e.kind === 'inject' && !/^Current runtime context|^<system-reminder>/.test(e.text));
     if (i > 0) {
@@ -2730,7 +2765,6 @@ function buildTrace(events, firstSeq, meta = {}) {
       entries.splice(i, 1);
     }
   }
-  return { model: meta.model, entries };
 }
 
 // 旧运行记录（无 trace 快照）按 sessionId 从 dsh 会话存档现场回放轨迹

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/live-trace.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/live-trace.test.mjs
@@ -1,0 +1,84 @@
+// 实时轨迹单测（issue #52）：foldTraceEvent 增量折叠与 buildTrace 全量产出同语义；
+// 折叠语义回归：input/inject/assistant/tool(call+result 配对)/turn-end。
+import assert from 'node:assert/strict';
+
+const { foldTraceEvent, finalizeTrace } = await import('../lib/index.js');
+
+let passed = 0;
+const test = (name, fn) => Promise.resolve()
+  .then(fn)
+  .then(() => { passed += 1; console.log(`  ✓ ${name}`); })
+  .catch((error) => { console.error(`  ✗ ${name}\n${error.message}`); process.exitCode = 1; });
+
+const newTrace = () => ({ model: 'test:model', entries: [{ kind: 'input', text: '任务' }] });
+
+await test('tool/call 与 tool/result 按 callId 配对（增量逐事件折叠 = 全量一次折叠）', () => {
+  const trace = newTrace();
+  const pending = new Map();
+  const meta = { input: '任务', model: 'test:model' };
+  const events = [
+    { seq: 1, type: 'tool/call', data: { callId: 'c1', name: 'bash', arguments: '{"cmd":"ls"}', turn: 1, step: 1 } },
+    { seq: 2, type: 'assistant/message', data: { message: { content: [{ type: 'text', text: '查看目录' }] }, usage: { outputTokens: 10 } } },
+    { seq: 3, type: 'tool/result', data: { message: { content: [{ type: 'tool-result', toolCallId: 'c1', isError: false, content: [{ type: 'text', text: 'a.txt' }] }] } } },
+    { seq: 4, type: 'turn/end', data: { reason: { kind: 'end_turn' } } },
+  ];
+  for (const ev of events) foldTraceEvent(trace, ev, pending, meta);
+  assert.deepEqual(trace.entries.map((e) => e.kind), ['input', 'tool', 'assistant', 'turn-end']);
+  assert.equal(trace.entries[0].text, '任务');
+  assert.equal(trace.entries[1].name, 'bash');
+  assert.equal(trace.entries[1].result.ok, true);
+  assert.equal(trace.entries[1].result.text, 'a.txt');
+  assert.equal(trace.entries[2].usage.outputTokens, 10);
+  assert.equal(trace.entries[3].reason, 'end_turn');
+});
+
+await test('running 中工具调用先出现、结果未到 → result 缺省（前端显示 …）', () => {
+  const trace = newTrace();
+  const pending = new Map();
+  foldTraceEvent(trace, { seq: 1, type: 'tool/call', data: { callId: 'c9', name: 'read', arguments: '{}', turn: 1, step: 1 } }, pending, { input: '任务' });
+  assert.equal(trace.entries[1].kind, 'tool');
+  assert.equal(trace.entries[1].result, undefined);
+  // 下一 tick 结果到达：增量配对回填同一条 entry
+  foldTraceEvent(trace, { seq: 2, type: 'tool/result', data: { message: { content: [{ type: 'tool-result', toolCallId: 'c9', isError: true, content: [{ type: 'text', text: 'boom' }] }] }, error: { name: 'E', code: 'X' } } }, pending, { input: '任务' });
+  assert.equal(trace.entries[1].result.ok, false);
+  assert.equal(trace.entries[1].result.error, 'E: X');
+});
+
+await test('pending Map 跨 tick 持久：call 在前一 tick、result 在后一 tick 也能配对', () => {
+  const trace = newTrace();
+  const pending = new Map();
+  const meta = { input: '任务' };
+  foldTraceEvent(trace, { seq: 1, type: 'tool/call', data: { callId: 'ck', name: 'fs', arguments: 'a', turn: 1, step: 1 } }, pending, meta);
+  // 模拟第二个 tick：pending 沿用同一个 Map（引擎侧 pendingByCallId 常驻）
+  foldTraceEvent(trace, { seq: 2, type: 'tool/result', data: { message: { content: [{ type: 'tool-result', toolCallId: 'ck', isError: false, content: [{ type: 'text', text: 'ok' }] }] } } }, pending, meta);
+  assert.equal(trace.entries[1].result.text, 'ok');
+});
+
+await test('user/message 注入上下文折叠为 inject；与 input 相同文本不重复', () => {
+  const trace = newTrace();
+  const pending = new Map();
+  const meta = { input: '任务' };
+  foldTraceEvent(trace, { seq: 1, type: 'user/message', data: { message: { content: [{ type: 'text', text: '技能规范加载' }] } } }, pending, meta);
+  foldTraceEvent(trace, { seq: 2, type: 'user/message', data: { content: [{ type: 'text', text: '任务' }] } }, pending, meta);
+  assert.deepEqual(trace.entries.filter((e) => e.kind === 'inject').map((e) => e.text), ['技能规范加载']);
+});
+
+await test('finalizeTrace：空 input 时把首条非系统 inject 归位为 input（回放语义不回归）', () => {
+  const trace = { model: '', entries: [{ kind: 'input', text: '' }, { kind: 'inject', text: '真实用户输入' }, { kind: 'inject', text: '<system-reminder>系统</system-reminder>' }] };
+  finalizeTrace(trace, { input: '' });
+  assert.equal(trace.entries[0].text, '真实用户输入');
+  assert.equal(trace.entries.length, 2);
+  assert.equal(trace.entries[1].text, '<system-reminder>系统</system-reminder>');
+});
+
+await test('失败结果 isError=true → ok=false；成功不带 error 字段', () => {
+  const trace = newTrace();
+  const pending = new Map();
+  const meta = { input: '任务' };
+  foldTraceEvent(trace, { seq: 1, type: 'tool/call', data: { callId: 'x', name: 'bash', arguments: 'e', turn: 1, step: 1 } }, pending, meta);
+  foldTraceEvent(trace, { seq: 2, type: 'tool/result', data: { message: { content: [{ type: 'tool-result', toolCallId: 'x', isError: true, content: [{ type: 'text', text: 'exit 1' }] }] } } }, pending, meta);
+  assert.equal(trace.entries[1].result.ok, false);
+  assert.equal(trace.entries[1].result.error, undefined);
+});
+
+console.log(process.exitCode ? 'live-trace tests: FAIL' : `live-trace tests: ALL PASS (${passed})`);

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "test:variables": "node src/variables.test.mjs && node src/global-variables.test.mjs && node src/json-response.test.mjs && node src/api-base.test.mjs && node src/trial-request.test.mjs && node src/variable-scope.test.mjs && node src/run-event-routing.test.mjs && node src/workflow-serialization.test.mjs",
     "test:results": "node src/result-adapter.test.mjs",
     "test:scripts": "node src/script-parameters.test.mjs",
-    "test:ui": "node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs && node src/notify-node.test.mjs && node src/workflow-transfer-ui.test.mjs && node src/run-switcher.test.mjs && node src/schedule-center.test.mjs"
+    "test:ui": "node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs && node src/notify-node.test.mjs && node src/workflow-transfer-ui.test.mjs && node src/run-switcher.test.mjs && node src/schedule-center.test.mjs && node src/node-detail-polling.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/web/src/NodeDetailModal.jsx
+++ b/web/src/NodeDetailModal.jsx
@@ -1,12 +1,13 @@
 // 节点运行详情弹窗：点击运行日志的节点行打开。
 // 数据来自 /wf1/api/node-detail —— 输入（模板渲染后）、输出全文、agent 过程轨迹
-// （轮次 / 助手文本 / 每一次工具调用的参数与结果）。轨迹由 orchestrator 在节点
-// 完成时从 dsh session 事件折叠存档；旧运行现场从会话存档回放补齐。
+// （轮次 / 助手文本 / 每一次工具调用的参数与结果）。运行中的 agent 节点按 1.5s 轮询
+// 实时轨迹（引擎 watchTick 折叠进内存 run），终态即停；完成节点仍读落盘快照。
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Modal } from './ui.jsx';
 import { apiUrl } from './api.js';
 import { ArtifactLinks } from './ArtifactPreview.jsx';
+import { nextPollDelayMs, shouldAutoSelectTrace } from './node-detail-polling.js';
 
 const ENTRY_ICON = { input: '↳', inject: '⊕', assistant: '✦', tool: '🔧', 'turn-end': '↩' };
 const ENTRY_LABEL = { input: '输入', inject: '注入上下文', assistant: '助手', tool: '工具调用', 'turn-end': '轮次结束' };
@@ -84,21 +85,32 @@ export function NodeDetailModal({ runId, nodeId, onClose }) {
   const [data, setData] = useState(null);
   const [err, setErr] = useState(null);
   const [tab, setTab] = useState('trace');
+  const firstLoadRef = useRef(true);
+  const userTabRef = useRef(false);
+  const pickTab = (next) => { userTabRef.current = true; setTab(next); };
 
   useEffect(() => {
     let alive = true;
-    fetch(apiUrl(`/node-detail?run=${encodeURIComponent(runId)}&node=${encodeURIComponent(nodeId)}`))
-      .then((r) => r.json())
-      .then((d) => {
-        if (!alive) return;
-        if (d.error) setErr(d.error);
-        else {
+    let timer = null;
+    const load = () => {
+      fetch(apiUrl(`/node-detail?run=${encodeURIComponent(runId)}&node=${encodeURIComponent(nodeId)}`))
+        .then((r) => r.json())
+        .then((d) => {
+          if (!alive) return;
+          if (d.error) { setErr(d.error); return; }
+          const first = firstLoadRef.current;
+          firstLoadRef.current = false;
+          if (shouldAutoSelectTrace(d, first, userTabRef.current)) setTab('trace');
           setData(d);
-          setTab(d.trace ? 'trace' : 'io');
-        }
-      })
-      .catch((e) => alive && setErr(String(e)));
-    return () => { alive = false; };
+          setErr(null);
+          // running 节点持续轮询（引擎侧 2s 折叠一次轨迹），终态即停
+          const delay = nextPollDelayMs(d.status);
+          if (delay) timer = setTimeout(load, delay);
+        })
+        .catch((e) => { if (alive) setErr(String(e)); });
+    };
+    load();
+    return () => { alive = false; if (timer) clearTimeout(timer); };
   }, [runId, nodeId]);
 
   const trace = data?.trace;
@@ -114,6 +126,7 @@ export function NodeDetailModal({ runId, nodeId, onClose }) {
         <>
           <div className="detail-meta">
             <span className={`log-status dot-${data.status}`}>{data.status}</span>
+            {data.status === 'running' && <span className="detail-live">实时跟踪中 · 1.5s 刷新</span>}
             {data.state?.durationMs != null && <span>{(data.state.durationMs / 1000).toFixed(1)}s</span>}
             {data.state?.chars != null && <span>{data.state.chars} 字</span>}
             {data.state?.turns != null && <span>{data.state.turns} 轮</span>}
@@ -123,8 +136,8 @@ export function NodeDetailModal({ runId, nodeId, onClose }) {
           </div>
 
           <div className="detail-tabs">
-            {trace && <button className={`log-filter ${tab === 'trace' ? 'log-filter-on' : ''}`} onClick={() => setTab('trace')}>执行过程</button>}
-            <button className={`log-filter ${tab === 'io' ? 'log-filter-on' : ''}`} onClick={() => setTab('io')}>输入 / 输出</button>
+            {trace && <button className={`log-filter ${tab === 'trace' ? 'log-filter-on' : ''}`} onClick={() => pickTab('trace')}>执行过程</button>}
+            <button className={`log-filter ${tab === 'io' ? 'log-filter-on' : ''}`} onClick={() => pickTab('io')}>输入 / 输出</button>
           </div>
 
           {tab === 'io' && (

--- a/web/src/ResultPanel.jsx
+++ b/web/src/ResultPanel.jsx
@@ -54,7 +54,8 @@ function useElapsedClock(startedAt, active) {
 
 function ProcessStep({ event, index, runId, onFocusNode, onOpenNodeDetail }) {
   const meta = stepStatusMeta(event.status);
-  const canOpenDetail = Boolean(event.nodeId && runId && !['running', 'queued', 'pending'].includes(event.status));
+  // running 节点也可打开：详情弹窗对运行中 agent 轮询实时轨迹（issue #52）
+  const canOpenDetail = Boolean(event.nodeId && runId && event.status !== 'queued');
   const openDetail = canOpenDetail ? () => onOpenNodeDetail?.(runId, event.nodeId) : undefined;
   const startClock = formatClock(event.startedAt);
   const liveElapsed = useElapsedClock(event.startedAt, event.status === 'running');

--- a/web/src/node-detail-polling.js
+++ b/web/src/node-detail-polling.js
@@ -1,0 +1,14 @@
+// 节点详情弹窗轮询纯逻辑（issue #52，可单测）：
+// nextPollDelayMs —— running 节点持续轮询（1.5s），终态停止；
+// shouldAutoSelectTrace —— 首次加载到 trace 且用户尚未手动选 tab 时自动进「执行过程」。
+
+export const POLL_INTERVAL_MS = 1500;
+const TERMINAL_STATUSES = new Set(['success', 'error', 'canceled', 'skipped', 'pending']);
+
+export function nextPollDelayMs(status) {
+  return status === 'running' ? POLL_INTERVAL_MS : null;
+}
+
+export function shouldAutoSelectTrace(detail, isFirstLoad, userTouchedTab) {
+  return Boolean(isFirstLoad && !userTouchedTab && detail?.trace);
+}

--- a/web/src/node-detail-polling.test.mjs
+++ b/web/src/node-detail-polling.test.mjs
@@ -1,0 +1,45 @@
+// 节点详情轮询纯逻辑单测（issue #52）
+import assert from 'node:assert/strict';
+import { POLL_INTERVAL_MS, nextPollDelayMs, shouldAutoSelectTrace } from './node-detail-polling.js';
+
+let passed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+    console.log(`  ✓ ${name}`);
+  } catch (error) {
+    console.error(`  ✗ ${name}`);
+    throw error;
+  }
+}
+
+test('running 节点按 1.5s 轮询', () => {
+  assert.equal(nextPollDelayMs('running'), POLL_INTERVAL_MS);
+  assert.equal(POLL_INTERVAL_MS, 1500);
+});
+
+test('终态节点停止轮询（返回 null）', () => {
+  for (const status of ['success', 'error', 'canceled', 'skipped']) {
+    assert.equal(nextPollDelayMs(status), null, status);
+  }
+  assert.equal(nextPollDelayMs(undefined), null);
+});
+
+test('首次加载到 trace 且用户未动 tab → 自动进「执行过程」', () => {
+  assert.equal(shouldAutoSelectTrace({ trace: { entries: [] } }, true, false), true);
+});
+
+test('用户手动切过 tab 后不再自动切换', () => {
+  assert.equal(shouldAutoSelectTrace({ trace: { entries: [] } }, true, true), false);
+});
+
+test('非首次加载（轮询后续）不触发自动切换', () => {
+  assert.equal(shouldAutoSelectTrace({ trace: { entries: [] } }, false, false), false);
+});
+
+test('无 trace 不自动切换', () => {
+  assert.equal(shouldAutoSelectTrace({ trace: null }, true, false), false);
+});
+
+console.log(`node-detail polling tests: ALL PASS (${passed})`);

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1497,6 +1497,9 @@ body {
   margin-bottom: 10px; font-size: 12px; color: var(--fg-faint);
 }
 .detail-tol { color: var(--warn, #F59E0B); }
+.detail-live { display: inline-flex; align-items: center; gap: 5px; color: var(--accent, #8B5CF6); }
+.detail-live::before { content: ''; width: 7px; height: 7px; border-radius: 50%; background: currentColor; animation: log-pulse 1.2s ease-in-out infinite; }
+@media (prefers-reduced-motion: reduce) { .detail-live::before { animation: none; } }
 .detail-tabs { display: flex; gap: 6px; margin-bottom: 10px; }
 .detail-io, .detail-trace { display: flex; flex-direction: column; gap: 10px; }
 .detail-io-block { display: flex; flex-direction: column; gap: 6px; }


### PR DESCRIPTION
## 背景

Closes #52。节点详情弹窗的「执行过程」（轮次/助手文本/工具调用参数与结果、token 用量）只在节点完成后才存在：轨迹在节点完成时折叠落盘，弹窗打开仅 fetch 一次。agent 节点长工具循环或疑似卡住时，恰恰最需要看「它现在在干什么」，却只能等跑完复盘。原始诉求（PR #17 评审）：「点击详情能跟这个 tab 页已运行的节点效果一样」。

## 方案（无新增存储格式）

1. **引擎**（`orchestrator/lib/index.js`）
   - `buildTrace` 拆出 `foldTraceEvent`（单事件折叠）+ `finalizeTrace`，全量落盘与实时增量共用同一套语义
   - `watchTick` 本来就 2s 逐事件扫描运行中的 session，扫描时按水位 `lastSeqRef` 增量折叠新事件进内存 `liveTracesByRun`（runId → nodeId → trace）；工具 call/result 跨轮询配对靠常驻 `pendingByCallId`
   - 节点终态即释放实时版（落盘版已随 run 持久化）；`run-end` 释放整个 run 条目
2. **API**：`/wf1/api/node-detail` 命中 running 节点时优先读内存实时轨迹；完成节点照旧读落盘快照；旧运行仍走 session 存档回放
3. **前端**（`NodeDetailModal.jsx` / `ResultPanel.jsx`）
   - running 节点 1.5s 轮询、终态即停；「实时跟踪中 · 1.5s 刷新」脉冲徽标（respect `prefers-reduced-motion`）
   - 过程列表 running 节点放开点击（原 running/queued/pending 一律禁点）
   - tab 自动选中只在首次加载且用户未手动切换时生效；轮询纯逻辑抽出 `node-detail-polling.js` 配单测

边界：过程 tab 行内保持只放状态+时长，实时性收敛在详情弹窗；runId 全链路隔离，与多运行并发模型兼容；断点续跑通知与去重不受影响。

## E2E 中发现并修复的 bug

- `liveTracesByRun` 只 get 不 set：内存轨迹表从未初始化，running 时 trace 恒为 null（首次真机验证即暴露）
- 引擎节点超时 throw 时丢弃 execute 已产出的 `result.extra`，超时节点详情弹窗无过程可复盘（`engine.js`）；现挂上 `timeoutError.nodeDetails`

## 验证

- 单测：新增 12 例（orchestrator `live-trace.test.mjs` 6 + web `node-detail-polling.test.mjs` 6），全量 `npm test` 通过，`build-web.sh` 双构建通过
- 本地真实 dsh（独立 profile :4032）+ 真实模型（glm-5.3）Playwright E2E 两轮：
  - 完成态轨迹回归：16 行时间线、6 工具调用、轮次结束、token 用量齐全
  - running 弹窗实时跟踪：fetch 探针确认 1.5s 轮询，工具调用 1→3→4→5→6 实时增长，失败 ✗ 实时可见
  - 终态翻转：`running`→`success`，脉冲徽标消失（停轮询），落盘轨迹正常读出
  - 超时复盘：timeoutSec=20 + sleep 任务，超时节点弹窗带轨迹

🤖 Generated with [Claude Code](https://claude.com/claude-code)