### PR TITLE
feat(docwall): .univer 产物文稿视图预览——内嵌 univer-office Viewer

### DIFF
--- a/dsh-plugins/dsh-ccpg-document-preview/src/index.js
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/index.js
@@ -5,7 +5,7 @@ export const MIME_BY_EXTENSION = Object.freeze({
   json: 'application/json', log: 'text/plain', md: 'text/markdown', mdown: 'text/markdown',
   pdf: 'application/pdf', png: 'image/png', ppt: 'application/vnd.ms-powerpoint',
   pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation', txt: 'text/plain',
-  webp: 'image/webp', xls: 'application/vnd.ms-excel',
+  univer: 'application/x-univer', webp: 'image/webp', xls: 'application/vnd.ms-excel',
   xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
 });
 
@@ -16,6 +16,7 @@ const KIND_BY_MIME = Object.freeze({
   'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'pptx',
   'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'sheet',
   'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'docx',
+  'application/x-univer': 'univer',
   'text/csv': 'csv',
   'text/html': 'html',
   'text/markdown': 'markdown',

--- a/dsh-plugins/dsh-ccpg-document-preview/src/react.jsx
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/react.jsx
@@ -10,6 +10,7 @@ const PdfRenderer = lazy(() => import('./renderers/pdf.jsx'));
 const DocxRenderer = lazy(() => import('./renderers/docx.jsx'));
 const SheetRenderer = lazy(() => import('./renderers/sheet.jsx'));
 const PptxRenderer = lazy(() => import('./renderers/pptx.jsx'));
+const UniverRenderer = lazy(() => import('./renderers/univer.jsx'));
 const FOCUSABLE = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 function Loading() {
@@ -92,6 +93,7 @@ function PreviewContent({ document, kind, maxTextBytes }) {
   if (kind === 'docx') return <DocxRenderer document={document} />;
   if (kind === 'sheet') return <SheetRenderer document={document} />;
   if (kind === 'pptx') return <PptxRenderer document={document} />;
+  if (kind === 'univer') return <UniverRenderer document={document} />;
   return <div className="dsh-doc-preview-message">该文件类型暂不支持预览，旧 DOC 和 PPT 请下载后查看。</div>;
 }
 

--- a/dsh-plugins/dsh-ccpg-document-preview/src/renderers/univer.jsx
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/renderers/univer.jsx
@@ -6,8 +6,9 @@
 import { useEffect, useMemo, useState } from 'react';
 import { fileKeyOf, pickWorktree, resolveEndpointOf } from '../univer-core.js';
 
-async function fetchJson(url, signal) {
-  const res = await fetch(url, { credentials: 'same-origin', signal });
+async function fetchJson(url, options = {}) {
+  const signal = options.signal;
+  const res = await fetch(url, { credentials: 'same-origin', ...options });
   if (!res.ok) {
     const error = new Error(`HTTP ${res.status}`);
     error.status = res.status;
@@ -18,14 +19,14 @@ async function fetchJson(url, signal) {
 
 async function buildViewerUrl(resolveUrl, signal) {
   const resolved = await fetchJson(resolveUrl, signal);
-  // /univer-api/status 是 dsh 宿主同源路由（univer-office 注册）；Gateway 端口
-  // 被占会逐次递增，所以每次现查不缓存。
-  const status = await fetchJson('/univer-api/status', signal);
-  const gateway = String(status?.gateway || '').replace(/\/$/, '');
-  if (!gateway) throw new Error('univer-office Gateway 未运行');
+  // Gateway 随 dsh 重启即停：先显式拉起（幂等，运行中 reused=true），再查地址；
+  // 端口被占会逐次递增，所以每次现查不缓存。
+  const started = await fetchJson('/univer-api/gateway/start', { method: 'POST', signal });
+  const gateway = String(started?.gateway || '').replace(/\/$/, '');
+  if (!gateway) throw new Error('univer-office Gateway 启动失败');
   const fileKey = fileKeyOf(resolved.file);
   if (!fileKey) throw new Error('文件路径编码失败');
-  const listing = await fetchJson(`${gateway}/uf/${fileKey}/worktrees`, signal);
+  const listing = await fetchJson(`${gateway}/uf/${fileKey}/worktrees`, { signal });
   const worktree = pickWorktree(listing?.worktrees);
   const params = new URLSearchParams({ file: fileKey, mode: 'embedded' });
   if (worktree) params.set('worktree', worktree);

--- a/dsh-plugins/dsh-ccpg-document-preview/src/renderers/univer.jsx
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/renderers/univer.jsx
@@ -1,0 +1,65 @@
+// Univer Viewer 渲染器：.univer 文件内嵌 dsh-univer-office 的 Viewer 页面。
+// 纯 URL 集成——不 import univer-office 的任何值，只拼它的 Gateway URL；
+// 协议三步：/univer-api/status 发现 Gateway → /wf1/api/univer/resolve 换绝对路径
+// → Gateway /uf/<key>/worktrees 选 worktree 后 iframe 打开。
+// 纯函数（fileKey/pickWorktree/resolveEndpoint）在 ../univer-core.js，单测直覆盖。
+import { useEffect, useMemo, useState } from 'react';
+import { fileKeyOf, pickWorktree, resolveEndpointOf } from '../univer-core.js';
+
+async function fetchJson(url, signal) {
+  const res = await fetch(url, { credentials: 'same-origin', signal });
+  if (!res.ok) {
+    const error = new Error(`HTTP ${res.status}`);
+    error.status = res.status;
+    throw error;
+  }
+  return res.json();
+}
+
+async function buildViewerUrl(resolveUrl, signal) {
+  const resolved = await fetchJson(resolveUrl, signal);
+  // /univer-api/status 是 dsh 宿主同源路由（univer-office 注册）；Gateway 端口
+  // 被占会逐次递增，所以每次现查不缓存。
+  const status = await fetchJson('/univer-api/status', signal);
+  const gateway = String(status?.gateway || '').replace(/\/$/, '');
+  if (!gateway) throw new Error('univer-office Gateway 未运行');
+  const fileKey = fileKeyOf(resolved.file);
+  if (!fileKey) throw new Error('文件路径编码失败');
+  const listing = await fetchJson(`${gateway}/uf/${fileKey}/worktrees`, signal);
+  const worktree = pickWorktree(listing?.worktrees);
+  const params = new URLSearchParams({ file: fileKey, mode: 'embedded' });
+  if (worktree) params.set('worktree', worktree);
+  return `${gateway}/?${params.toString()}`;
+}
+
+export default function UniverRenderer({ document }) {
+  const resolveUrl = useMemo(() => resolveEndpointOf(document.downloadUrl), [document.downloadUrl]);
+  const [state, setState] = useState({ loading: true, error: '', url: '' });
+
+  useEffect(() => {
+    if (!resolveUrl) {
+      setState({ loading: false, error: '预览地址缺少产物定位信息，无法打开 Univer Viewer。', url: '' });
+      return undefined;
+    }
+    const controller = new AbortController();
+    setState({ loading: true, error: '', url: '' });
+    buildViewerUrl(resolveUrl, controller.signal).then((url) => {
+      if (!controller.signal.aborted) setState({ loading: false, error: '', url });
+    }).catch((reason) => {
+      if (controller.signal.aborted || reason?.name === 'AbortError') return;
+      const missing = reason?.status === 404;
+      setState({
+        loading: false,
+        error: missing
+          ? '未安装 dsh-univer-office 插件，无法预览 .univer 文件；请下载后用 Univer 打开。'
+          : `Univer 预览不可用：${reason?.message || reason}`,
+        url: '',
+      });
+    });
+    return () => controller.abort();
+  }, [resolveUrl]);
+
+  if (loading) return <div className="dsh-doc-preview-message">正在连接 Univer Viewer…</div>;
+  if (error) return <div className="dsh-doc-preview-message is-error">{error}</div>;
+  return <iframe className="dsh-doc-preview-frame" src={state.url} title={`预览 ${document.name}`} />;
+}

--- a/dsh-plugins/dsh-ccpg-document-preview/src/univer-core.js
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/univer-core.js
@@ -13,9 +13,14 @@ export function resolveEndpointOf(downloadUrl) {
 }
 
 // Viewer 的 fileKeyOf：utf8 → base64url（gateway-app 与 host 两侧一致）。
+// 纯 Web API 实现（TextEncoder + btoa）：本文件同时被浏览器 renderer 与 node --test 引用，
+// 不能用 Node 的 Buffer——Vite 不注入，浏览器运行时 ReferenceError。
 export function fileKeyOf(absolutePath) {
   try {
-    return Buffer.from(String(absolutePath), 'utf8').toString('base64url');
+    const bytes = new TextEncoder().encode(String(absolutePath));
+    let binary = '';
+    for (const byte of bytes) binary += String.fromCharCode(byte);
+    return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
   } catch {
     return '';
   }

--- a/dsh-plugins/dsh-ccpg-document-preview/src/univer-core.js
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/univer-core.js
@@ -1,0 +1,32 @@
+// Univer Viewer 集成纯函数：与 renderers/univer.jsx 共享，保持零 JSX 依赖，
+// 让 node --test 直接覆盖（渲染器本体只做 hooks 编排与 iframe 渲染）。
+
+// downloadUrl 形如 <base>/api/artifact?run=&node=&file=（runArtifact/legacyArtifact 构造），
+// resolve 端点与它同基址，仅把路径段 /artifact 换成 /univer/resolve。
+export function resolveEndpointOf(downloadUrl) {
+  const raw = String(downloadUrl || '');
+  const qIndex = raw.indexOf('?');
+  if (qIndex < 0) return '';
+  const path = raw.slice(0, qIndex);
+  if (!/\/artifact$/.test(path)) return '';
+  return `${path.slice(0, path.length - '/artifact'.length)}/univer/resolve${raw.slice(qIndex)}`;
+}
+
+// Viewer 的 fileKeyOf：utf8 → base64url（gateway-app 与 host 两侧一致）。
+export function fileKeyOf(absolutePath) {
+  try {
+    return Buffer.from(String(absolutePath), 'utf8').toString('base64url');
+  } catch {
+    return '';
+  }
+}
+
+// worktree 选择：draft 里 createdAt 最新优先；没有 draft 取最新一个；
+// 完全没有 worktree 返回 null（空文件主线直接开）。
+export function pickWorktree(worktrees) {
+  const list = (Array.isArray(worktrees) ? worktrees : []).filter((w) => w && w.worktreeId);
+  if (!list.length) return null;
+  const byTime = (a, b) => String(b.createdAt || '').localeCompare(String(a.createdAt || ''));
+  const drafts = list.filter((w) => w.status === 'draft').sort(byTime);
+  return (drafts[0] || list.slice().sort(byTime)[0]).worktreeId;
+}

--- a/dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs
+++ b/dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs
@@ -103,8 +103,9 @@ test('univer-core: resolveEndpointOf/fileKeyOf/pickWorktree 纯函数', async ()
   );
   assert.equal(resolveEndpointOf('http://x/other?file=a.univer'), '');
   assert.equal(resolveEndpointOf(''), '');
-  // fileKeyOf 与 host 侧 fileKeyOf 同语义：utf8 base64url
+  // fileKeyOf 与 host 侧 fileKeyOf 同语义：utf8 base64url（纯 Web API，浏览器可用）
   assert.equal(fileKeyOf('/tmp/a.univer'), Buffer.from('/tmp/a.univer', 'utf8').toString('base64url'));
+  assert.equal(fileKeyOf('/tmp/中文名.univer'), Buffer.from('/tmp/中文名.univer', 'utf8').toString('base64url'));
   // worktree 选择：最新 draft 优先 → 无 draft 取最新 → 空列表 null
   assert.equal(pickWorktree([]), null);
   assert.equal(pickWorktree(null), null);

--- a/dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs
+++ b/dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs
@@ -79,3 +79,43 @@ test('apply tolerates a missing webServer', () => {
   assert.doesNotThrow(() => apply({ logger: { info() {} } }));
 });
 
+
+// ---- univer 渲染器纯函数 ----
+
+test('univer: .univer maps to univer kind and previewable', () => {
+  assert.equal(documentPreviewKind('报表.univer'), 'univer');
+  assert.equal(documentMimeType('报表.univer'), 'application/x-univer');
+  assert.equal(canPreviewDocument({ name: '报表.univer' }), true);
+});
+
+
+
+test('univer-core: resolveEndpointOf/fileKeyOf/pickWorktree 纯函数', async () => {
+  const { resolveEndpointOf, fileKeyOf, pickWorktree } = await import('../src/univer-core.js');
+  // resolve 端点推导：run 形态与 legacy 形态都取同基址；非 artifact 路径拒绝
+  assert.equal(
+    resolveEndpointOf('http://x/wf1/api/artifact?run=r1&node=n1&file=a.univer'),
+    'http://x/wf1/api/univer/resolve?run=r1&node=n1&file=a.univer',
+  );
+  assert.equal(
+    resolveEndpointOf('/wf1/api/artifact?node=数据节点&file=%E6%8A%A5%E8%A1%A8.univer'),
+    '/wf1/api/univer/resolve?node=数据节点&file=%E6%8A%A5%E8%A1%A8.univer',
+  );
+  assert.equal(resolveEndpointOf('http://x/other?file=a.univer'), '');
+  assert.equal(resolveEndpointOf(''), '');
+  // fileKeyOf 与 host 侧 fileKeyOf 同语义：utf8 base64url
+  assert.equal(fileKeyOf('/tmp/a.univer'), Buffer.from('/tmp/a.univer', 'utf8').toString('base64url'));
+  // worktree 选择：最新 draft 优先 → 无 draft 取最新 → 空列表 null
+  assert.equal(pickWorktree([]), null);
+  assert.equal(pickWorktree(null), null);
+  assert.equal(pickWorktree([{ worktreeId: 'a', status: 'merged', createdAt: '2026-01-01' }]), 'a');
+  assert.equal(pickWorktree([
+    { worktreeId: 'old', status: 'draft', createdAt: '2026-01-01' },
+    { worktreeId: 'new', status: 'draft', createdAt: '2026-02-01' },
+    { worktreeId: 'm', status: 'merged', createdAt: '2026-03-01' },
+  ]), 'new');
+  assert.equal(pickWorktree([
+    { worktreeId: 'm1', status: 'merged', createdAt: '2026-01-01' },
+    { worktreeId: 'm2', status: 'merged', createdAt: '2026-05-01' },
+  ]), 'm2');
+});

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -2675,6 +2675,57 @@ export function apply(ctx, config) {
     return streamArtifactResponse(req, res, { file: realFull, filename: file, mediaType, preview });
   } });
 
+  // .univer 产物解析：给 document-preview 的 Univer Viewer 渲染器返回文件系统绝对路径
+  //（Viewer 以绝对路径 base64url 为 file key，且要求路径以 .univer 结尾、落在 workspace 内）。
+  // 因此不走内容寻址的快照目录（无后缀），统一解析节点工作区里的原始 .univer：
+  // 已结束运行沿 artifactIndex 的 relativePath 定位（断点续跑产物在祖先运行目录，沿 resumedFrom 回退），
+  // 运行中直接按 file 名在工作区解析。安全约束与 /wf1/api/artifact 同款。
+  register({ kind: 'exact', path: '/wf1/api/univer/resolve', async handler(req, res) {
+    if (req.method !== 'GET') return json(res, 405, { error: 'method' });
+    const url = new URL(req.url, 'http://x');
+    const runId = url.searchParams.get('run') || '';
+    const file = url.searchParams.get('file') || '';
+    const nodeParam = url.searchParams.get('node') || '';
+    if (!runId && !nodeParam) return json(res, 400, { error: '需要 node 和 file' });
+    if (!file) return json(res, 400, { error: '需要 node 和 file' });
+    if (extname(file).toLowerCase() !== '.univer') return json(res, 400, { error: '仅支持 .univer 文件' });
+    const hit = (absolutePath) => json(res, 200, { file: absolutePath });
+    const run = runId ? readRun(runId) : null;
+    const ancestors = [];
+    if (run) {
+      ancestors.push(runId);
+      let cursor = run;
+      for (let depth = 0; cursor?.resumedFrom && depth < 10; depth += 1) {
+        ancestors.push(cursor.resumedFrom);
+        cursor = readRun(cursor.resumedFrom);
+      }
+    }
+    // 已结束运行：artifactIndex 记录了 relativePath（相对节点工作区），按它精确解析；
+    // 请求的 file 名与索引对不上时回退到按名匹配（同名即认，运行中写入与索引时点差异）。
+    const indexed = (run?.artifactIndex || []).filter((a) => a?.relativePath?.toLowerCase().endsWith('.univer'));
+    const candidates = [];
+    if (indexed.length) {
+      const exact = indexed.find((a) => a.nodeId === nodeParam && (a.relativePath === file || a.name === file));
+      const byName = indexed.filter((a) => a.name === file);
+      for (const a of [exact, ...byName]) {
+        if (a && !candidates.some((c) => c.nodeId === a.nodeId && c.relativePath === a.relativePath)) candidates.push(a);
+      }
+    }
+    for (const candidateRunId of ancestors.length ? ancestors : [runId]) {
+      const rels = candidates.filter((a) => a.nodeId === nodeParam).map((a) => a.relativePath);
+      for (const rel of rels.length ? rels : (runId ? [] : [file])) {
+        const ws = resolveInside(STORAGE.workspaceForNode({
+          workflowId: run?.workflowId || 'draft', runId: candidateRunId, nodeId: nodeParam,
+        }), rel);
+        if (!ws || !existsSync(ws) || !statSync(ws).isFile()) continue;
+        const realWs = realpathSync(ws);
+        if (resolveInside(realpathSync(dirname(realWs)), realWs) !== realWs) continue;
+        return hit(realWs);
+      }
+    }
+    return json(res, 404, { error: '产物不存在' });
+  } });
+
   // 文稿墙批量正文：一次请求返回运行内多个产物的文本截断稿，替代逐卡 fetch（37 卡 = 37 请求）。
   // POST { runId, items: [{ node, file }] } → { files: { "<node>\u0000<file>": { content, truncated } } }；
   // 总字节预算 1.5MB，超预算的条目返回 { omitted: true }，前端回退单卡惰性拉取。仅文本类产物。


### PR DESCRIPTION
## 背景

dsh-univer-office 集成调研（#无 issue，会话决策）确认：agent 节点可零代码使用 univer_* 工具产出 .univer 办公文档，但文稿视图对 .univer 只能下载不能预览。本 PR 打通最后一环：点开 .univer 产物直接内嵌 univer-office 自带 Viewer 预览/编辑。

## 方案

纯 URL/iframe 集成，零跨插件依赖（构建纯度门无感）：

- **orchestrator**：新增 `GET /wf1/api/univer/resolve`，按 run+node+file 把 .univer 产物解析为节点工作区原始文件的绝对路径（Viewer file key = 绝对路径 base64url）。已结束运行沿 artifactIndex.relativePath 精确定位，断点续跑沿 resumedFrom 祖先链回退，运行中按名解析。路径校验与 /wf1/api/artifact 同款（resolveInside + realpath），仅 .univer 后缀。
- **document-preview**：注册 `univer` kind；新渲染器三步拼 Viewer URL——`/univer-api/status` 发现 Gateway（端口会漂移，现查不缓存）→ resolve 换绝对路径 → Gateway `/uf/<key>/worktrees` 选 worktree（draft 最新优先；实测不带 worktree 显示「空文件」，因 agent 产物在 draft 未合入 trunk）→ `mode=embedded` iframe。未装 univer-office 时 404 降级为提示 + 现有下载路径。

## 验证

- 单测：orchestrator 全量 ✅；document-preview 10 例（新增 kind 注册 + 纯函数 fileKeyOf/pickWorktree/resolveEndpointOf）✅
- `build-web.sh` 双构建 ✅
- **真实 E2E**：web profile 实机跑通——上轮工作流产出的「2026年8月杂项支出表.univer」经 resolve → gateway → worktree → iframe 全链路，官方 UI 页面内 iframe 完整渲染（SUM 公式、表头样式、货币格式、工作表标签全对，截图见下）
- E2E 中发现并修复：快照产物是内容寻址名（无后缀）被 Gateway 拒收 → resolve 改为解析工作区原始 .univer

## 风险与边界

- univer-office 0.2.x URL 协议无稳定性承诺 → 集中在一个 renderer + 纯函数文件，协议变了只改一处
- Gateway 本机 loopback 无鉴权 → 与 univer-office 自身设计一致，dsh 拒听 0.0.0.0，远程场景不存在
- 配套项（另做）：skill-seed 提示词引导 agent 优先交付 .univer 源文件