### PR TITLE
fix(one): engines 统一 ≥22.15.0，清除 >=20 虚假承诺（#45 尾巴）

### DIFF
--- a/dsh-plugins/dsh-ccpg-brand/package.json
+++ b/dsh-plugins/dsh-ccpg-brand/package.json
@@ -12,7 +12,7 @@
     "directory": "dsh-plugins/dsh-ccpg-brand"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.15.0"
   },
   "peerDependencies": {
     "@deepseek-ai/schemastery": "*"

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -12,7 +12,7 @@
     "directory": "dsh-plugins/dsh-ccpg-canvasui"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.15.0"
   },
   "scripts": {
     "prepack": "sh ../build-canvasui.sh"

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -10,7 +10,7 @@
     "directory": "dsh-plugins/dsh-ccpg-document-preview"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.15.0"
   },
   "type": "module",
   "main": "./src/host.js",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -12,7 +12,7 @@
     "directory": "dsh-plugins/dsh-ccpg-larkauth"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.15.0"
   },
   "peerDependencies": {
     "@deepseek-ai/schemastery": "*"

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -12,7 +12,7 @@
     "directory": "dsh-plugins/dsh-ccpg-llm-guard"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.15.0"
   },
   "exports": {
     ".": "./lib/index.js",

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -12,7 +12,7 @@
     "directory": "dsh-plugins/dsh-ccpg-tools"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.15.0"
   },
   "peerDependencies": {
     "@deepseek-ai/schemastery": "*",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -12,7 +12,7 @@
     "directory": "dsh-plugins/dsh-ccpg-web"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22.15.0"
   },
   "scripts": {
     "prepack": "sh ../build-web.sh"

--- a/scripts/verify-plugin-packages.mjs
+++ b/scripts/verify-plugin-packages.mjs
@@ -33,7 +33,7 @@ for (const name of sources) {
   assert.equal(pkg.private, false, `${name} must be publishable`);
   assert.equal(pkg.license, 'MIT');
   assert.equal(pkg.repository?.directory, `dsh-plugins/${name}`);
-  assert.equal(pkg.engines?.node, name === 'dsh-ccpg-orchestrator' ? '>=22.15.0' : '>=20');
+  assert.equal(pkg.engines?.node, '>=22.15.0');
   assert.equal(pkg.dsh?.bundle?.patch, './cordis.patch.yml');
   for (const path of required[name] || []) {
     assert(existsSync(join(dir, path)), `${name} is missing ${path}`);


### PR DESCRIPTION
## 背景
#45 只统一了文档口径（≥22.15），engines 字段没动：7 个插件 package.json 仍写 node >=20。

## 为什么是虚假承诺
套件所有包都依赖 orchestrator（用 node:sqlite，22.15 起稳定）；dsh 本体依赖 node:zlib 的 zstd API（同样 22.15 起）。装在 Node 20 必然运行失败——>=20 只会误导用户。

另发现 verify-plugin-packages.mjs:36 的契约校验竟然断言了这个不一致（orchestrator 特例 >=22.15.0、其余 >=20），一并改为统一断言。

## 方案
- 7 个 package.json：node >=20 → >=22.15.0
- verify 脚本：去掉 orchestrator 特例，统一断言 >=22.15.0

## 验证
- [x] verify-plugin-packages.mjs ok
- [x] 全量单测绿（npm test）
- [x] build-web.sh 双构建 + assemble-one + publish-npm --dry-run 通过
- [x] 文档（README/dsh-plugins/docs）无残留 >=20 口径