### PR TITLE
build(one): 准备 0.6.0 发版

### DIFF
--- a/dsh-plugins/dsh-ccpg-brand/package.json
+++ b/dsh-plugins/dsh-ccpg-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-brand",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-one",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.5.1",
-    "dsh-ccpg-document-preview": "0.5.1",
-    "dsh-ccpg-larkauth": "0.5.1",
-    "dsh-ccpg-llm-guard": "0.5.1",
-    "dsh-ccpg-orchestrator": "0.5.1",
-    "dsh-ccpg-tools": "0.5.1",
-    "dsh-ccpg-web": "0.5.1"
+    "dsh-ccpg-canvasui": "0.6.0",
+    "dsh-ccpg-document-preview": "0.6.0",
+    "dsh-ccpg-larkauth": "0.6.0",
+    "dsh-ccpg-llm-guard": "0.6.0",
+    "dsh-ccpg-orchestrator": "0.6.0",
+    "dsh-ccpg-tools": "0.6.0",
+    "dsh-ccpg-web": "0.6.0"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
@@ -274,7 +274,7 @@ console.log('system-upgrade tests:');
       assert.match(plan.actions[0].title, /更新/);
       const calls = [];
       const realFetch = globalThis.fetch;
-      globalThis.fetch = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '0.5.1' } }) });
+      globalThis.fetch = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '0.6.0' } }) });
       try {
         await executePlan(plan, {
           dshBin: '/fake/dsh',
@@ -285,7 +285,7 @@ console.log('system-upgrade tests:');
       }
       const up = calls.find((c) => c[4] === 'up');
       assert.ok(up, '在装用户用 up 原地更新');
-      assert.equal(up[5], `${PACKAGE}@0.5.1`);
+      assert.equal(up[5], `${PACKAGE}@0.6.0`);
       assert.ok(!calls.some((c) => c[4] === 'remove'), 'up 路径不 remove 任何包');
       assert.ok(calls.some((c) => c[4] === 'add' && String(c[5] || '').startsWith(SIDEBAR)), '纯净安装兜底：依赖表无 sidebar 时补 add 注册 bundle');
     } finally {

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
### 背景

v0.5.1（npm latest）发布后 main 又合了四个用户可见改动，均未发版：

- #78 定时任务 per-schedule 时区支持（#58）
- #80 运行中节点详情弹窗实时显示执行轨迹（#52）
- #81 运行历史抽屉按画布工作流隔离（#79）
- #82 token 用量可视化：节点/运行级汇总 + cache 口径防误读（#64）

3 feat + 1 fix → **0.6.0**（minor）。

### 方案

- 8 个插件 `package.json` 版本 0.5.1 → 0.6.0，`dsh-ccpg-one` 内部依赖表同步
- 升级器测试的 npm latest mock 0.5.1 → 0.6.0（保持 latest 领先已装的语义；fixture 已装 0.5.0 不变）

### 验证

- 全量单测绿（升级器 12 例含改 mock 的 up 路径）
- `build-web.sh` 双构建通过
- `assemble-one.sh` + `publish-npm.sh --dry-run` 通过：dsh-harness-one@0.6.0，117 files，完整性清单全过

合并后打 tag `v0.6.0` 触发 release.yml（npm 发布 + GitHub Release 离线包）。