### PR TITLE
fix(orchestrator): check-update 改查 dsh-harness-one（0.5+ 用户检查更新失灵）

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -50,7 +50,7 @@ import {
 } from './agent-schema.js';
 import { FeishuClient } from './feishu.js';
 import { createFeishuNotificationChannel } from './notification-feishu.js';
-import { collectInstallReport, compareSemver, executePlan, planUpgrade } from './system-upgrade.js';
+import { collectInstallReport, compareSemver, executePlan, planUpgrade, PACKAGE as UPGRADE_PACKAGE } from './system-upgrade.js';
 import { NotificationChannelRegistry, WorkflowNotificationManager } from './notifications.js';
 import { listFeishuCreds, addFeishuCred, removeFeishuCred, setDefaultFeishuCred, getFeishuCredOrEnv } from './credentials.js';
 import { Orchestrator, lintGraph, getKind } from './engine.js';
@@ -2217,8 +2217,11 @@ export function apply(ctx, config) {
     try {
       const ctrl = new AbortController();
       const timer = setTimeout(() => ctrl.abort(), 8000);
-      const r = await fetch('https://registry.npmjs.org/dsh-ccpg-one', {
-        headers: { accept: 'application/vnd.npm.install-v1+json', 'user-agent': 'dsh-ccpg-one-upgrade-check' },
+      // 发版渠道自 0.5.0 起是单包 dsh-harness-one（老包 latest 永钉 0.4.1，
+      // 查老包会让所有 0.5+ 用户永远「已是最新」）；与 system-upgrade 的
+      // latestVersion() 同源，保证检查口径 = 实际升级口径。
+      const r = await fetch(`https://registry.npmjs.org/${UPGRADE_PACKAGE}`, {
+        headers: { accept: 'application/vnd.npm.install-v1+json', 'user-agent': 'dsh-harness-one-upgrade-check' },
         signal: ctrl.signal,
       });
       clearTimeout(timer);


### PR DESCRIPTION
## 背景

v0.5.0 单包化时漏改 `/wf1/api/system/check-update`：它仍查废弃老包 `dsh-ccpg-one`（npm latest 永钉 0.4.1）。所有 0.5.0+ 用户（含 0.6.0/0.6.1）点「检查更新」永远显示「已是最新」，实际执行器 `latestVersion()` 查的是 `dsh-harness-one`，升级能力正常但入口失灵——今天发 0.6.1 后实测升级流程时发现。

## 方案

复用 `system-upgrade.js` 导出的 `PACKAGE`（dsh-harness-one），检查口径与升级执行口径同源；顺手把 user-agent 也改成新包名。

## 验证

- system-upgrade 12 例 + orchestrator 全部 17 套测试绿
- 端点无单测直测（fetch 外部 registry），行为在隔离环境 UI 实测中覆盖

## 后续

合入后随下个版本发布；0.6.1 用户升级到该版本前，检查更新仍不提示（但升级按钮路径完好——本 PR 合入后将按 0.6.2 发出）。