### PR TITLE
docs(readme): 收录徽标改链 agents-workflows 分册

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DeepSeek-Harness-4D6BFE?labelColor=0F0F1A" alt="DeepSeek Harness plugin"></a>
   <a href="https://zcode.z.ai/cn"><img src="https://img.shields.io/badge/Built%20with-ZCode-14B8A6?labelColor=0F0F1A" alt="Built with ZCode"></a>
-  <a href="https://github.com/bruc3van/awesome-dsh-plugin/blob/main/catalog/media-vision.md"><img src="https://img.shields.io/badge/listed%20in-awesome--dsh--plugin-2563EB?labelColor=0F0F1A" alt="Listed in awesome-dsh-plugin"></a>
+  <a href="https://github.com/bruc3van/awesome-dsh-plugin/blob/main/catalog/agents-workflows.md"><img src="https://img.shields.io/badge/listed%20in-awesome--dsh--plugin-2563EB?labelColor=0F0F1A" alt="Listed in awesome-dsh-plugin"></a>
   <a href="https://www.npmjs.com/package/dsh-harness-one"><img src="https://img.shields.io/npm/v/dsh-harness-one" alt="npm version"></a>
   <a href="https://github.com/chumingjun/dsh-harness-one/actions/workflows/ci.yml"><img src="https://github.com/chumingjun/dsh-harness-one/actions/workflows/ci.yml/badge.svg" alt="CI status"></a>
   <a href="https://github.com/chumingjun/dsh-harness-one/releases/latest"><img src="https://img.shields.io/github/v/release/chumingjun/dsh-harness-one" alt="latest release"></a>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <a href="https://github.com/deepseek-ai/deepseek-harness"><img src="https://img.shields.io/badge/DeepSeek-Harness-4D6BFE?labelColor=0F0F1A" alt="DeepSeek Harness 插件"></a>
   <a href="https://zcode.z.ai/cn"><img src="https://img.shields.io/badge/Built%20with-ZCode-14B8A6?labelColor=0F0F1A" alt="使用 ZCode 开发"></a>
-  <a href="https://github.com/bruc3van/awesome-dsh-plugin/blob/main/catalog/media-vision.md"><img src="https://img.shields.io/badge/listed%20in-awesome--dsh--plugin-2563EB?labelColor=0F0F1A" alt="已被 awesome-dsh-plugin 收录"></a>
+  <a href="https://github.com/bruc3van/awesome-dsh-plugin/blob/main/catalog/agents-workflows.md"><img src="https://img.shields.io/badge/listed%20in-awesome--dsh--plugin-2563EB?labelColor=0F0F1A" alt="已被 awesome-dsh-plugin 收录"></a>
   <a href="https://www.npmjs.com/package/dsh-harness-one"><img src="https://img.shields.io/npm/v/dsh-harness-one" alt="npm 版本"></a>
   <a href="https://github.com/chumingjun/dsh-harness-one/actions/workflows/ci.yml"><img src="https://github.com/chumingjun/dsh-harness-one/actions/workflows/ci.yml/badge.svg" alt="CI 状态"></a>
   <a href="https://github.com/chumingjun/dsh-harness-one/releases/latest"><img src="https://img.shields.io/github/v/release/chumingjun/dsh-harness-one" alt="最新版本"></a>


### PR DESCRIPTION
## 背景

bruc3van 导览站的分类纠正 PR（bruc3van/awesome-dsh-plugin#112）已于 2026-08-29 合并：我们被从 `catalog/media-vision.md` 重新归档到 `catalog/agents-workflows.md`（描述里的 "Visual" 指 DAG 可视化画布，非图像视觉能力）。

## 改动

README.md / README.en.md 第 14 行「已被 awesome-dsh-plugin 收录」徽标的链接从 `media-vision.md` 分册改为 `agents-workflows.md` 分册，与新分类保持一致。

## 验证

- 新链接可达：`https://raw.githubusercontent.com/bruc3van/awesome-dsh-plugin/main/catalog/agents-workflows.md` 返回 200，且包含我们的条目
- 旧分册已无我们条目（grep 计数 0）