### PR TITLE
build(one): 准备 0.7.1 发版

### DIFF
--- a/dsh-plugins/dsh-ccpg-brand/package.json
+++ b/dsh-plugins/dsh-ccpg-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-brand",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-one",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.7.0",
-    "dsh-ccpg-document-preview": "0.7.0",
-    "dsh-ccpg-larkauth": "0.7.0",
-    "dsh-ccpg-llm-guard": "0.7.0",
-    "dsh-ccpg-orchestrator": "0.7.0",
-    "dsh-ccpg-tools": "0.7.0",
-    "dsh-ccpg-web": "0.7.0"
+    "dsh-ccpg-canvasui": "0.7.1",
+    "dsh-ccpg-document-preview": "0.7.1",
+    "dsh-ccpg-larkauth": "0.7.1",
+    "dsh-ccpg-llm-guard": "0.7.1",
+    "dsh-ccpg-orchestrator": "0.7.1",
+    "dsh-ccpg-tools": "0.7.1",
+    "dsh-ccpg-web": "0.7.1"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
@@ -274,7 +274,7 @@ console.log('system-upgrade tests:');
       assert.match(plan.actions[0].title, /更新/);
       const calls = [];
       const realFetch = globalThis.fetch;
-      globalThis.fetch = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '0.7.0' } }) });
+      globalThis.fetch = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '0.7.1' } }) });
       try {
         await executePlan(plan, {
           dshBin: '/fake/dsh',
@@ -285,7 +285,7 @@ console.log('system-upgrade tests:');
       }
       const up = calls.find((c) => c[4] === 'up');
       assert.ok(up, '在装用户用 up 原地更新');
-      assert.equal(up[5], `${PACKAGE}@0.7.0`);
+      assert.equal(up[5], `${PACKAGE}@0.7.1`);
       assert.ok(!calls.some((c) => c[4] === 'remove'), 'up 路径不 remove 任何包');
       assert.ok(calls.some((c) => c[4] === 'add' && String(c[5] || '').startsWith(SIDEBAR)), '纯净安装兜底：依赖表无 sidebar 时补 add 注册 bundle');
     } finally {

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 背景
engines 统一（#92）单独成版发 v0.7.1，让 npm 渠道用户拿到修正后的 engines 声明。

## 方案
- 10 个 package.json 0.7.0 → 0.7.1（one 依赖表 7 子包精确 pin 同步）
- system-upgrade.test.mjs 两处版本引用同步
- dsh-harness-one 装配目录由 assemble-one 现场生成（gitignore 产物，随 assemble 取 0.7.1）

## 验证
- [x] 全量单测绿（`npm test`）
- [x] `build-web.sh` 双构建 + assemble-one + `publish-npm.sh --dry-run` 通过（dsh-harness-one@0.7.1，全新安装 smoke 过）
- [x] 升级器单测 12 套绿