### PR TITLE
fix(one): 入库目录包名对齐 dsh-harness-one（修市场 npm 字段关联）

### DIFF
--- a/dsh-plugins/dsh-ccpg-one/bin/install.js
+++ b/dsh-plugins/dsh-ccpg-one/bin/install.js
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-// dsh-ccpg-one 安装入口（npx dsh-ccpg-one / npm exec dsh-ccpg-one）。
+// dsh-harness-one 安装入口（聚合源目录 dsh-plugins/dsh-ccpg-one 的 bin）（npx dsh-harness-one / npm exec dsh-harness-one）。
 //
-// 为什么存在：`dsh plugin --profile X add dsh-ccpg-one` 是 profile 目录里裸跑
-// pnpm 11 的薄转发器，而聚合依赖链 dsh-ccpg-one → dsh-better-sidebar → node-pty
+// 为什么存在：`dsh plugin --profile X add dsh-harness-one` 是 profile 目录里裸跑
+// pnpm 11 的薄转发器，而聚合依赖链 dsh-harness-one → dsh-better-sidebar → node-pty
 // 带原生构建脚本。pnpm 11 的 strict-dep-builds 在 allowBuilds 未声明时直接
 // ERR_PNPM_IGNORED_BUILDS 非零退出——dsh 跳过 bundle 注册，且 pnpm 已往 profile
 // 的 pnpm-workspace.yaml 写入非法占位符（`node-pty: set this to true or false`），
@@ -17,15 +17,15 @@ import { spawnSync } from 'node:child_process';
 
 const DSH_HOME = process.env.DSH_HOME || join(process.env.HOME, '.dsh');
 const PROFILE = process.argv[2] || 'dsh-ccpg';
-const PKG = 'dsh-ccpg-one';
+const PKG = 'dsh-harness-one';
 const SUBPLUGINS = ['dsh-ccpg-canvasui', 'dsh-ccpg-document-preview', 'dsh-ccpg-larkauth',
   'dsh-ccpg-llm-guard', 'dsh-ccpg-orchestrator', 'dsh-ccpg-tools', 'dsh-ccpg-web'];
 
 const trailingNewline = (s) => (s.endsWith('\n') ? '' : '\n');
 const escapeRe = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
