### PR TITLE
fix(canvasui): 版本中心残留旧包名——npx 命令与聚合徽标改认 dsh-harness-one

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -966,7 +966,8 @@ window.__ModuleLoader__.load({
     }
 
     function ProfileBlock(profile) {
-      var agg = profile.packages.find(function (p) { return p.name === "dsh-ccpg-one"; }) || null;
+      var agg = profile.packages.find(function (p) { return p.name === "dsh-harness-one"; })
+        || profile.packages.find(function (p) { return p.name === "dsh-ccpg-one"; }) || null;
       return react.createElement(
         "div",
         {
@@ -1239,7 +1240,7 @@ window.__ModuleLoader__.load({
               paddingTop: "8px",
             },
           },
-          "你的工作流、运行记录、定时任务和飞书登录都不会被升级改动，无需备份迁移。偏好转命令行的话：npm 安装的用户重跑一次 npx dsh-ccpg-one 效果等同。",
+          "你的工作流、运行记录、定时任务和飞书登录都不会被升级改动，无需备份迁移。偏好转命令行的话：npm 安装的用户重跑一次 npx dsh-harness-one 效果等同。",
         ),
       );
     }


### PR DESCRIPTION
## 背景

设置页「Workflow One 版本中心」数据安全脚注仍在引导 npm 用户执行 `npx dsh-ccpg-one`。v0.5.0 起发版渠道合并为单包 `dsh-harness-one`，旧包已停更（latest 永钉 0.4.1），照文案执行会装回死包。

## 方案

改 `dsh-ccpg-canvasui/src/client.js` 两处：

1. **脚注文案**：`npx dsh-ccpg-one` → `npx dsh-harness-one`（与装配包 bin 名一致）
2. **顺带修真 bug**：`ProfileBlock` 的「聚合安装」徽标只探测 `dsh-ccpg-one`，0.5+ 单包用户该标签永不显示。改为优先认 `dsh-harness-one`，回退 `dsh-ccpg-one`（迁移窗口内老安装仍可见徽标）

后端 `check-update` 的 `UPGRADE_PACKAGE` 已是新包，无需动。

## 验证

- `build-canvasui.sh` bundle 重建 ✓（1440 行）
- `node test/client.test.mjs` passed ✓
- `assemble-one.sh` 装配校验通过 ✓（dsh-harness-one@0.6.1）
- 改动仅 1 个源码文件（bundle/装配目录均为 gitignore 产物）