### PR TITLE
fix(orchestrator): 升级器 maxBuffer 64MB + ✗ 日志截断（实机升级误判修复）

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/system-upgrade.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/system-upgrade.js
@@ -247,7 +247,9 @@ export function compareSemver(a, b) {
 
 function run(cmd, args, cwd) {
   return new Promise((res) => {
-    execFile(cmd, args, { cwd, encoding: 'utf8', timeout: 10 * 60_000 }, (err, stdout, stderr) => {
+    // maxBuffer 必须远超默认 1MB：build-web.sh 的 vite/npm 输出轻松超限，
+    // 超限会把「构建成功」误判成失败（exit 0 也拿不到）。
+    execFile(cmd, args, { cwd, encoding: 'utf8', timeout: 10 * 60_000, maxBuffer: 64 * 1024 * 1024 }, (err, stdout, stderr) => {
       res({ ok: !err, out: `${stdout || ''}${stderr || ''}`.trim(), err: err ? String(err.message || err) : null });
     });
   });
@@ -255,6 +257,13 @@ function run(cmd, args, cwd) {
 
 async function sh(script, cwd) {
   return run('/bin/sh', ['-c', script], cwd);
+}
+
+// ✗ 日志只留关键信息（首段），整段构建输出不进 UI 横幅。
+function clip(text) {
+  const s = String(text || '').trim();
+  if (!s) return '（无输出）';
+  return s.length > 300 ? s.slice(0, 300) + '…' : s;
 }
 
 // 顺序执行计划；每步产出一行日志。失败不中断整体（后续步骤按各自前置再判），
@@ -278,18 +287,18 @@ export async function executePlan(plan, { dshBin, runCmd = run, runSh = sh } = {
         continue;
       }
       const pulled = await runCmd('git', ['pull', '--ff-only'], action.root);
-      push(pulled.ok ? `  ${pulled.out.split('\n').pop() || '已是最新'}` : `  ✗ pull 失败：${pulled.out || pulled.err}`);
+      push(pulled.ok ? `  ${pulled.out.split('\n').pop() || '已是最新'}` : `  ✗ pull 失败：${clip(pulled.out || pulled.err)}`);
       if (!pulled.ok) continue;
       const webBuild = await runSh('./build-web.sh', action.pluginsDir);
-      if (!webBuild.ok) push(`  ✗ build-web.sh：${webBuild.out}`);
+      if (!webBuild.ok) push(`  ✗ build-web.sh：${clip(webBuild.err || webBuild.out)}`);
       else push('  ✓ 画布双构建完成');
       const canvasBuild = await runSh('./build-canvasui.sh --check || ./build-canvasui.sh', action.pluginsDir);
-      push(canvasBuild.ok ? '  ✓ canvasui bundle 就绪' : `  ✗ canvasui bundle：${canvasBuild.out}`);
+      push(canvasBuild.ok ? '  ✓ canvasui bundle 就绪' : `  ✗ canvasui bundle：${clip(canvasBuild.err || canvasBuild.out)}`);
       const orchDeps = await runSh(
         '[ -d dsh-ccpg-orchestrator/node_modules/quickjs-emscripten ] || npm install --no-audit --no-fund --prefix dsh-ccpg-orchestrator',
         action.pluginsDir,
       );
-      if (!orchDeps.ok) push(`  ✗ orchestrator 依赖：${orchDeps.out}`);
+      if (!orchDeps.ok) push(`  ✗ orchestrator 依赖：${clip(orchDeps.err || orchDeps.out)}`);
       else push('  ✓ orchestrator 依赖就绪');
     } else if (action.type === 'npm-migrate' || action.type === 'npm-reinstall') {
       const dsh = dshBin || await resolveDshBin(runCmd);
@@ -311,7 +320,7 @@ export async function executePlan(plan, { dshBin, runCmd = run, runSh = sh } = {
         // 装新在前：失败则老包仍在位，可整段重试。
         const add = await runCmd(dsh, ['plugin', '--profile', action.profile, 'add', `${PACKAGE}@${latest}`]);
         if (!add.ok) {
-          push(`  ✗ 安装 ${PACKAGE} 失败：${add.out}（旧安装未动，可重试）`);
+          push(`  ✗ 安装 ${PACKAGE} 失败：${clip(add.out)}（旧安装未动，可重试）`);
           continue;
         }
         push(`  ✓ ${PACKAGE}@${latest} 已安装`);
@@ -324,7 +333,7 @@ export async function executePlan(plan, { dshBin, runCmd = run, runSh = sh } = {
         for (const legacy of LEGACY_PACKAGES) {
           if (!readDep(action.profilePath, legacy)) continue;
           const rm = await runCmd(dsh, ['plugin', '--profile', action.profile, 'remove', legacy]);
-          push(rm.ok ? `  ✓ 已移除旧包 ${legacy}` : `  ✗ 移除 ${legacy} 失败：${rm.out}（可手动 remove）`);
+          push(rm.ok ? `  ✓ 已移除旧包 ${legacy}` : `  ✗ 移除 ${legacy} 失败：${clip(rm.out)}（可手动 remove）`);
         }
         push(`  ✓ 迁移完成：${PACKAGE}@${latest}`);
       } else {
@@ -335,7 +344,7 @@ export async function executePlan(plan, { dshBin, runCmd = run, runSh = sh } = {
         const currentSpec = readDep(action.profilePath, PACKAGE);
         const verb = currentSpec ? 'up' : 'add';
         const up = await runCmd(dsh, ['plugin', '--profile', action.profile, verb, `${PACKAGE}@${latest}`]);
-        push(up.ok ? `  ✓ ${PACKAGE} → ${latest}（${verb === 'up' ? '原地更新' : '重装落表'}）` : `  ✗ ${verb} 失败：${up.out}`);
+        push(up.ok ? `  ✓ ${PACKAGE} → ${latest}（${verb === 'up' ? '原地更新' : '重装落表'}）` : `  ✗ ${verb} 失败：${clip(up.out)}`);
       }
       // sidebar bundle 注册兜底：dsh reconcile 只认 profile 直接依赖，sidebar 作为
       // 本包传递依赖即使解析到实体也不进 bundles 层——纯净安装（依赖表只有本包）


### PR DESCRIPTION
## 背景
v0.7.0 发版后实机验证「设置 → Workflow One → 一键升级」：升级链路跑到源码重建的 build-web.sh 步骤，UI 报 ✗ 失败——但构建实际成功（手动复跑 exit 0，产物齐全）。

## 根因
`run()` 用 `execFile` 默认 **1MB maxBuffer**；build-web.sh 的 vite + npm 输出（含 document-preview 双份 chunk 清单 + install-scripts 警告）超限。maxBuffer 超限触发 err，stdout 一并丢弃——构建明明 exit 0 也被判失败。

## 修复
- `maxBuffer: 64MB`
- 全部 ✗ 日志行加 `clip()`（首 300 字符），整段构建输出不再塞进 UI 横幅

## 实机另证（不改代码）
desktop profile（npm 渠道）首次 `pnpm up` 撞 `minimumReleaseAge` 供应链策略：依赖 `dsh-better-sidebar@0.17.1` 刚发版 1.2h，距策略窗口不足。属外部策略瞬态，时间窗过后重试即过（已实测 ^0.7.0 落地）。升级器对这类失败本来就支持重试，行为正确。

## 验证
- [x] system-upgrade 12 套单测全绿
- [x] 实机 UI 升级链路：源码 profile pull→重建已到 0.7.0；desktop npm 渠道重试后 ^0.7.0 落地
- [x] 修复后重启 dsh 复测一键升级全绿（见下补）