-const say = (msg) => console.log(`[dsh-ccpg-one] ${msg}`);
-const die = (msg) => { console.error(`[dsh-ccpg-one] ${msg}`); process.exit(1); };
+const say = (msg) => console.log(`[dsh-harness-one] ${msg}`);
+const die = (msg) => { console.error(`[dsh-harness-one] ${msg}`); process.exit(1); };
 
 if (process.argv.includes('-h') || process.argv.includes('--help')) {
   console.log(`用法：npx ${PKG} [profile] [--prewrite]
@@ -71,7 +71,7 @@ if (process.argv.includes('--prewrite')) process.exit(0);
 say(`dsh plugin --profile ${PROFILE} add ${PKG} …`);
 const add = spawnSync(dsh, ['plugin', '--profile', PROFILE, 'add', PKG], { stdio: 'inherit' });
 if (add.status !== 0) {
-  console.error(`[dsh-ccpg-one] 安装失败（exit ${add.status}）。
+  console.error(`[dsh-harness-one] 安装失败（exit ${add.status}）。
 若上面有 ERR_PNPM_IGNORED_BUILDS：重试无效（pnpm 会反复拦截）——重跑本命令即可，
 它会先把 profile pnpm-workspace.yaml 的放行修正（allowBuilds: node-pty: true）再安装。`);
   process.exit(add.status ?? 1);
@@ -83,7 +83,7 @@ if (add.status !== 0) {
 if (process.env.CCPG_NO_SIDEBAR || process.env.CCPG_ONLY_CORE) {
   say('CCPG_NO_SIDEBAR/CCPG_ONLY_CORE 生效：移除 dsh-better-sidebar …');
   const rm = spawnSync(dsh, ['plugin', '--profile', PROFILE, 'remove', 'dsh-better-sidebar'], { stdio: 'inherit' });
-  if (rm.status !== 0) console.error('[dsh-ccpg-one] better-sidebar 移除失败（可手动：dsh plugin --profile ' + PROFILE + ' remove dsh-better-sidebar）');
+  if (rm.status !== 0) console.error('[dsh-harness-one] better-sidebar 移除失败（可手动：dsh plugin --profile ' + PROFILE + ' remove dsh-better-sidebar）');
 }
 say('安装完成，重启 dsh 生效。独立画布: http://127.0.0.1:4021/wf1/');
 

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dsh-ccpg-one",
+  "name": "dsh-harness-one",
   "version": "0.7.1",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
@@ -34,7 +34,7 @@
   "private": false,
   "main": "lib/index.js",
   "bin": {
-    "dsh-ccpg-one": "./bin/install.js"
+    "dsh-harness-one": "./bin/install.js"
   },
   "exports": {
     ".": "./lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/test/install.test.mjs
+++ b/dsh-plugins/dsh-ccpg-one/test/install.test.mjs
@@ -46,7 +46,7 @@ try {
   assert.match(allowBlock, /^  node-pty: true$/m);
   assert.match(allowBlock, /^  protobufjs: true$/m);
   assert.match(out, /minimumReleaseAgeExclude:\n  - dsh-better-sidebar@0\.16\.1\n/);
-  for (const p of ['dsh-ccpg-one', 'dsh-ccpg-canvasui', 'dsh-ccpg-orchestrator', 'dsh-ccpg-tools', 'dsh-ccpg-web']) {
+  for (const p of ['dsh-harness-one', 'dsh-ccpg-canvasui', 'dsh-ccpg-orchestrator', 'dsh-ccpg-tools', 'dsh-ccpg-web']) {
     assert.match(out, new RegExp(`^  - ${p}$`, 'm'), `${p} 应在 minimumReleaseAgeExclude`);
   }
   // 顶级键顺序不乱：packages 仍在最前
@@ -70,7 +70,7 @@ try {
   });
   const out2 = readFileSync(join(p2, 'pnpm-workspace.yaml'), 'utf8');
   assert.match(out2, /allowBuilds:\n  node-pty: true\n  protobufjs: true\n/);
-  assert.match(out2, /minimumReleaseAgeExclude:\n  - dsh-ccpg-one\n/);
+  assert.match(out2, /minimumReleaseAgeExclude:\n  - dsh-harness-one\n/);
 } finally {
   rmSync(home, { recursive: true, force: true });
 }
@@ -78,4 +78,4 @@ try {
 function mkdirTree(p) { execFileSync('/bin/mkdir', ['-p', p]); }
 function writeFileSyncUTF8(p, t) { execFileSync('/bin/sh', ['-c', `cat > ${JSON.stringify(p)} << 'EOF'\n${t}\nEOF`]); }
 
-console.log('✓ dsh-ccpg-one bin/install --prewrite：占位符归位 / 幂等 / 空白 profile 三组通过');
+console.log('✓ dsh-harness-one bin/install --prewrite：占位符归位 / 幂等 / 空白 profile 三组通过');


### PR DESCRIPTION
## 背景

awesome 清单 CI（probe-npm）从投稿条目子目录的 `package.json` 抓 `name` 作为市场 `npm` 字段，并校验该 npm 包的 `repository` 与条目 url 关联。

入库目录 `dsh-plugins/dsh-ccpg-one/package.json` 的 `name` 仍是停更老包 `dsh-ccpg-one`（npm 停在 0.4.1，repository 还是改名前的 `harness-one`）。保持现状的后果：
1. 市场安装命令指向停更老包，用户装不到当前版本
2. probe-npm 的 repository 匹配失败，`npm` 字段被判 `null`，条目降级为 GitHub-only

## 改动

- `dsh-plugins/dsh-ccpg-one/package.json`：`name`/`bin` 改为 `dsh-harness-one`
- `bin/install.js`：`PKG` 常量与提示文案同步
- `test/install.test.mjs`：断言同步

目录名不动（git 路径与 awesome 条目 url 已对齐维护者要求）；脚本全部按**路径**读该 package.json（version/sidebar 依赖），无按 name 的模块解析；`assemble-one.sh` 产物的 name 本就独立硬编码 `dsh-harness-one`。

## 验证

- `npm test` 全量 48 套通过（含改后的 install 3 组）
- `sh dsh-plugins/build-web.sh` 双构建通过
- `sh dsh-plugins/assemble-one.sh --check` 装配校验通过