### PR TITLE
feat(web): token 用量可视化——节点/运行级汇总 + cache 口径防误读 (#64)

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/run-results.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/run-results.js
@@ -307,6 +307,10 @@ function resultRow(run, node) {
     structuredOutput: run.structuredOutputs[node.id] || null,
     error: state.error || state.toleratedError || null,
     durationMs: state.durationMs ?? null,
+    // usage 四元组（input/output/cacheRead/cacheWrite）与节点模型标识原样透出：
+    // 供成果面板用量合计与 runs/export 离线对账；上游未回报时保持 undefined（≠ 0）
+    usage: state.usage || undefined,
+    model: state.model || undefined,
   };
 }
 
@@ -379,6 +383,23 @@ export function createRunResults(value, { apiBase = '/wf1/api', sessionId = '' }
       message: String(state.error || state.toleratedError),
     }] : []),
   ];
+  // 运行级用量合计：跨节点求和四元组；任一节点有 usage 即有合计，全部缺上报时保持
+  // undefined（前端显示「无记录」，绝不折算成 0）。口径：输入列是未命中缓存部分，
+  // 总输入读取 = input + cacheRead（cache 单价与全价不同，禁止直接乘单价算钱）。
+  const usageTotal = (() => {
+    let has = false;
+    const total = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+    for (const row of rows) {
+      const u = row.usage;
+      if (!u) continue;
+      has = true;
+      total.inputTokens += u.inputTokens || 0;
+      total.outputTokens += u.outputTokens || 0;
+      total.cacheReadTokens += u.cacheReadTokens || 0;
+      total.cacheWriteTokens += u.cacheWriteTokens || 0;
+    }
+    return has ? total : undefined;
+  })();
   return {
     runId: run.runId,
     status: run.status,
@@ -387,6 +408,7 @@ export function createRunResults(value, { apiBase = '/wf1/api', sessionId = '' }
     finishedAt: run.finishedAt,
     durationMs: run.durationMs,
     finalStatus,
+    usageTotal,
     outputResults,
     processResults,
     nodeTimeline: rows.map((row) => ({ ...row, text: processText(row) })),

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/run-results.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/run-results.test.mjs
@@ -86,7 +86,7 @@ await test('run results use output nodes as final results and include every runt
   const result = createRunResults(run);
   assert.deepEqual(Object.keys(result), [
     'runId', 'status', 'workflowName', 'startedAt', 'finishedAt', 'durationMs',
-    'finalStatus', 'outputResults', 'processResults', 'nodeTimeline', 'primaryResult',
+    'finalStatus', 'usageTotal', 'outputResults', 'processResults', 'nodeTimeline', 'primaryResult',
     'results', 'artifacts', 'finalArtifacts', 'processArtifacts', 'links', 'inputs', 'issues',
   ]);
   assert.equal(result.finalStatus, 'available');
@@ -101,6 +101,31 @@ await test('run results use output nodes as final results and include every runt
   assert.equal(Object.hasOwn(result.artifacts[0], 'snapshot'), false);
   assert.equal(Object.hasOwn(result.artifacts[0], 'relativePath'), false);
   assert.equal(result.links[0].url, 'https://example.test/doc');
+});
+
+await test('usage passes through per node and totals across nodes; absent stays undefined (≠ 0)', () => {
+  const run = normalizeRunDocument({
+    ...baseRun(),
+    nodeStates: {
+      ...baseRun().nodeStates,
+      agent: {
+        status: 'success', artifacts: ['report.md'],
+        model: 'provider-a:model-x',
+        usage: { inputTokens: 100, outputTokens: 40, cacheReadTokens: 900, cacheWriteTokens: 60 },
+      },
+      output: { status: 'success', writeback: { ok: true }, usage: { inputTokens: 5, outputTokens: 2 } },
+    },
+  });
+  const result = createRunResults(run);
+  const agentRow = result.results.find((row) => row.nodeId === 'agent');
+  assert.deepEqual(agentRow.usage, { inputTokens: 100, outputTokens: 40, cacheReadTokens: 900, cacheWriteTokens: 60 });
+  assert.equal(agentRow.model, 'provider-a:model-x');
+  // 运行级合计跨节点求和；input 节点无 usage 不贡献也不影响
+  assert.deepEqual(result.usageTotal, { inputTokens: 105, outputTokens: 42, cacheReadTokens: 900, cacheWriteTokens: 60 });
+  // 全部节点都无上报 → undefined（前端显示「无记录」，不得是 0 值对象）
+  const bare = createRunResults(normalizeRunDocument(baseRun()));
+  assert.equal(bare.usageTotal, undefined);
+  assert.equal(bare.results.every((row) => row.usage === undefined), true);
 });
 
 await test('artifact URLs inherit sessionId so scoped routes can resolve the workspace', () => {

--- a/web/src/NodeDetailModal.jsx
+++ b/web/src/NodeDetailModal.jsx
@@ -8,6 +8,7 @@ import { Modal } from './ui.jsx';
 import { apiUrl } from './api.js';
 import { ArtifactLinks } from './ArtifactPreview.jsx';
 import { nextPollDelayMs, shouldAutoSelectTrace } from './node-detail-polling.js';
+import { UsageMeta } from './UsageMeta.jsx';
 
 const ENTRY_ICON = { input: '↳', inject: '⊕', assistant: '✦', tool: '🔧', 'turn-end': '↩' };
 const ENTRY_LABEL = { input: '输入', inject: '注入上下文', assistant: '助手', tool: '工具调用', 'turn-end': '轮次结束' };
@@ -41,10 +42,11 @@ function TraceEntry({ en, i }) {
         <span className="trace-tag">{ENTRY_ICON.assistant} {ENTRY_LABEL.assistant}</span>
         <pre className="trace-text">{en.text}</pre>
         {en.usage && (
-          <span className="trace-usage">
-            {en.usage.outputTokens ? `${en.usage.outputTokens} tok` : ''}
-            {en.usage.inputTokens ? ` + ${en.usage.inputTokens} in` : ''}
-            {en.usage.cacheReadTokens ? ` (${en.usage.cacheReadTokens} cache)` : ''}
+          <span className="trace-usage" title="↑输出 ↓输入（未命中缓存部分，总输入读取 = 输入 + 缓存读）⇦缓存读 ⇨缓存写。缓存读写计价与全价不同，请勿按 token 数直接估算账单金额。">
+            {en.usage.outputTokens ? `↑${en.usage.outputTokens}` : ''}
+            {en.usage.inputTokens ? ` ↓${en.usage.inputTokens}` : ''}
+            {en.usage.cacheReadTokens ? ` ⇦${en.usage.cacheReadTokens}` : ''}
+            {en.usage.cacheWriteTokens ? ` ⇨${en.usage.cacheWriteTokens}` : ''}
           </span>
         )}
       </div>
@@ -132,6 +134,7 @@ export function NodeDetailModal({ runId, nodeId, onClose }) {
             {data.state?.turns != null && <span>{data.state.turns} 轮</span>}
             {toolCount > 0 && <span>{toolCount} 次工具调用</span>}
             {data.state?.model && <span>{data.state.model}</span>}
+            <UsageMeta usage={data.state?.usage} />
             {data.state?.toleratedError && <span className="detail-tol">失败后继续：{data.state.toleratedError}</span>}
           </div>
 

--- a/web/src/ResultPanel.jsx
+++ b/web/src/ResultPanel.jsx
@@ -14,6 +14,7 @@ import {
 } from './result-adapter.js';
 import { deriveRunViewState, RESULT_TABS } from './run-view-state.js';
 import ResultViewer, { ProcessArtifacts } from './ResultViewer.jsx';
+import { UsageMeta } from './UsageMeta.jsx';
 import './result-panel.css';
 
 function formatTime(value) {
@@ -82,10 +83,11 @@ function ProcessStep({ event, index, runId, onFocusNode, onOpenNodeDetail }) {
           </button>
           <span className={`result-step-pill result-step-pill-${meta.tone}`}>{meta.label}</span>
         </div>
-        {(startClock || duration) && (
+        {(startClock || duration || event.usage) && (
           <div className="result-step-meta">
             {startClock && <span><Clock3 size={11} />开始 {startClock}</span>}
             {duration && <span className={event.status === 'running' ? 'result-step-elapsed' : ''}><Timer size={11} />{event.status === 'running' ? `已运行 ${duration}` : `耗时 ${duration}`}</span>}
+            {event.usage && <UsageMeta usage={event.usage} />}
           </div>
         )}
         {event.error && <p className="result-step-text">{event.error}</p>}
@@ -267,6 +269,11 @@ export function ResultPanel({
           <span className={`result-status result-status-${viewState.status.tone}`}>{viewState.status.label}</span>
           <strong>{model.workflowName}</strong>
           {model.startedAt && <span className="result-run-time"><Clock3 size={12} />{formatTime(model.startedAt)}</span>}
+          {model.runId && model.usageTotal && (
+            <span className="result-run-usage" title="整次运行跨节点用量合计。输入为未命中缓存部分，总输入读取 = 输入 + 缓存读；缓存读写计价与全价不同，请勿按 token 数直接估算账单金额。">
+              <UsageMeta usage={model.usageTotal} title="整次运行跨节点用量合计。输入为未命中缓存部分；总输入读取 = 输入 + 缓存读。缓存读写计价与全价不同，请勿按 token 数直接估算账单金额。" />
+            </span>
+          )}
         </div>
         <div className="result-head-actions">
           <button className="btn-icon" title="刷新成果" aria-label="刷新成果" onClick={refresh} disabled={!runId || loading}><RefreshCw size={15} className={loading ? 'result-spin' : ''} /></button>

--- a/web/src/UsageMeta.jsx
+++ b/web/src/UsageMeta.jsx
@@ -1,0 +1,21 @@
+// 用量展示组件（#64）：节点详情 meta 区 / 成果面板运行级合计共用。
+// 口径防误读（issue 核心诉求）：
+// - 输入列是「未命中缓存部分」，总输入读取 = input + cacheRead；
+// - cacheRead/cacheWrite 计价与全价不同（通常 ~0.1x / ~1.25x），不得拿 token 数直接乘单价算钱；
+// - 上游未回报 usage（部分流式调用被砍/provider 未回）时显示「用量无记录」，绝不渲染成 0。
+import { formatTokens } from './usage-format.js';
+
+export function UsageMeta({ usage, title }) {
+  if (!usage || typeof usage !== 'object') {
+    return <span className="usage-meta usage-none" title="本次运行未收到模型侧用量回报（可能是流式调用未回传）">用量无记录</span>;
+  }
+  const t = title || '输入为未命中缓存部分；总输入读取 = 输入 + 缓存读。缓存读写计价与全价不同，请勿按 token 数直接估算账单金额。';
+  return (
+    <span className="usage-meta" title={t}>
+      <span className="usage-out" title="模型输出 token">↑{formatTokens(usage.outputTokens)}</span>
+      <span className="usage-in" title="输入（未命中缓存部分）">↓{formatTokens(usage.inputTokens)}</span>
+      {usage.cacheReadTokens ? <span className="usage-cache" title="缓存读（总输入读取 = 输入 + 缓存读）">⇦{formatTokens(usage.cacheReadTokens)}</span> : null}
+      {usage.cacheWriteTokens ? <span className="usage-cache" title="缓存写">⇨{formatTokens(usage.cacheWriteTokens)}</span> : null}
+    </span>
+  );
+}

--- a/web/src/result-adapter.js
+++ b/web/src/result-adapter.js
@@ -195,6 +195,8 @@ function normalizeResultRow(row, nodes, runDetail) {
     durationMs: first(value.durationMs, state.durationMs),
     startedAt: first(value.startedAt, state.startedAt),
     legacyInferred: Boolean(value.legacyInferred),
+    usage: first(value.usage, state.usage) || null,
+    model: first(value.model, state.model) || null,
   };
 }
 
@@ -218,6 +220,32 @@ function timelineText(row) {
   if (row.status === 'skipped') return '本次流程未执行该节点';
   if (row.status === 'canceled') return '节点已取消';
   return `节点状态：${row.status}`;
+}
+
+// usage 四元组求和：输入列是未命中缓存部分（总输入读取 = input + cacheRead，
+// cache 单价与全价不同，不得直接乘单价算钱）；无任一 usage 时返回 null（≠ 0）
+export function sumUsageTotal(rowsOrTotal) {
+  if (!Array.isArray(rowsOrTotal)) {
+    const total = asObject(rowsOrTotal);
+    return total.inputTokens !== undefined ? {
+      inputTokens: Number(total.inputTokens) || 0,
+      outputTokens: Number(total.outputTokens) || 0,
+      cacheReadTokens: Number(total.cacheReadTokens) || 0,
+      cacheWriteTokens: Number(total.cacheWriteTokens) || 0,
+    } : null;
+  }
+  let has = false;
+  const total = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+  for (const row of rowsOrTotal) {
+    const u = asObject(row?.usage ?? row);
+    if (u.inputTokens === undefined) continue;
+    has = true;
+    total.inputTokens += Number(u.inputTokens) || 0;
+    total.outputTokens += Number(u.outputTokens) || 0;
+    total.cacheReadTokens += Number(u.cacheReadTokens) || 0;
+    total.cacheWriteTokens += Number(u.cacheWriteTokens) || 0;
+  }
+  return has ? total : null;
 }
 
 // 面向普通用户的耗时文案：毫秒不直接暴露，统一换算成秒/分
@@ -369,6 +397,9 @@ export function adaptRunResults(payload, context = {}) {
     durationMs: first(source.durationMs, source.run?.durationMs, runDetail.durationMs),
     summary: textOf(first(source.summary, result.summary, source.description, result.description)),
     finalStatus,
+    // 运行级用量合计：后端 usageTotal 优先，旧响应无此字段时从节点行兜底求和；
+    // 全部节点都无 usage 时为 null（渲染「无记录」，不是 0）
+    usageTotal: sumUsageTotal(result.usageTotal || source.usageTotal) || sumUsageTotal(nodeTimeline) || null,
     outputResults: effectiveOutputs,
     processResults,
     coreText,

--- a/web/src/result-adapter.test.mjs
+++ b/web/src/result-adapter.test.mjs
@@ -109,6 +109,35 @@ assert.equal(backendShape.finalFiles[0].url, '/artifact');
 assert.equal(backendShape.processFiles[0].url, '/debug');
 assert.equal(backendShape.input, '后端输入');
 
+// usage 透传与合计（#64）：后端 usageTotal 优先；节点行 usage 跟随；缺上报 = null（≠ 0）
+const withUsage = adaptRunResults({
+  runId: 'run-usage',
+  status: 'success',
+  finalStatus: 'available',
+  usageTotal: { inputTokens: 105, outputTokens: 42, cacheReadTokens: 900, cacheWriteTokens: 60 },
+  outputResults: [{ nodeId: 'output', nodeLabel: '最终交付', nodeType: 'output', status: 'success', output: 'ok' }],
+  nodeTimeline: [
+    { nodeId: 'agent', nodeLabel: '写报告', nodeType: 'agent', status: 'success', usage: { inputTokens: 100, outputTokens: 40, cacheReadTokens: 900, cacheWriteTokens: 60 }, model: 'p:m' },
+  ],
+}, { runDetail });
+assert.deepEqual(withUsage.usageTotal, { inputTokens: 105, outputTokens: 42, cacheReadTokens: 900, cacheWriteTokens: 60 });
+assert.deepEqual(withUsage.nodeTimeline[0].usage, { inputTokens: 100, outputTokens: 40, cacheReadTokens: 900, cacheWriteTokens: 60 });
+assert.equal(withUsage.nodeTimeline[0].model, 'p:m');
+// 旧后端响应无 usageTotal：从节点行兜底求和
+const legacyRows = adaptRunResults({
+  runId: 'run-legacy-usage',
+  status: 'success',
+  finalStatus: 'available',
+  outputResults: [{ nodeId: 'output', nodeLabel: '最终交付', nodeType: 'output', status: 'success', output: 'ok' }],
+  nodeTimeline: [
+    { nodeId: 'agent', nodeLabel: '写报告', nodeType: 'agent', status: 'success', usage: { inputTokens: 10, outputTokens: 4 } },
+    { nodeId: 'output', nodeLabel: '最终交付', nodeType: 'output', status: 'success', usage: { inputTokens: 1, outputTokens: 2, cacheReadTokens: 3 } },
+  ],
+}, { runDetail });
+assert.deepEqual(legacyRows.usageTotal, { inputTokens: 11, outputTokens: 6, cacheReadTokens: 3, cacheWriteTokens: 0 });
+// 全部节点都无 usage：null，前端渲染「无记录」
+assert.equal(fallback.usageTotal, null);
+
 const failedOutput = adaptRunResults({}, {
   runDetail: {
     ...runDetail,

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1522,6 +1522,13 @@ body {
   padding: 2px 0; letter-spacing: .06em;
 }
 .trace-usage { font-size: 11px; color: var(--fg-faint); margin-left: auto; }
+/* 用量分列展示（#64）：↑输出 ↓输入(未缓存) ⇦缓存读 ⇨缓存写；口径注释在 title */
+.usage-meta { display: inline-flex; align-items: center; gap: 6px; font-variant-numeric: tabular-nums; cursor: help; }
+.usage-meta .usage-out { color: var(--type-agent, #8B5CF6); }
+.usage-meta .usage-in { color: var(--fg-faint); }
+.usage-meta .usage-cache { color: var(--fg-faint); opacity: .85; }
+.usage-meta.usage-none { cursor: default; opacity: .7; }
+.result-run-usage { display: inline-flex; align-items: center; margin-left: 4px; }
 .trace-tool-head {
   display: flex; align-items: center; gap: 8px; width: 100%;
   padding: 5px 8px;

--- a/web/src/usage-format.js
+++ b/web/src/usage-format.js
@@ -1,0 +1,8 @@
+// token 数格式化：千位以上用 k/m 简写，避免 meta 区被 7 位数撑爆。
+export function formatTokens(n) {
+  const v = Number(n) || 0;
+  if (v >= 1_000_000) return `${(v / 1_000_000).toFixed(1)}m`;
+  if (v >= 10_000) return `${(v / 1_000).toFixed(0)}k`;
+  if (v >= 1_000) return `${(v / 1_000).toFixed(1)}k`;
+  return String(v);
+}


### PR DESCRIPTION
fix #64

## 方案

严格只动呈现层与字段透出，采集链（`sumUsage` / firstSeq 隔离）一字不改。

**后端**（`run-results.js`）：
- `resultRow` 透出 `usage` 四元组与 `model`（`nodeTimeline` / `results` / **`runs/export` 的 run-results.json** 均携带，issue 第 4 点的离线对账由此闭环）
- `createRunResults` 新增 `usageTotal`：跨节点求和四元组；任一节点有上报即有合计，全部缺上报保持 `undefined`

**前端**：
- 新组件 `UsageMeta`：分列 `↑输出 ↓输入(未缓存) ⇦缓存读 ⇨缓存写`，hover tooltip 全文注明口径——「输入为未命中缓存部分；总输入读取 = 输入 + 缓存读。缓存读写计价与全价不同，请勿按 token 数直接估算账单金额」
- 接入三处：节点详情弹窗 meta 区（issue 第 1 点）、成果面板头部运行级合计（第 2 点）、过程 tab 节点行
- trace 逐条助手消息的用量从 ``X tok + Y in (Z cache)``（issue 点名的易误读格式）改为同款箭头口径 + tooltip
- 上游缺 usage 显示「用量无记录」，绝不渲染成 0（约束 2）；不做成本折算列（约束 3，按 issue 允许直接砍掉）
- 大数 k/m 简写，7 位数不撑爆 meta 区

## 验证

- 单测：`run-results.test.mjs` 新增 usage 透传/合计/undefined 三态用例（15 全绿）；`result-adapter.test.mjs` 新增合计直传、旧响应节点行兜底求和、全缺 null 三态
- 全量：orchestrator 17 套、web 14 套、`build-web.sh` 双构建通过
- **真机**（scratch profile + Playwright，worflow 工作区 8/25 工程手册 41 节点真实运行）：
  - 运行级合计：头部 `↑781k ↓2.3m ⇦27.5m` + tooltip 口径全文
  - 过程节点行：A1 `↑1.9k ↓20k ⇦55k` … A11 `↑102k ↓199k ⇦2.2m`；非 agent 节点（输入/判定）正确无用量
  - 节点详情 meta：`↑1.9k ↓20k ⇦55k` + `deepseek-official:deepseek-v4-flash` 模型标识
  - trace 助手行：`↑228 ↓3793 ⇦14336` + 口径 tooltip
