### PR TITLE
build(one): 准备 0.6.1 发版

### DIFF
--- a/dsh-plugins/dsh-ccpg-brand/package.json
+++ b/dsh-plugins/dsh-ccpg-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-brand",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-one",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.6.0",
-    "dsh-ccpg-document-preview": "0.6.0",
-    "dsh-ccpg-larkauth": "0.6.0",
-    "dsh-ccpg-llm-guard": "0.6.0",
-    "dsh-ccpg-orchestrator": "0.6.0",
-    "dsh-ccpg-tools": "0.6.0",
-    "dsh-ccpg-web": "0.6.0"
+    "dsh-ccpg-canvasui": "0.6.1",
+    "dsh-ccpg-document-preview": "0.6.1",
+    "dsh-ccpg-larkauth": "0.6.1",
+    "dsh-ccpg-llm-guard": "0.6.1",
+    "dsh-ccpg-orchestrator": "0.6.1",
+    "dsh-ccpg-tools": "0.6.1",
+    "dsh-ccpg-web": "0.6.1"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
@@ -274,7 +274,7 @@ console.log('system-upgrade tests:');
       assert.match(plan.actions[0].title, /更新/);
       const calls = [];
       const realFetch = globalThis.fetch;
-      globalThis.fetch = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '0.6.0' } }) });
+      globalThis.fetch = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '0.6.1' } }) });
       try {
         await executePlan(plan, {
           dshBin: '/fake/dsh',
@@ -285,7 +285,7 @@ console.log('system-upgrade tests:');
       }
       const up = calls.find((c) => c[4] === 'up');
       assert.ok(up, '在装用户用 up 原地更新');
-      assert.equal(up[5], `${PACKAGE}@0.6.0`);
+      assert.equal(up[5], `${PACKAGE}@0.6.1`);
       assert.ok(!calls.some((c) => c[4] === 'remove'), 'up 路径不 remove 任何包');
       assert.ok(calls.some((c) => c[4] === 'add' && String(c[5] || '').startsWith(SIDEBAR)), '纯净安装兜底：依赖表无 sidebar 时补 add 注册 bundle');
     } finally {

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 背景

v0.6.0 发版（#83）之后 main 又合入一个用户可见改动：定时任务停机错过触发点的记录与补偿（#57/#84）。线上 npm 0.6.0 不含 misfire，需要发 0.6.1 把它带给用户。

## 方案

- 源码树 8 包 package.json 0.6.0 → 0.6.1，`dsh-ccpg-one` 依赖表同步
- 升级器测试 npm latest mock 0.6.0 → 0.6.1（保持 latest 领先已装语义）
- npm 渠道仍只发单包 `dsh-harness-one`（版本取自 dsh-ccpg-one）；老 8 包维持 deprecate
- 版本取 0.6.1（patch）：本次仅含 misfire 一个 feat，保持「一个发版窗口一个 minor」节奏

## 验证

- 全量单测绿（`npm test`）
- `build-web.sh` 双构建通过
- `assemble-one.sh` + `publish-npm.sh --dry-run` 通过（dsh-harness-one@0.6.1，tarball 完整性 + 安装 smoke 无 SDK 泄漏）

## 后续

合入后打 `v0.6.1` tag 触发 release.yml（pack → boot-smoke → npm 单包 → asset），然后在隔离环境实测设置面板一键升级 0.6.0 → 0.6.1。