### PR TITLE
feat(docwall): 支持文稿评论与 AI 修订版本

### DIFF
--- a/dsh-plugins/dsh-ccpg-document-preview/src/index.js
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/index.js
@@ -66,10 +66,36 @@ export function normalizePreviewDocument(document) {
   };
 }
 
+export function previewErrorMessage(reason) {
+  if (reason?.name === 'AbortError') return '';
+  if (reason?.status === 404) return '文件不存在或已随运行历史清理。';
+  if (reason?.status === 409) return '当前工作区会话已失效，请刷新页面后重试。';
+  if (reason?.status >= 500) return '文档服务暂时不可用，请稍后重试。';
+  const raw = String(reason?.message || reason || '');
+  if (/failed to fetch|networkerror|load failed|network request failed/i.test(raw)) {
+    return '文档加载失败，请检查连接后重试。';
+  }
+  return raw || '文档加载失败，请稍后重试。';
+}
+
 export async function fetchPreviewResponse(url, options = {}) {
-  if (!url) throw new Error('Preview URL is missing');
-  const response = await fetch(url, { credentials: 'same-origin', ...options });
-  if (!response.ok) throw new Error(`Failed to load document (HTTP ${response.status})`);
+  if (!url) throw new Error('预览地址缺失，无法加载文档。');
+  let response;
+  try {
+    response = await fetch(url, { credentials: 'same-origin', ...options });
+  } catch (reason) {
+    if (reason?.name === 'AbortError') throw reason;
+    const error = new Error(previewErrorMessage(reason));
+    error.code = 'preview-network-error';
+    error.cause = reason;
+    throw error;
+  }
+  if (!response.ok) {
+    const error = new Error(previewErrorMessage({ status: response.status }));
+    error.status = response.status;
+    error.code = response.status === 404 ? 'preview-not-found' : response.status === 409 ? 'preview-session-required' : 'preview-http-error';
+    throw error;
+  }
   return response;
 }
 

--- a/dsh-plugins/dsh-ccpg-document-preview/src/react.jsx
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/react.jsx
@@ -1,9 +1,9 @@
-import { lazy, Suspense, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Component, lazy, Suspense, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { Download, Expand, Eye, Minimize, X } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { documentPreviewKind, loadPreviewText, normalizePreviewDocument } from './index.js';
+import { documentPreviewKind, loadPreviewText, normalizePreviewDocument, previewErrorMessage } from './index.js';
 import './styles.css';
 
 const PdfRenderer = lazy(() => import('./renderers/pdf.jsx'));
@@ -17,6 +17,24 @@ function Loading() {
   return <div className="dsh-doc-preview-message">正在准备预览…</div>;
 }
 
+class PreviewErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      return <div className="dsh-doc-preview-message is-error">预览组件加载失败，请刷新页面后重试。</div>;
+    }
+    return this.props.children;
+  }
+}
+
 function TextRenderer({ document, kind, maxTextBytes }) {
   const [state, setState] = useState({ loading: true, error: '', text: '' });
   useEffect(() => {
@@ -25,7 +43,7 @@ function TextRenderer({ document, kind, maxTextBytes }) {
     loadPreviewText(document.previewUrl, { signal: controller.signal, maxBytes: maxTextBytes })
       .then((text) => setState({ loading: false, error: '', text }))
       .catch((reason) => {
-        if (reason?.name !== 'AbortError') setState({ loading: false, error: reason?.message || String(reason), text: '' });
+        if (reason?.name !== 'AbortError') setState({ loading: false, error: previewErrorMessage(reason), text: '' });
       });
     return () => controller.abort();
   }, [document.previewUrl, maxTextBytes]);
@@ -173,7 +191,9 @@ export function DocumentPreviewDialog({ document: input, open = true, onClose, m
         </div>
       </header>
       <main className="dsh-doc-preview-content">
-        <Suspense fallback={<Loading />}><PreviewContent document={document} kind={kind} maxTextBytes={maxTextBytes} /></Suspense>
+        <PreviewErrorBoundary>
+          <Suspense fallback={<Loading />}><PreviewContent document={document} kind={kind} maxTextBytes={maxTextBytes} /></Suspense>
+        </PreviewErrorBoundary>
       </main>
     </section>
   </div>;

--- a/dsh-plugins/dsh-ccpg-document-preview/src/renderers/univer.jsx
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/renderers/univer.jsx
@@ -5,9 +5,9 @@
 // 纯函数（fileKey/pickWorktree/resolveEndpoint）在 ../univer-core.js，单测直覆盖。
 import { useEffect, useMemo, useState } from 'react';
 import { fileKeyOf, pickWorktree, resolveEndpointOf } from '../univer-core.js';
+import { previewErrorMessage } from '../index.js';
 
 async function fetchJson(url, options = {}) {
-  const signal = options.signal;
   const res = await fetch(url, { credentials: 'same-origin', ...options });
   if (!res.ok) {
     const error = new Error(`HTTP ${res.status}`);
@@ -18,7 +18,7 @@ async function fetchJson(url, options = {}) {
 }
 
 async function buildViewerUrl(resolveUrl, signal) {
-  const resolved = await fetchJson(resolveUrl, signal);
+  const resolved = await fetchJson(resolveUrl, { signal });
   // Gateway 随 dsh 重启即停：先显式拉起（幂等，运行中 reused=true），再查地址；
   // 端口被占会逐次递增，所以每次现查不缓存。
   const started = await fetchJson('/univer-api/gateway/start', { method: 'POST', signal });
@@ -53,14 +53,14 @@ export default function UniverRenderer({ document }) {
         loading: false,
         error: missing
           ? '未安装 dsh-univer-office 插件，无法预览 .univer 文件；请下载后用 Univer 打开。'
-          : `Univer 预览不可用：${reason?.message || reason}`,
+          : `Univer 预览不可用：${previewErrorMessage(reason)}`,
         url: '',
       });
     });
     return () => controller.abort();
   }, [resolveUrl]);
 
-  if (loading) return <div className="dsh-doc-preview-message">正在连接 Univer Viewer…</div>;
-  if (error) return <div className="dsh-doc-preview-message is-error">{error}</div>;
+  if (state.loading) return <div className="dsh-doc-preview-message">正在连接 Univer Viewer…</div>;
+  if (state.error) return <div className="dsh-doc-preview-message is-error">{state.error}</div>;
   return <iframe className="dsh-doc-preview-frame" src={state.url} title={`预览 ${document.name}`} />;
 }

--- a/dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs
+++ b/dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs
@@ -7,6 +7,8 @@ import { apply, inject as hostInject, name as hostName } from '../src/host.js';
 import {
   canPreviewDocument,
   createDocumentPreviewHost,
+  fetchPreviewResponse,
+  previewErrorMessage,
   documentExtension,
   documentMimeType,
   documentPreviewKind,
@@ -44,6 +46,37 @@ test('createDocumentPreviewHost exposes pure helper API', () => {
   assert.equal(host.supports({ name: 'a.pdf' }), true);
   assert.equal(host.kind({ name: 'a.ppt' }), null);
   assert.equal(canPreviewDocument({ name: 'a.docx' }), true);
+});
+
+test('preview errors map network and scoped HTTP failures to actionable messages', async () => {
+  assert.equal(previewErrorMessage(new TypeError('Failed to fetch')), '文档加载失败，请检查连接后重试。');
+  assert.equal(previewErrorMessage({ status: 404 }), '文件不存在或已随运行历史清理。');
+  assert.equal(previewErrorMessage({ status: 409 }), '当前工作区会话已失效，请刷新页面后重试。');
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => { throw new TypeError('Failed to fetch'); };
+  try {
+    await assert.rejects(fetchPreviewResponse('/artifact'), (error) => {
+      assert.equal(error.code, 'preview-network-error');
+      assert.equal(error.message, '文档加载失败，请检查连接后重试。');
+      return true;
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('preview HTTP failures preserve status and stable code', async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => ({ ok: false, status: 404 });
+  try {
+    await assert.rejects(fetchPreviewResponse('/artifact'), (error) => {
+      assert.equal(error.status, 404);
+      assert.equal(error.code, 'preview-not-found');
+      return true;
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
 });
 
 test('host entry declares the plugin shape and serves client-assets static files', async () => {

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/artifact-feedback.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/artifact-feedback.js
@@ -1,0 +1,97 @@
+// 产物评论与修订（issue #97 轻通道）：微图构造与修订提取的纯函数。
+// 服务端路由 lib/index.js 消费；单测 test/artifact-feedback.test.mjs 直接跑这里。
+
+const REVISION_AGENT_NODE_ID = 'revision_agent';
+const MAX_INLINE_BODY = 2000;
+const MAX_REVISION_CONTENT = 120 * 1024; // 修订正文入库上限，防超大文件撑爆 document_json 行
+
+export function revisionAgentNodeId() {
+  return REVISION_AGENT_NODE_ID;
+}
+
+function clampText(value, max, label) {
+  const text = String(value ?? '');
+  if (text.length <= max) return text;
+  return `${text.slice(0, max)}\n…（${label}过长已截断）`;
+}
+
+// 评论列表 → 有序去重的用户意见文本；单条超长截断
+export function formatCommentBodies(comments = []) {
+  const seen = new Set();
+  const lines = [];
+  for (const comment of comments || []) {
+    const body = String(comment?.body || '').trim();
+    if (!body || seen.has(body)) continue;
+    seen.add(body);
+    lines.push(clampText(body, MAX_INLINE_BODY, '评论'));
+  }
+  return lines;
+}
+
+// 单 agent 微图：原稿已由路由复制进该节点输出目录，prompt 只携带评论清单（与文档长度解耦）
+export function buildRevisionGraph({ comments = [], originalName, fileName, sourceFileName, instruction } = {}) {
+  const lines = formatCommentBodies(comments);
+  const inputName = sourceFileName || fileName;
+  const commentBlock = lines.length
+    ? lines.map((body, index) => `${index + 1}. ${body}`).join('\n')
+    : '（无具体评论，按通用润化要求处理）';
+  const prompt = [
+    '你是一名文稿修订编辑。用户在工作流产物文稿上写下了评论/修改建议，你的任务：以原稿为唯一事实来源，按评论逐条落实修改，产出完整修订稿。',
+    '- 原稿只读，绝不改动；修订稿必须写入你自己的输出目录。',
+    '- 未被评论涉及的内容保持原样，不做自由发挥；格式约定（Markdown 层级、代码块语言标注等）与原稿一致。',
+    `- 修订稿文件名固定为 ${fileName}，与原稿同名便于对照（不同目录不会覆盖）。`,
+    `- 原稿副本文件名为 ${inputName}，只读读取，不要覆盖、删除或把它当作修订稿交付。`,
+    '- 最终回复只需简述改了什么（每条评论一行），不要复述全文。',
+  ].join('\n');
+  const inputTemplate = [
+    `原稿：${originalName}（副本 ${inputName} 已放入你的输出目录，用 read 工具读取全文）`,
+    instruction ? `补充要求：${clampText(instruction, MAX_INLINE_BODY, '补充要求')}` : '',
+    '',
+    '用户评论/修改建议：',
+    commentBlock,
+  ].filter((line) => line !== '').join('\n');
+  return {
+    nodes: [{
+      id: REVISION_AGENT_NODE_ID,
+      type: 'agent',
+      position: { x: 0, y: 0 },
+      data: {
+        label: '按评论修订',
+        prompt,
+        inputTemplate,
+        inputFiles: [inputName],
+        skills: [],
+      },
+    }],
+    edges: [],
+  };
+}
+
+// 从改写 run 的产物快照中选修订稿：优先同名 md/doc 类文本，否则第一个文本产物
+function pickRevisionArtifact(artifacts = [], fileName) {
+  const textual = (artifact) => /\.(md|markdown|txt)$/i.test(artifact?.name || '');
+  return artifacts.find((artifact) => artifact?.nodeId === REVISION_AGENT_NODE_ID && artifact?.name === fileName)
+    || artifacts.find((artifact) => artifact?.nodeId === REVISION_AGENT_NODE_ID && textual(artifact))
+    || artifacts.find((artifact) => artifact?.nodeId === REVISION_AGENT_NODE_ID) || null;
+}
+
+// run 落盘后提取修订记录入版本链；读文件由调用方注入（保持纯函数可测）
+export function extractRevision({ run, fileName, readFile }) {
+  if (!run || run.status !== 'success') return null;
+  const artifact = pickRevisionArtifact(run.artifactIndex || [], fileName);
+  if (!artifact?.snapshot) return null;
+  let content = null;
+  try {
+    content = clampText(readFile(artifact), MAX_REVISION_CONTENT, '修订正文');
+  } catch {
+    content = null; // 快照读失败：记录元数据，正文留空，前端提示下载兜底
+  }
+  return {
+    nodeId: REVISION_AGENT_NODE_ID,
+    revisionRunId: run.runId,
+    name: artifact.name,
+    summary: String(run.outputs?.[REVISION_AGENT_NODE_ID] || '').slice(0, 500) || null,
+    fileName: artifact.name,
+    content,
+  };
+}

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
@@ -76,7 +76,7 @@ export class Orchestrator {
   }
 
   async run(graph, {
-    triggerInput = '', runId, workflowName, workflowId, canvasId, source, workspaceRoot,
+    triggerInput = '', runId, workflowName, workflowId, canvasId, source, workspaceRoot, revises,
     globalVariables = {}, workflowVariables = {}, runInputs = {},
     resume = null,
   } = {}) {
@@ -86,6 +86,7 @@ export class Orchestrator {
       runId: id, startedAt: new Date().toISOString(), status: 'running',
       triggerInput, runInputs: safeRunInputs, workflowName: workflowName || null, workflowId: workflowId || null,
       canvasId: canvasId || null, source: source || null, workspaceRoot: workspaceRoot || null,
+      revises: revises || null,
       schemaVersion: RUN_SCHEMA_VERSION,
       nodeStates: {}, outputs: {}, structuredOutputs: {}, nodeOrder: [],
       canceled: false,

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -56,6 +56,7 @@ import { listFeishuCreds, addFeishuCred, removeFeishuCred, setDefaultFeishuCred,
 import { Orchestrator, lintGraph, getKind } from './engine.js';
 import { createWorkflowExportManifest, importWorkflowDocument, normalizeWorkflowDocument } from './workflow-document.js';
 import { saveArtifactsToWorkspace } from './artifact-save.js';
+import { buildRevisionGraph, extractRevision, revisionAgentNodeId } from './artifact-feedback.js';
 import { createStoragePaths } from './storage-paths.js';
 import { WorkflowSqliteStore } from './sqlite-store.js';
 import {
@@ -920,9 +921,10 @@ export function apply(ctx, config) {
     }
   };
   // 保留策略：SQLite 提交删除后，再清理对应运行产物目录。
+  // 改写 run（source='revision'）不受该窗口挤压：仍在版本链里的修订引用其产物正文。
   const pruneRuns = () => {
     try {
-      for (const run of currentDatabase().pruneRuns(RUNS_KEEP)) {
+      for (const run of currentDatabase().pruneRuns(RUNS_KEEP, { keepRevisionRuns: currentDatabase().revisionRunIds() })) {
         try {
           rmSync(STORAGE.runRoot({ workflowId: run.workflowId || 'draft', runId: run.runId }), { recursive: true, force: true });
         } catch (error) {
@@ -957,9 +959,12 @@ export function apply(ctx, config) {
     const document = normalizeRunDocument(run);
     return currentDatabase().putRun(document);
   };
-  const recentRuns = (limit = 50, workflowId) => currentDatabase().listRuns(limit, workflowId).map((run) => (
-    run.status === 'running' && !pendingRunIds.has(run.runId) ? (readRun(run.runId) || run) : run
-  ));
+  const recentRuns = (limit = 50, workflowId) => currentDatabase().listRuns(limit, workflowId)
+    // 改写 run（source='revision'）归组到被修产物的版本链下展示，不作为独立运行条目
+    .filter((run) => run.source !== 'revision')
+    .map((run) => (
+      run.status === 'running' && !pendingRunIds.has(run.runId) ? (readRun(run.runId) || run) : run
+    ));
   const checkpointRun = (runId) => {
     const live = orch?.runs.get(runId);
     if (!live || live.run.workspaceRoot !== currentStore().workspaceRoot) return;
@@ -1061,7 +1066,7 @@ export function apply(ctx, config) {
 
   const startRun = (graph, {
     triggerInput, workflowName, workflowId, canvasId, source,
-    globalVariables = {}, workflowVariables = {}, runInputs = {}, runId: providedRunId, replayOf, resume,
+    globalVariables = {}, workflowVariables = {}, runInputs = {}, runId: providedRunId, replayOf, resume, revises,
   } = {}) => {
     const store = currentStore();
     const runId = providedRunId || `run_${Date.now().toString(36)}_${++runIdSeq}`;
@@ -1074,6 +1079,7 @@ export function apply(ctx, config) {
         runId, status: 'running', startedAt: new Date().toISOString(),
         triggerInput: triggerInput ?? '', workflowName: workflowName || null, workflowId: workflowId || null,
         canvasId: canvasId || null, source: source || null, replayOf: replayOf || null,
+        revises: revises || null,
         ...(resume ? { resumedFrom: resume.runId || null } : {}),
         nodeStates: {}, outputs: {}, structuredOutputs: {}, issues: [],
         graph: graph ? { nodes: graph.nodes.map((n) => ({ id: n.id, type: n.type, position: n.position, data: n.data })), edges: graph.edges } : undefined,
@@ -1081,12 +1087,13 @@ export function apply(ctx, config) {
       }));
     } catch { /* 快照写失败不阻塞运行；最终 persistRun 仍会落盘 */ }
     const promise = workspaceContext.run(store, () => Promise.resolve().then(() => orch.run(graph, {
-      triggerInput, workflowName, workflowId, canvasId, source, runId,
+      triggerInput, workflowName, workflowId, canvasId, source, runId, revises,
       workspaceRoot: store.workspaceRoot,
       globalVariables, workflowVariables, runInputs,
       resume,
     })).then(async (run) => {
       if (replayOf) run.replayOf = replayOf;
+      if (revises) run.revises = revises;
       try { await notifications.complete(runId, run); }
       catch (error) {
         notifications.discard(runId);
@@ -1155,7 +1162,7 @@ export function apply(ctx, config) {
     const rendered = renderTemplate(d.inputTemplate || '', tctx);
     let userPrompt = rendered.text || '(无上游输入)';
     const attachments = (s.graph?.nodes || []).filter((n) => n.type === 'input').flatMap((n) => n.data?.attachments || []);
-    const inputFiles = [];
+    const inputFiles = Array.isArray(d.inputFiles) ? d.inputFiles.map((file) => safeFilename(file)).filter(Boolean) : [];
     if (attachments.length) {
       for (const att of attachments) {
         try {
@@ -2771,6 +2778,127 @@ export function apply(ctx, config) {
       else if (!files[`${nodeId}\u0000${file}`]) files[`${nodeId}\u0000${file}`] = { omitted: true };
     }
     return json(res, 200, { files });
+  } });
+
+  // ---- 产物评论与修订（issue #97 轻通道）----
+  // 评论/修订存独立表（run 文档之外的用户数据，run 历史保持不可变）。
+  // GET /wf1/api/comments?runId= → { comments, revisions }：一次拉全 run 的评论与版本链，前端按卡归组
+  register({ kind: 'exact', path: '/wf1/api/comments', async handler(req, res) {
+    const url = new URL(req.url, 'http://x');
+    const runId = url.searchParams.get('runId') || '';
+    if (!runId) return json(res, 400, { error: '缺少 runId' });
+    const db = currentDatabase();
+    const comments = req.method === 'GET' ? db.listArtifactComments(runId) : [];
+    const revisions = db.listArtifactRevisions(runId);
+    return json(res, 200, { comments, revisions });
+  } });
+
+  // POST /wf1/api/comments { runId, nodeId, artifactId, body } → { comment }；DELETE ?id=
+  register({ kind: 'exact', path: '/wf1/api/comments/add', async handler(req, res) {
+    if (req.method !== 'POST') return json(res, 405, { error: 'method' });
+    const body = await readBody(req);
+    const runId = String(body?.runId || '');
+    const nodeId = String(body?.nodeId || '');
+    const artifactId = String(body?.artifactId || '');
+    const text = String(body?.body || '').trim();
+    if (!runId || !nodeId || !artifactId) return json(res, 400, { error: '需要 runId、nodeId、artifactId' });
+    if (!text) return json(res, 400, { error: '评论内容不能为空' });
+    if (!readRun(runId)) return json(res, 404, { error: '运行记录不存在' });
+    const comment = currentDatabase().addArtifactComment({ runId, nodeId, artifactId, body: text });
+    return json(res, 200, { ok: true, comment });
+  } });
+
+  register({ kind: 'exact', path: '/wf1/api/comments/delete', async handler(req, res) {
+    if (req.method !== 'POST') return json(res, 405, { error: 'method' });
+    const body = await readBody(req);
+    const id = Number(body?.id);
+    if (!Number.isInteger(id) || id <= 0) return json(res, 400, { error: '需要有效 id' });
+    const removed = currentDatabase().deleteArtifactComment(id);
+    return json(res, 200, { ok: removed });
+  } });
+
+  // POST /wf1/api/artifacts/revise：按评论改写这一篇（轻通道）。
+  // 动态合成单 agent 微图，原稿复制进改写节点输出目录，以 source='revision' 走引擎正常起跑
+  // （超时/重试/llm-guard/usage 免费复用）；完成后修订正文入版本链表，不写回原 run。
+  register({ kind: 'exact', path: '/wf1/api/artifacts/revise', async handler(req, res) {
+    if (req.method !== 'POST') return json(res, 405, { error: 'method' });
+    const body = await readBody(req);
+    const runId = String(body?.runId || '');
+    const nodeId = String(body?.nodeId || '');
+    const artifactId = String(body?.artifactId || '');
+    const instruction = String(body?.instruction || '').trim();
+    if (!runId || !nodeId || !artifactId) return json(res, 400, { error: '需要 runId、nodeId、artifactId' });
+    const run = readRun(runId);
+    if (!run) return json(res, 404, { error: '运行记录不存在' });
+    if (run.source === 'revision') return json(res, 400, { error: '改写稿不能再次发起改写' });
+    // 产物定位：先按 artifactIndex id，未命中回退按 name（文稿卡前端两形态都可能传）
+    let resolved = resolveRunArtifact(artifactLocationsForRun(run), run, artifactId);
+    if (!resolved) {
+      const byName = (run.artifactIndex || []).find((item) => item.name === artifactId);
+      if (byName) resolved = resolveRunArtifact(artifactLocationsForRun(run), run, byName.id);
+    }
+    if (!resolved) return json(res, 404, { error: '产物不存在或已被清理' });
+    const comments = currentDatabase().listArtifactComments(runId)
+      .filter((row) => row.node_id === nodeId && row.artifact_id === resolved.artifact.name);
+    if (!comments.length && !instruction) return json(res, 400, { error: '没有可用的评论或补充要求' });
+
+    const revisionRunId = `run_${Date.now().toString(36)}_rev${++runIdSeq}`;
+    // 原稿复制进改写节点输出目录：prompt 与文档长度解耦，agent 用 read 工具自取
+    const revisionWs = STORAGE.workspaceForNode({
+      workflowId: run.workflowId || 'draft', runId: revisionRunId, nodeId: revisionAgentNodeId(),
+    });
+    const fileName = safeFilename(resolved.artifact.name);
+    const sourceFileName = `__wf1_original__${fileName}`;
+    try {
+      mkdirSync(revisionWs, { recursive: true, mode: 0o700 });
+      copyFileSync(resolved.file, resolveInside(revisionWs, sourceFileName) || join(revisionWs, sourceFileName));
+    } catch (error) {
+      return json(res, 500, { error: `原稿复制失败：${error.message}` });
+    }
+    const graph = buildRevisionGraph({
+      comments,
+      originalName: resolved.artifact.name,
+      fileName,
+      sourceFileName,
+      instruction,
+    });
+    const { runId: startedId, promise } = startRun(graph, {
+      workflowId: run.workflowId || null,
+      workflowName: `${run.workflowName || run.runId} · 按评论修订`,
+      source: 'revision',
+      runId: revisionRunId,
+      revises: { runId, nodeId, artifactId: resolved.artifact.name },
+    });
+    // 路由即刻返回；修订落库在 run 收尾后异步执行。
+    // .then 已脱离路由的 workspaceContext（AsyncLocalStorage），须以路由捕获的 store 重入
+    const routeStore = currentStore();
+    // 评论/修订统一以产物 name 为键（与前端卡片键一致；artifactId 参数可能是索引 id）
+    const artifactKey = resolved.artifact.name;
+    promise.then((revisionRun) => {
+      if (!revisionRun) return;
+      workspaceContext.run(routeStore, () => {
+        const persisted = readRun(startedId);
+        const record = persisted && extractRevision({
+          run: persisted,
+          fileName,
+          readFile: (artifact) => {
+            const found = resolveRunArtifact(artifactLocationsForRun(persisted), persisted, artifact.id);
+            if (!found) throw new Error('快照文件缺失');
+            return readFileSync(found.file, 'utf8');
+          },
+        });
+        if (!record) return;
+        currentDatabase().addArtifactRevision({
+          targetRunId: runId, nodeId, artifactId: artifactKey,
+          revisionRunId: record.revisionRunId,
+          name: record.name, summary: record.summary, fileName: record.fileName, content: record.content,
+        });
+        broadcast('revision-ready', { runId, nodeId, artifactId: artifactKey, revisionRunId: startedId });
+      });
+    }).catch((error) => {
+      ctx.logger?.error?.(`[wf1] 修订落库失败（${runId}/${artifactKey} → ${startedId}）：${error.message}`);
+    });
+    return json(res, 200, { ok: true, revisionRunId: startedId });
   } });
 
   // ---- /workflow-one 触发源执行端（#63）----

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -2743,39 +2743,61 @@ export function apply(ctx, config) {
     const items = Array.isArray(body?.items) ? body.items.slice(0, 200) : [];
     if (!runId || !items.length) return json(res, 400, { error: '需要 runId 和 items' });
     const run = readRun(runId);
-    // 与 /artifact 兜底同款：沿 resumedFrom 祖先链回退定位节点工作区
-    const ancestorRunIds = [runId];
+    if (!run) return json(res, 404, { error: '运行记录不存在', code: 'run-not-found' });
+    // 与 /artifact 兜底同款：沿 resumedFrom 祖先链回退定位节点工作区；
+    // 优先读不可变快照，避免历史运行的节点工作区已清理时正文仍不可读。
+    const ancestorRuns = [run];
     let cursor = run;
     for (let depth = 0; cursor?.resumedFrom && depth < 10; depth += 1) {
-      ancestorRunIds.push(cursor.resumedFrom);
       cursor = readRun(cursor.resumedFrom);
+      if (cursor) ancestorRuns.push(cursor);
     }
     const BUDGET = 1.5 * 1024 * 1024;
     const CLIP = 4096;
     const files = {};
     let used = 0;
+    const readCandidate = (candidateRun, nodeId, file, requestedArtifactId = '') => {
+      const indexed = (candidateRun.artifactIndex || []).filter((artifact) => artifact?.nodeId === nodeId);
+      const byId = requestedArtifactId ? indexed.find((artifact) => artifact.id === requestedArtifactId) : null;
+      const exact = byId || indexed.find((artifact) => artifact.relativePath === file || artifact.name === file);
+      const byName = indexed.filter((artifact) => artifact.name === file);
+      const candidates = exact ? [exact, ...byName.filter((artifact) => artifact.id !== exact.id)] : byName;
+      for (const artifact of candidates) {
+        const resolved = resolveRunArtifact(artifactLocationsForRun(candidateRun), candidateRun, artifact.id);
+        if (resolved?.file) return resolved.file;
+      }
+      const ws = resolveInside(STORAGE.workspaceForNode({
+        workflowId: candidateRun.workflowId || run.workflowId || 'draft', runId: candidateRun.runId, nodeId,
+      }), file);
+      if (!ws || !existsSync(ws) || !statSync(ws).isFile()) return null;
+      const realWs = realpathSync(ws);
+      if (resolveInside(realpathSync(dirname(realWs)), realWs) !== realWs) return null;
+      return realWs;
+    };
     for (const item of items) {
       const nodeId = String(item?.node || '');
       const file = String(item?.file || '');
+      const artifactId = String(item?.artifactId || '');
+      const key = `${nodeId}\u0000${file}`;
       if (!nodeId || !file) continue;
       const ext = extname(file).toLowerCase();
-      if (!['.md', '.markdown', '.txt', '.csv'].includes(ext)) continue;
-      let content = null;
-      for (const candidateRunId of ancestorRunIds) {
-        const ws = resolveInside(STORAGE.workspaceForNode({
-          workflowId: run?.workflowId || 'draft', runId: candidateRunId, nodeId,
-        }), file);
-        if (!ws || !existsSync(ws) || !statSync(ws).isFile()) continue;
-        const realWs = realpathSync(ws);
-        if (resolveInside(realpathSync(dirname(realWs)), realWs) !== realWs) continue;
-        if (used > BUDGET) { files[`${nodeId}\u0000${file}`] = { omitted: true }; break; }
-        const raw = readFileSync(realWs, 'utf8');
-        used += Buffer.byteLength(raw);
-        content = raw.length > CLIP ? { content: `${raw.slice(0, CLIP)}…`, truncated: true } : { content: raw, truncated: false };
-        break;
+      if (!['.md', '.markdown', '.txt', '.csv'].includes(ext)) {
+        files[key] = { missing: true, reason: 'unsupported-type' };
+        continue;
       }
-      if (content) files[`${nodeId}\u0000${file}`] = content;
-      else if (!files[`${nodeId}\u0000${file}`]) files[`${nodeId}\u0000${file}`] = { omitted: true };
+      const source = ancestorRuns.map((candidateRun) => readCandidate(candidateRun, nodeId, file, artifactId)).find(Boolean);
+      if (!source) {
+        files[key] = { missing: true, reason: 'artifact-not-found' };
+        continue;
+      }
+      const size = statSync(source).size;
+      if (used + size > BUDGET) {
+        files[key] = { omitted: true, reason: 'budget' };
+        continue;
+      }
+      const raw = readFileSync(source, 'utf8');
+      used += size;
+      files[key] = raw.length > CLIP ? { content: `${raw.slice(0, CLIP)}…`, truncated: true } : { content: raw, truncated: false };
     }
     return json(res, 200, { files });
   } });

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/sqlite-store.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/sqlite-store.js
@@ -14,7 +14,7 @@ import { basename, dirname, join } from 'node:path';
 import { normalizeRunDocument } from './run-results.js';
 import { normalizeWorkflowDocument } from './workflow-document.js';
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 
 const SCHEMA = `
   CREATE TABLE IF NOT EXISTS workflows (
@@ -38,6 +38,30 @@ const SCHEMA = `
   ) STRICT;
   CREATE INDEX IF NOT EXISTS runs_started_at ON runs(started_at DESC);
   CREATE INDEX IF NOT EXISTS runs_workflow_started_at ON runs(workflow_id, started_at DESC);
+
+  CREATE TABLE IF NOT EXISTS artifact_comments (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id TEXT NOT NULL,
+    node_id TEXT NOT NULL,
+    artifact_id TEXT NOT NULL,
+    body TEXT NOT NULL,
+    created_at TEXT NOT NULL
+  ) STRICT;
+  CREATE INDEX IF NOT EXISTS artifact_comments_scope ON artifact_comments(run_id, node_id, artifact_id, id);
+
+  CREATE TABLE IF NOT EXISTS artifact_revisions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    target_run_id TEXT NOT NULL,
+    node_id TEXT NOT NULL,
+    artifact_id TEXT NOT NULL,
+    revision_run_id TEXT NOT NULL,
+    name TEXT,
+    summary TEXT,
+    file_name TEXT,
+    content TEXT,
+    created_at TEXT NOT NULL
+  ) STRICT;
+  CREATE INDEX IF NOT EXISTS artifact_revisions_scope ON artifact_revisions(target_run_id, node_id, artifact_id, id);
 `;
 
 const jsonFiles = (dir) => {
@@ -91,6 +115,20 @@ export class WorkflowSqliteStore {
     const version = Number(this.db.prepare('PRAGMA user_version').get()?.user_version || 0);
     if (version > SCHEMA_VERSION) throw new Error(`不支持的 Workflow One SQLite schema：${version}`);
     if (version === SCHEMA_VERSION) return;
+
+    // JSON 目录重导只在 legacy → SQLite（0→N）时做；已有库小版本升级（如 1→2 加表）只执行 DDL，
+    // 否则陈旧的迁移源 JSON 会 upsert 覆盖库内更新的数据。
+    if (version > 0) {
+      this.db.exec('BEGIN IMMEDIATE');
+      try {
+        this.db.exec(SCHEMA);
+        this.db.exec(`PRAGMA user_version = ${SCHEMA_VERSION}; COMMIT;`);
+      } catch (error) {
+        try { this.db.exec('ROLLBACK'); } catch { /* transaction already closed */ }
+        throw error;
+      }
+      return;
+    }
 
     const workflows = [];
     const runs = [];
@@ -191,6 +229,17 @@ export class WorkflowSqliteStore {
       `),
       staleRuns: this.db.prepare('SELECT run_id, workflow_id FROM runs ORDER BY started_at DESC, run_id DESC LIMIT -1 OFFSET ?'),
       deleteRun: this.db.prepare('DELETE FROM runs WHERE run_id = ?'),
+      addComment: this.db.prepare('INSERT INTO artifact_comments (run_id, node_id, artifact_id, body, created_at) VALUES (?, ?, ?, ?, ?)'),
+      getComment: this.db.prepare('SELECT id, run_id, node_id, artifact_id, body, created_at FROM artifact_comments WHERE id = ?'),
+      listComments: this.db.prepare('SELECT id, run_id, node_id, artifact_id, body, created_at FROM artifact_comments WHERE run_id = ? ORDER BY id ASC'),
+      deleteComment: this.db.prepare('DELETE FROM artifact_comments WHERE id = ?'),
+      deleteCommentsForRun: this.db.prepare('DELETE FROM artifact_comments WHERE run_id = ?'),
+      addRevision: this.db.prepare(`INSERT INTO artifact_revisions
+        (target_run_id, node_id, artifact_id, revision_run_id, name, summary, file_name, content, created_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`),
+      listRevisions: this.db.prepare('SELECT * FROM artifact_revisions WHERE target_run_id = ? ORDER BY id ASC'),
+      deleteRevisionsForRun: this.db.prepare('DELETE FROM artifact_revisions WHERE target_run_id = ?'),
+      revisionRunIds: this.db.prepare('SELECT DISTINCT revision_run_id FROM artifact_revisions'),
     };
   }
 
@@ -268,13 +317,19 @@ export class WorkflowSqliteStore {
     return this.#runRunStatement(this.statements.putRun, value);
   }
 
-  pruneRuns(keep) {
+  pruneRuns(keep, { keepRevisionRuns = [] } = {}) {
     const count = Math.max(0, Math.floor(Number(keep) || 0));
-    const stale = this.statements.staleRuns.all(count).map((row) => ({ runId: row.run_id, workflowId: row.workflow_id }));
+    const protectedIds = new Set(keepRevisionRuns.map(String));
+    const stale = this.statements.staleRuns.all(count)
+      .map((row) => ({ runId: row.run_id, workflowId: row.workflow_id }))
+      .filter((row) => !protectedIds.has(row.runId));
     if (!stale.length) return stale;
     this.db.exec('BEGIN IMMEDIATE');
     try {
-      for (const row of stale) this.statements.deleteRun.run(row.runId);
+      for (const row of stale) {
+        this.deleteRunData(row.runId);
+        this.statements.deleteRun.run(row.runId);
+      }
       this.db.exec('COMMIT');
     } catch (error) {
       try { this.db.exec('ROLLBACK'); } catch { /* transaction already closed */ }
@@ -282,6 +337,53 @@ export class WorkflowSqliteStore {
     }
     try { this.db.exec('PRAGMA incremental_vacuum(1000)'); } catch { /* 回收失败不影响已提交删除 */ }
     return stale;
+  }
+
+  // ---- 产物评论与修订（run 文档之外的用户数据；见 issue #97）----
+
+  addArtifactComment({ runId, nodeId, artifactId, body, createdAt }) {
+    const created = createdAt || new Date().toISOString();
+    const info = this.statements.addComment.run(String(runId), String(nodeId), String(artifactId), String(body ?? ''), created);
+    return this.getArtifactComment(Number(info.lastInsertRowid));
+  }
+
+  getArtifactComment(id) {
+    return this.statements.getComment.get(Number(id)) || null;
+  }
+
+  listArtifactComments(runId) {
+    return this.statements.listComments.all(String(runId));
+  }
+
+  deleteArtifactComment(id) {
+    return Number(this.statements.deleteComment.run(Number(id)).changes) > 0;
+  }
+
+  addArtifactRevision({ targetRunId, nodeId, artifactId, revisionRunId, name, summary, fileName, content, createdAt }) {
+    const created = createdAt || new Date().toISOString();
+    const info = this.statements.addRevision.run(
+      String(targetRunId), String(nodeId), String(artifactId), String(revisionRunId),
+      name == null ? null : String(name),
+      summary == null ? null : String(summary),
+      fileName == null ? null : String(fileName),
+      content == null ? null : String(content),
+      created,
+    );
+    return Number(info.lastInsertRowid);
+  }
+
+  listArtifactRevisions(targetRunId) {
+    return this.statements.listRevisions.all(String(targetRunId));
+  }
+
+  revisionRunIds() {
+    return this.statements.revisionRunIds.all().map((row) => row.revision_run_id);
+  }
+
+  // run 记录删除时级联清理其评论与修订；修订正文所引用的改写 run 由调用方按 revisionRunIds 决策
+  deleteRunData(runId) {
+    this.statements.deleteCommentsForRun.run(String(runId));
+    this.statements.deleteRevisionsForRun.run(String(runId));
   }
 
   close() {

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/artifact-feedback.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/artifact-feedback.integration.test.mjs
@@ -114,6 +114,50 @@ try {
     mkdirSync(runDir, { recursive: true });
     writeFileSync(join(runDir, 'art_report'), '# 巡检报告\n正文…');
   }
+  const batchRun = {
+    runId: 'run_fb_batch', workflowId: 'wf_fb', status: 'success',
+    startedAt: '2026-08-11T00:00:00.000Z', finishedAt: '2026-08-11T00:00:02.000Z',
+    nodeStates: { n_batch: { status: 'success', artifacts: ['reports/nested.md'] } },
+    artifactIndex: [{ id: 'art_nested', nodeId: 'n_batch', name: 'nested.md', relativePath: 'reports/nested.md', snapshot: 'run_fb_batch/art_nested', previewable: true, size: 14, mediaType: 'text/markdown' }],
+    schemaVersion: 3,
+  };
+  {
+    const db = new DatabaseSync(databaseFile(workspace));
+    try {
+      db.prepare(`INSERT INTO runs (run_id, workflow_id, status, started_at, finished_at, updated_at, document_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(run_id) DO UPDATE SET document_json=excluded.document_json`)
+        .run(batchRun.runId, batchRun.workflowId, batchRun.status, batchRun.startedAt, batchRun.finishedAt, new Date().toISOString(), JSON.stringify(batchRun));
+    } finally { db.close(); }
+  }
+  {
+    const { hashedKey } = await import('../lib/storage-paths.js');
+    const runDir = join(artifactDir, hashedKey('wf_fb'), hashedKey('run_fb_batch'), 'artifacts', 'run_fb_batch');
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(join(runDir, 'art_nested'), '# 快照正文');
+    const workspaceDir = join(workspace, '.workflow-one', 'runtime', hashedKey('wf_fb'), hashedKey('run_fb_batch'), 'nodes', hashedKey('n_batch'), 'workspace', 'reports');
+    mkdirSync(workspaceDir, { recursive: true });
+    writeFileSync(join(workspaceDir, 'nested.md'), '# 工作区旧正文');
+  }
+
+  console.log('feedback api integration tests:');
+
+  // 批量正文优先读 immutable snapshot，并保留嵌套路径与 artifactId 定位
+  {
+    const res = await call('POST', '/wf1/api/artifacts/content', {
+      runId: 'run_fb_batch', items: [{ node: 'n_batch', file: 'reports/nested.md', artifactId: 'art_nested' }],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.files[`n_batch\u0000reports/nested.md`].content, '# 快照正文');
+  }
+  // 批量正文区分缺失文件
+  {
+    const res = await call('POST', '/wf1/api/artifacts/content', {
+      runId: 'run_fb_batch', items: [{ node: 'n_batch', file: 'missing.md' }],
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.files[`n_batch\u0000missing.md`].missing, true);
+  }
 
   console.log('feedback api integration tests:');
 

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/artifact-feedback.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/artifact-feedback.integration.test.mjs
@@ -1,0 +1,215 @@
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { DatabaseSync } from 'node:sqlite';
+import { apply } from '../lib/index.js';
+
+function responseCapture() {
+  return {
+    status: 0,
+    chunks: [],
+    writableEnded: false,
+    writeHead(status) { this.status = status; },
+    write(chunk) { this.chunks.push(Buffer.from(chunk)); },
+    end(chunk) { if (chunk) this.chunks.push(Buffer.from(chunk)); this.writableEnded = true; },
+    on() { return this; },
+    destroy(error) { if (error) throw error; },
+    json() { return JSON.parse(Buffer.concat(this.chunks).toString('utf8') || '{}'); },
+  };
+}
+
+function request(method, url, body) {
+  const req = new EventEmitter();
+  req.method = method;
+  req.url = url;
+  req.headers = {};
+  queueMicrotask(() => {
+    if (body !== undefined) req.emit('data', Buffer.from(JSON.stringify(body)));
+    req.emit('end');
+  });
+  return req;
+}
+
+const withSession = (url, sessionId) => `${url}${url.includes('?') ? '&' : '?'}sessionId=${sessionId}`;
+const databaseFile = (workspace) => join(workspace, '.workflow-one', 'workflow-one.sqlite');
+const readStoredRun = (workspace, runId) => {
+  if (!existsSync(databaseFile(workspace))) return null;
+  const db = new DatabaseSync(databaseFile(workspace), { readOnly: true });
+  try {
+    const row = db.prepare('SELECT document_json FROM runs WHERE run_id = ?').get(runId);
+    return row ? JSON.parse(row.document_json) : null;
+  } finally {
+    db.close();
+  }
+};
+
+const dshHome = mkdtempSync(join(tmpdir(), 'wf1-fbhome-'));
+const workspacesRoot = mkdtempSync(join(tmpdir(), 'wf1-fbws-'));
+const workspace = join(workspacesRoot, 'ws');
+mkdirSync(workspace, { recursive: true });
+const originalDshHome = process.env.DSH_HOME;
+process.env.DSH_HOME = dshHome;
+const packageLegacyDir = join(dshHome, 'package-legacy');
+mkdirSync(join(packageLegacyDir, 'state'), { recursive: true });
+process.env.WF1_LEGACY_DATA_DIR = packageLegacyDir;
+writeFileSync(join(packageLegacyDir, 'state', 'graph.json'), JSON.stringify({ nodes: [], edges: [] }));
+
+const disposers = [];
+try {
+  const routes = [];
+  const sessionMap = new Map([['session-1', { header: { cwd: workspace } }]]);
+  const ctx = {
+    webServer: { register(route) { routes.push(route); } },
+    tools: { register() {}, schemas() { return []; } },
+    get(name) {
+      if (name === 'sessions') return { get: (id) => sessionMap.get(String(id)), flush: async () => {} };
+      if (name === 'workspaceRegistry') return { list: () => [{ path: workspace }] };
+      return null;
+    },
+    skills: { async list() { return []; } },
+    llm: { listProviders() { return []; }, async listModels() { return []; } },
+    agentPresets: { async mount() {} },
+    logger: { info() {}, warn() {}, error() {} },
+    effect(setup) { const dispose = setup(); if (dispose) disposers.push(dispose); },
+  };
+  apply(ctx, {});
+  const route = (path) => routes.find((entry) => entry.kind === 'exact' && entry.path === path)?.handler;
+  const call = async (method, url, body) => {
+    const res = responseCapture();
+    await route(url.split('?')[0])(request(method, withSession(url, 'session-1'), body), res);
+    return { status: res.status, body: res.json() };
+  };
+
+  // ---- 准备：先经任一 API 触发 store 初始化，再 seed 一个带产物文件的成功 run ----
+  {
+    const warm = responseCapture();
+    await route('/wf1/api/runs')(request('GET', withSession('/wf1/api/runs', 'session-1')), warm);
+    assert.equal(warm.status, 200);
+  }
+  const inputRun = {
+    runId: 'run_fb_src', workflowId: 'wf_fb', status: 'success',
+    startedAt: '2026-08-10T00:00:00.000Z', finishedAt: '2026-08-10T00:00:02.000Z',
+    triggerInput: '', outputs: { n_input: 'ok' }, structuredOutputs: {},
+    nodeStates: { n_input: { status: 'success' } },
+    artifactIndex: [{ id: 'art_report', nodeId: 'n_input', name: '巡检报告.md', snapshot: 'run_fb_src/art_report', relativePath: '巡检报告.md', previewable: true, size: 10, mediaType: 'text/markdown' }],
+    schemaVersion: 3,
+  };
+  {
+    const db = new DatabaseSync(databaseFile(workspace));
+    try {
+      db.prepare(`INSERT INTO runs (run_id, workflow_id, status, started_at, finished_at, updated_at, document_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(run_id) DO UPDATE SET document_json=excluded.document_json`)
+        .run(inputRun.runId, inputRun.workflowId, inputRun.status, inputRun.startedAt, inputRun.finishedAt, new Date().toISOString(), JSON.stringify(inputRun));
+    } finally { db.close(); }
+  }
+  // 产物快照文件（resolveRunArtifact 按 snapshot 路径在 artifacts 目录下找）
+  const artifactDir = join(workspace, '.workflow-one', 'runtime');
+  mkdirSync(join(artifactDir), { recursive: true });
+  {
+    const { hashedKey } = await import('../lib/storage-paths.js');
+    const runDir = join(artifactDir, hashedKey('wf_fb'), hashedKey('run_fb_src'), 'artifacts', 'run_fb_src');
+    mkdirSync(runDir, { recursive: true });
+    writeFileSync(join(runDir, 'art_report'), '# 巡检报告\n正文…');
+  }
+
+  console.log('feedback api integration tests:');
+
+  // 评论 404：run 不存在
+  {
+    const res = await call('POST', '/wf1/api/comments/add', { runId: 'run_nope', nodeId: 'n_input', artifactId: 'art_report', body: 'x' });
+    assert.equal(res.status, 404);
+  }
+  // 评论写入 + 列表
+  {
+    const res = await call('POST', '/wf1/api/comments/add', { runId: 'run_fb_src', nodeId: 'n_input', artifactId: 'art_report', body: '语气太随意' });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.comment.body, '语气太随意');
+    const list = await call('GET', '/wf1/api/comments?runId=run_fb_src');
+    assert.equal(list.status, 200);
+    assert.equal(list.body.comments.length, 1);
+    assert.equal(list.body.revisions.length, 0);
+  }
+  // 空评论 400
+  {
+    const res = await call('POST', '/wf1/api/comments/add', { runId: 'run_fb_src', nodeId: 'n_input', artifactId: 'art_report', body: '   ' });
+    assert.equal(res.status, 400);
+  }
+  // revise：产物解析失败 → 404（用不存在的 artifactId）
+  {
+    const res = await call('POST', '/wf1/api/artifacts/revise', { runId: 'run_fb_src', nodeId: 'n_input', artifactId: '不存在.md' });
+    assert.equal(res.status, 404);
+  }
+  // revise：run 不存在 → 404
+  {
+    const res = await call('POST', '/wf1/api/artifacts/revise', { runId: 'run_nope', nodeId: 'n_input', artifactId: 'art_report' });
+    assert.equal(res.status, 404);
+  }
+  // revise happy path：起改写 run（agent 在测试 ctx 下必然失败，但 run 要落盘、revises 保留、原稿已复制）
+  let revisionRunId;
+  {
+    const add = await call('POST', '/wf1/api/comments/add', { runId: 'run_fb_src', nodeId: 'n_input', artifactId: 'art_report', body: '改正式些' });
+    assert.equal(add.status, 200);
+    const res = await call('POST', '/wf1/api/artifacts/revise', { runId: 'run_fb_src', nodeId: 'n_input', artifactId: 'art_report', instruction: '保持结构' });
+    assert.equal(res.status, 200);
+    revisionRunId = res.body.revisionRunId;
+    assert.ok(revisionRunId);
+    let stored;
+    for (let attempt = 0; attempt < 40; attempt += 1) {
+      stored = readStoredRun(workspace, revisionRunId);
+      if (stored && stored.status !== 'running') break;
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    }
+    assert.ok(stored, '改写 run 已落盘');
+    assert.equal(stored.source, 'revision');
+    assert.deepEqual(stored.revises, { runId: 'run_fb_src', nodeId: 'n_input', artifactId: '巡检报告.md' });
+    // 原 run 文档不可变红线：源 run 产物与字段未被改写
+    const src = readStoredRun(workspace, 'run_fb_src');
+    assert.equal(src.artifactIndex.length, 1);
+    assert.equal(src.artifactIndex[0].id, 'art_report');
+    assert.equal(src.source == null, true);
+  }
+  // 原稿已复制进改写节点工作区，并使用输入专用文件名，避免被收集为修订产物
+  {
+    const { hashedKey } = await import('../lib/storage-paths.js');
+    const revisionWs = join(workspace, '.workflow-one', 'runtime', hashedKey('wf_fb'), hashedKey(revisionRunId), 'nodes', hashedKey('revision_agent'), 'workspace');
+    assert.equal(existsSync(join(revisionWs, '__wf1_original__巡检报告.md')), true, '原稿已复制进改写 agent 工作区');
+    assert.equal(existsSync(join(revisionWs, '巡检报告.md')), false, '原稿副本不占用修订输出文件名');
+  }
+  // revision run 不进 /runs 列表
+  {
+    const res = await call('GET', '/wf1/api/runs?limit=50');
+    assert.equal(res.body.runs.some((r) => r.runId === revisionRunId), false, '改写 run 不作为独立运行条目');
+    assert.equal(res.body.runs.some((r) => r.runId === 'run_fb_src'), true);
+  }
+  // 改写 run 不能再发起改写
+  {
+    const res = await call('POST', '/wf1/api/artifacts/revise', { runId: revisionRunId, nodeId: 'revision_agent', artifactId: 'art_report' });
+    assert.equal(res.status, 400);
+  }
+  // 删除评论（清空全部两条）
+  {
+    const list = await call('GET', '/wf1/api/comments?runId=run_fb_src');
+    assert.equal(list.body.comments.length, 2);
+    for (const comment of list.body.comments) {
+      const res = await call('POST', '/wf1/api/comments/delete', { id: comment.id });
+      assert.equal(res.status, 200);
+    }
+    const after = await call('GET', '/wf1/api/comments?runId=run_fb_src');
+    assert.equal(after.body.comments.length, 0);
+  }
+
+  console.log('\nintegration tests passed');
+} catch (error) {
+  console.error(`  ✗\n    ${error.stack || error.message}`);
+  process.exitCode = 1;
+} finally {
+  for (const dispose of disposers) {
+    try { dispose(); } catch { /* 清理尽力而为 */ }
+  }
+  process.env.DSH_HOME = originalDshHome;
+  rmSync(workspacesRoot, { recursive: true, force: true });
+  rmSync(dshHome, { recursive: true, force: true });
+}

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/artifact-feedback.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/artifact-feedback.test.mjs
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { buildRevisionGraph, extractRevision, formatCommentBodies, revisionAgentNodeId } from '../lib/artifact-feedback.js';
+
+let passed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+    console.log(`  ✓ ${name}`);
+  } catch (error) {
+    console.error(`  ✗ ${name}\n    ${error.stack || error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+console.log('artifact feedback tests:');
+
+test('formatCommentBodies dedups and clamps long bodies', () => {
+  const lines = formatCommentBodies([
+    { body: '改正式些' },
+    { body: '改正式些' },
+    { body: '   ' },
+    { body: 'x'.repeat(2500) },
+    { body: null },
+  ]);
+  assert.equal(lines.length, 2);
+  assert.equal(lines[0], '改正式些');
+  assert.equal(lines[1].endsWith('（评论过长已截断）'), true);
+  assert.equal(lines[1].length < 2500, true);
+});
+
+test('buildRevisionGraph 单 agent 微图：评论进 inputTemplate，文件名进指令', () => {
+  const graph = buildRevisionGraph({
+    comments: [{ body: '语气太随意' }, { body: '补充数据来源' }],
+    originalName: '巡检报告.md',
+    fileName: '巡检报告.md',
+    instruction: '保持三段结构',
+  });
+  assert.equal(graph.nodes.length, 1);
+  assert.equal(graph.edges.length, 0);
+  const node = graph.nodes[0];
+  assert.equal(node.id, revisionAgentNodeId());
+  assert.equal(node.type, 'agent');
+  assert.equal(node.data.skills.length, 0);
+  assert.deepEqual(node.data.inputFiles, ['巡检报告.md']);
+  assert.equal(node.data.prompt.includes('巡检报告.md'), true);
+  assert.equal(node.data.inputTemplate.includes('1. 语气太随意'), true);
+  assert.equal(node.data.inputTemplate.includes('2. 补充数据来源'), true);
+  assert.equal(node.data.inputTemplate.includes('保持三段结构'), true);
+  // 裸 {{变量}} 约束不适用（纯后端模板），但模板引擎的 {{ }} 占位不得出现在评论拼接结果里被误渲染
+  assert.equal(node.data.inputTemplate.includes('{{'), false);
+});
+
+test('buildRevisionGraph 无评论时给通用润化占位', () => {
+  const graph = buildRevisionGraph({ comments: [], originalName: 'a.md', fileName: 'a.md', instruction: '' });
+  assert.equal(graph.nodes[0].data.inputTemplate.includes('（无具体评论'), true);
+});
+
+test('extractRevision 优先同名产物、读失败降级空正文', () => {
+  const run = {
+    runId: 'run_rev1', status: 'success',
+    outputs: { revision_agent: '改了两处' },
+    artifactIndex: [
+      { id: 'x1', nodeId: 'other_node', name: 'notes.txt', snapshot: 's1' },
+      { id: 'x2', nodeId: revisionAgentNodeId(), name: 'other.md', snapshot: 's2' },
+      { id: 'x3', nodeId: revisionAgentNodeId(), name: '巡检报告.md', snapshot: 's3' },
+    ],
+  };
+  const record = extractRevision({ run, fileName: '巡检报告.md', readFile: () => '# 新稿' });
+  assert.equal(record.fileName, '巡检报告.md');
+  assert.equal(record.content, '# 新稿');
+  assert.equal(record.summary, '改了两处');
+  assert.equal(record.revisionRunId, 'run_rev1');
+
+  const broken = extractRevision({ run, fileName: '巡检报告.md', readFile: () => { throw new Error('gone'); } });
+  assert.equal(broken.content, null);
+  assert.equal(broken.fileName, '巡检报告.md');
+});
+
+test('extractRevision 失败/无产物 run 返回 null', () => {
+  assert.equal(extractRevision({ run: { status: 'error', artifactIndex: [] }, fileName: 'a.md', readFile: () => '' }), null);
+  assert.equal(extractRevision({ run: { status: 'success', artifactIndex: [] }, fileName: 'a.md', readFile: () => '' }), null);
+  assert.equal(extractRevision({ run: null, fileName: 'a.md', readFile: () => '' }), null);
+});
+
+test('超长修订正文截断入库', () => {
+  const run = {
+    runId: 'r', status: 'success', outputs: {},
+    artifactIndex: [{ id: 'x', nodeId: revisionAgentNodeId(), name: 'a.md', snapshot: 's' }],
+  };
+  const record = extractRevision({ run, fileName: 'a.md', readFile: () => 'x'.repeat(200 * 1024) });
+  assert.equal(record.content.length < 200 * 1024, true);
+  assert.equal(record.content.endsWith('（修订正文过长已截断）'), true);
+});
+
+console.log(passed > 0 ? `\n${passed} tests passed` : '');

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/sqlite-feedback.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/sqlite-feedback.test.mjs
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { WorkflowSqliteStore } from '../lib/sqlite-store.js';
+
+let passed = 0;
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+    console.log(`  ✓ ${name}`);
+  } catch (error) {
+    console.error(`  ✗ ${name}\n    ${error.stack || error.message}`);
+    process.exitCode = 1;
+  }
+}
+
+const run = (runId, startedAt, status = 'success', workflowId = null) => ({
+  runId,
+  workflowId,
+  status,
+  startedAt,
+  finishedAt: startedAt,
+  nodeStates: {},
+  outputs: {},
+  structuredOutputs: {},
+});
+
+const openStore = (root) => {
+  mkdirSync(join(root, 'workflows'), { recursive: true });
+  mkdirSync(join(root, 'runs'), { recursive: true });
+  return new WorkflowSqliteStore({
+    databaseFile: join(root, 'workflow-one.sqlite'),
+    workflowsDir: join(root, 'workflows'),
+    runsDir: join(root, 'runs'),
+  });
+};
+
+console.log('sqlite feedback tables tests:');
+
+test('add/list/delete comments roundtrip, scoped by run', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wf1-fb-'));
+  try {
+    const store = openStore(root);
+    const c1 = store.addArtifactComment({ runId: 'run_a', nodeId: 'n1', artifactId: 'report.md', body: '语气太随意' });
+    const c2 = store.addArtifactComment({ runId: 'run_a', nodeId: 'n1', artifactId: 'report.md', body: '补充数据来源' });
+    store.addArtifactComment({ runId: 'run_b', nodeId: 'n1', artifactId: 'report.md', body: '别的 run' });
+    assert.equal(c1.id > 0 && c2.id > c1.id, true);
+    assert.deepEqual(store.listArtifactComments('run_a').map((c) => c.body), ['语气太随意', '补充数据来源']);
+    assert.equal(store.listArtifactComments('run_a')[0].node_id, 'n1');
+    assert.equal(store.deleteArtifactComment(c1.id), true);
+    assert.equal(store.listArtifactComments('run_a').length, 1);
+    store.close();
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('revisions version chain keeps insert order and revisionRunIds dedups', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wf1-fb-'));
+  try {
+    const store = openStore(root);
+    const id1 = store.addArtifactRevision({ targetRunId: 'run_a', nodeId: 'n1', artifactId: 'report.md', revisionRunId: 'run_rev1', name: 'report.md', summary: '改了语气', fileName: 'report.md', content: '# v1' });
+    store.addArtifactRevision({ targetRunId: 'run_a', nodeId: 'n1', artifactId: 'report.md', revisionRunId: 'run_rev2', name: 'report.md', summary: '补了来源', fileName: 'report.md', content: '# v2' });
+    const revisions = store.listArtifactRevisions('run_a');
+    assert.equal(revisions.length, 2);
+    assert.equal(revisions[0].id, id1);
+    assert.deepEqual(revisions.map((r) => r.revision_run_id), ['run_rev1', 'run_rev2']);
+    assert.deepEqual(store.revisionRunIds(), ['run_rev1', 'run_rev2']);
+    assert.equal(store.listArtifactRevisions('run_b').length, 0);
+    store.close();
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('pruneRuns keeps revision runs out of the stale window', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wf1-fb-'));
+  try {
+    const store = openStore(root);
+    // 3 条真实 run + 1 条改写 run（最老）；keep=3 时按时间窗口最老的该删，但它是修订引用，须保留
+    store.putRun(run('run_keep1', '2026-08-01T00:00:01.000Z'));
+    store.putRun(run('run_keep2', '2026-08-01T00:00:02.000Z'));
+    store.putRun(run('run_keep3', '2026-08-01T00:00:03.000Z'));
+    store.putRun({ ...run('run_rev_old', '2026-08-01T00:00:00.000Z'), source: 'revision' });
+    store.addArtifactRevision({ targetRunId: 'run_keep1', nodeId: 'n1', artifactId: 'a.md', revisionRunId: 'run_rev_old', name: 'a.md', summary: null, fileName: 'a.md', content: 'x' });
+    const pruned = store.pruneRuns(3, { keepRevisionRuns: store.revisionRunIds() });
+    assert.deepEqual(pruned.map((r) => r.runId), []);
+    assert.equal(store.getRun('run_rev_old') != null, true);
+    // 反例：不在保护清单里的最老 run 正常淘汰
+    store.putRun(run('run_oldest', '2026-07-31T00:00:00.000Z'));
+    const pruned2 = store.pruneRuns(3, { keepRevisionRuns: store.revisionRunIds() });
+    assert.deepEqual(pruned2.map((r) => r.runId), ['run_oldest']);
+    store.close();
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('deleteRunData cascades comments and revisions for the run', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wf1-fb-'));
+  try {
+    const store = openStore(root);
+    store.addArtifactComment({ runId: 'run_a', nodeId: 'n1', artifactId: 'a.md', body: 'x' });
+    store.addArtifactRevision({ targetRunId: 'run_a', nodeId: 'n1', artifactId: 'a.md', revisionRunId: 'run_rev1', name: 'a.md', summary: null, fileName: 'a.md', content: 'y' });
+    store.addArtifactComment({ runId: 'run_b', nodeId: 'n1', artifactId: 'a.md', body: 'keep' });
+    store.deleteRunData('run_a');
+    assert.equal(store.listArtifactComments('run_a').length, 0);
+    assert.equal(store.listArtifactRevisions('run_a').length, 0);
+    assert.equal(store.listArtifactComments('run_b').length, 1);
+    store.close();
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+test('v1 库升级到 v2 只补 DDL，不重导旧 JSON', () => {
+  const root = mkdtempSync(join(tmpdir(), 'wf1-fb-'));
+  try {
+    // 先用 v1 版本语义建库：直接以当前 store 建库后，把 user_version 压回 1 并塞一份陈旧 JSON
+    const store = openStore(root);
+    store.putRun(run('run_x', '2026-08-02T00:00:00.000Z', 'success'));
+    store.addArtifactComment({ runId: 'run_x', nodeId: 'n1', artifactId: 'a.md', body: '新评论' });
+    store.close();
+    // 压回版本号 + 放一份会覆盖 run_x 的陈旧 JSON
+    const db = new DatabaseSync(join(root, 'workflow-one.sqlite'));
+    db.exec('PRAGMA user_version = 1;');
+    db.close();
+    writeFileSync(join(root, 'runs', 'run_x.json'), JSON.stringify(run('run_x', '2020-01-01T00:00:00.000Z', 'canceled')));
+    // 重开：1→2 只补 DDL；若错误重导 JSON，run_x 会被陈旧快照覆盖成 canceled
+    const reopened = openStore(root);
+    assert.equal(reopened.getRun('run_x').status, 'success');
+    assert.equal(reopened.listArtifactComments('run_x').length, 1);
+    reopened.close();
+  } finally { rmSync(root, { recursive: true, force: true }); }
+});
+
+console.log(passed > 0 ? `\n${passed} tests passed` : '');

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/sqlite-store.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/sqlite-store.test.mjs
@@ -89,7 +89,7 @@ test('migrates valid JSON, reports bad files, and becomes the only write source'
     store.close();
     store.close();
     const settings = new DatabaseSync(databaseFile);
-    assert.equal(settings.prepare('PRAGMA user_version').get().user_version, 1);
+    assert.equal(settings.prepare('PRAGMA user_version').get().user_version, 2);
     assert.equal(settings.prepare('PRAGMA auto_vacuum').get().auto_vacuum, 2);
     settings.close();
 

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -355,8 +355,10 @@ export default function App() {
 
   // 文稿视图数据：切到 docs 或 inspectedRunId 变化时拉 run-results（磁盘投影）。
   // 运行中先快速投影（不等 ready），run-end 后由 resultsReadyToken 触发重载拿最终产物。
+  const docWallRequestRef = useRef(0);
   const loadDocWall = useCallback(async (runId, { waitUntilReady = false } = {}) => {
-    if (!runId) { setDocWallResults(undefined); return; }
+    const requestId = ++docWallRequestRef.current;
+    if (!runId) { setDocWallResults(undefined); setDocWallLoading(false); return; }
     setDocWallLoading(true);
     setDocWallError('');
     try {
@@ -364,11 +366,13 @@ export default function App() {
         apiUrl(`/run-results?id=${encodeURIComponent(runId)}`),
         { waitUntilReady },
       );
+      if (requestId !== docWallRequestRef.current) return;
       setDocWallResults(data);
     } catch (error) {
+      if (requestId !== docWallRequestRef.current) return;
       setDocWallError(error?.message || String(error));
     } finally {
-      setDocWallLoading(false);
+      if (requestId === docWallRequestRef.current) setDocWallLoading(false);
     }
   }, []);
   const [docWallVisible, setDocWallVisible] = useState(false); // 只在 docs 视图挂载时拉数据

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -584,6 +584,11 @@ export default function App() {
         .then((detail) => setRunDetails((current) => ({ ...current, [p.runId]: detail })))
         .catch(() => {});
     });
+    es.addEventListener('revision-ready', (e) => {
+      const p = JSON.parse(e.data);
+      if (!p.runId || !appliesToActiveRun(p)) return;
+      setResultsReadyByRunId((current) => ({ ...current, [p.runId]: Date.now() }));
+    });
     es.addEventListener('run-persist-error', (e) => {
       const p = JSON.parse(e.data);
       if (!appliesToActiveRun(p)) return;
@@ -1601,6 +1606,7 @@ export default function App() {
               progressByNode={progress}
               nodeStates={runDetails[inspectedRunId]?.nodeStates || {}}
               inspectedRunId={inspectedRunId}
+              resultsReadyToken={resultsReadyByRunId[inspectedRunId] || 0}
               loading={docWallLoading}
               loadError={docWallError}
               onRetry={() => loadDocWall(inspectedRunId)}

--- a/web/src/DocWallView.jsx
+++ b/web/src/DocWallView.jsx
@@ -47,44 +47,93 @@ function LazyMount({ children, placeholderHeight = 320 }) {
    优先消费批量预取缓存（BULK context，一次请求拉全条带），缓存未命中再单卡惰性拉取；
    拉取失败（运行被清理/历史 resume 目录已删）渲染占位，不白屏不报错 ---------- */
 const BulkContext = createContext(null);
-// run 级产物清单（卡内引用互链）：正文行内 code 引用的文件名命中清单即变预览链接
+// run 级产物清单（卡内引用互链）：正文行内 code 引用的产物文件名命中清单即变预览链接
 const FilesContext = createContext([]);
+const DOC_FETCH_TIMEOUT_MS = 15000;
+
+function hasOwn(value, key) {
+  return value != null && Object.prototype.hasOwnProperty.call(value, key);
+}
+
+function docBodyErrorMessage(reason, timedOut = false) {
+  if (timedOut) return '正文读取超时，请重试。';
+  if (reason?.status === 404) return '正文文件不存在，可能已随运行历史清理。';
+  if (reason?.status === 409) return '当前工作区会话已失效，请刷新页面后重试。';
+  if (reason?.status >= 500) return '正文服务暂时不可用，请稍后重试。';
+  const raw = String(reason?.message || reason || '');
+  if (/failed to fetch|networkerror|load failed|network request failed/i.test(raw)) return '正文读取失败，请检查连接后重试。';
+  return '正文暂不可读，请重试。';
+}
 
 function useDocBody(doc) {
   const bulk = useContext(BulkContext);
-  const cached = bulk?.get(`${doc.nodeId || ''}\u0000${doc.name}`);
-  const [body, setBody] = useState(() => doc.content || cached?.content || '');
+  const key = `${doc.nodeId || ''}\u0000${doc.name}`;
+  const cached = bulk?.files?.get(key);
+  const inline = doc.hasContent || Boolean(doc.content);
+  const cachedContent = cached && hasOwn(cached, 'content');
+  const hasBody = inline || cachedContent;
+  const bulkPending = Boolean(bulk?.status === 'pending' && !cached);
+  const shouldFallback = !hasBody && !bulkPending && (
+    cached?.omitted || bulk?.status === 'failed' || bulk?.status === 'ready' || !bulk
+  );
+  const [body, setBody] = useState(() => (inline ? doc.content : cachedContent ? cached.content : ''));
+  const [error, setError] = useState('');
+  const [retry, setRetry] = useState(0);
   const [state, setState] = useState(() => {
-    if (doc.content || cached?.content) return 'ready';
-    if (cached?.omitted) return 'idle'; // 批量时超预算被省略，回退单卡拉取
-    return doc.downloadUrl ? 'idle' : 'missing';
+    if (hasBody) return 'ready';
+    if (bulkPending || shouldFallback) return shouldFallback ? 'loading' : 'loading';
+    return doc.downloadUrl ? 'loading' : 'missing';
   });
-  const startedRef = useRef(false);
+
   useEffect(() => {
-    // startedRef 防重入：状态只在完成时翻转，避免 setState 触发 effect 重跑
-    // 把在途 fetch 的结果用 alive 丢弃（会永远卡在 loading）
-    if (state !== 'idle' || startedRef.current || !doc.downloadUrl) return undefined;
-    startedRef.current = true;
-    let alive = true;
-    fetch(doc.downloadUrl).then(async (res) => {
-      if (!res.ok) throw new Error(String(res.status));
+    if (hasBody) {
+      setBody(inline ? doc.content : cached.content);
+      setError('');
+      setState('ready');
+      return undefined;
+    }
+    if (bulkPending || !shouldFallback) {
+      if (bulkPending) setState('loading');
+      return undefined;
+    }
+    if (!doc.downloadUrl) { setError('正文地址缺失。'); setState('missing'); return undefined; }
+
+    const controller = new AbortController();
+    let timedOut = false;
+    const timer = setTimeout(() => { timedOut = true; controller.abort(); }, DOC_FETCH_TIMEOUT_MS);
+    setError('');
+    setState('loading');
+    fetch(doc.downloadUrl, { signal: controller.signal }).then(async (res) => {
+      if (!res.ok) {
+        const error = new Error(`HTTP ${res.status}`);
+        error.status = res.status;
+        throw error;
+      }
       return res.text();
     }).then((text) => {
-      // 与内联 content 同一红线：卡内只渲染截断稿，全文进预览弹窗
-      if (alive) { setBody(clipDocContent(text)); setState('ready'); }
-    }).catch(() => {
-      if (alive) setState('missing');
-    });
-    return () => { alive = false; };
-  }, [state, doc.downloadUrl]);
-  return { state, body };
+      setBody(clipDocContent(text));
+      setError('');
+      setState('ready');
+    }).catch((reason) => {
+      if (reason?.name !== 'AbortError' || timedOut) {
+        setError(docBodyErrorMessage(reason, timedOut));
+        setState('missing');
+      }
+    }).finally(() => clearTimeout(timer));
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [bulk?.status, cached, doc.downloadUrl, hasBody, inline, shouldFallback, bulkPending, retry]);
+  return { state, body, error, retry: () => setRetry((value) => value + 1) };
 }
+
 
 /* ---------- 文档卡（md 可读卡 / 图片 / 视频占位 / data chip 由 Strip 渲染） ---------- */
 const DocCard = memo(function DocCard({ doc, onOpen, fresh, onComment, commentCount, revisionCount, commenting }) {
   const open = () => onOpen?.(doc);
   const files = useContext(FilesContext);
-  const { state, body: bodyText } = useDocBody(doc);
+  const { state, body: bodyText, error, retry } = useDocBody(doc);
   let body;
   if (doc.kind === 'image') {
     body = (
@@ -99,8 +148,11 @@ const DocCard = memo(function DocCard({ doc, onOpen, fresh, onComment, commentCo
     body = (
       <div className="docwall-card-body docwall-card-missing">
         <AlertTriangle size={15} />
-        <p>正文暂不可读（文件可能已随运行归档清理）。</p>
-        {doc.downloadUrl && <a href={doc.downloadUrl} download onClick={(e) => e.stopPropagation()}>尝试下载</a>}
+        <p>{error || '正文暂不可读。'}</p>
+        <div className="docwall-card-missing-actions">
+          {doc.downloadUrl && <a href={doc.downloadUrl} download onClick={(e) => e.stopPropagation()}>尝试下载</a>}
+          <button type="button" className="btn btn-sm" onClick={(e) => { e.stopPropagation(); retry(); }}>重试</button>
+        </div>
       </div>
     );
   } else if (state === 'loading' || state === 'idle') {
@@ -234,49 +286,78 @@ export function DocWallView({
   const [commentDoc, setCommentDoc] = useState(null);
   useEffect(() => { setCommentDoc(null); }, [model.runId]);
 
-  // 批量预取：一次请求拉全 run 的 doc 产物截断正文（替代 37 卡 37 请求）。
-  // 只对「无内联正文」的 doc 卡发起；key = `${nodeId}\u0000${name}`，与数据层去重键一致。
+  // 批量预取：一次请求拉全 run 的 doc 产物截断正文（替代逐卡请求）。
+  // bulk 带 runId 和阶段，防止换运行时旧缓存被新卡片消费。
+  const docItems = useMemo(() => {
+    const items = [];
+    const seen = new Set();
+    const add = (doc) => {
+      if (doc.kind !== 'doc' || doc.hasContent || !doc.nodeId) return;
+      const file = doc.path || doc.name;
+      const key = `${doc.nodeId}\u0000${file}`;
+      if (seen.has(key)) return;
+      seen.add(key);
+      items.push({ node: doc.nodeId, file, name: doc.name, artifactId: doc.id });
+    };
+    model.nodes.forEach((node) => node.docs.forEach(add));
+    model.finals.docs.forEach(add);
+    return items;
+  }, [model]);
+  const docItemsSignature = useMemo(
+    () => docItems.map(({ node, file, name, artifactId }) => `${node}\u0000${file}\u0000${name}\u0000${artifactId || ''}`).join('\u0001'),
+    [docItems],
+  );
   const [bulk, setBulk] = useState(null);
-  const bulkRunRef = useRef('');
+  const bulkContext = useMemo(() => (
+    bulk?.runId === model.runId
+      ? bulk
+      : { runId: model.runId || '', status: 'pending', files: new Map() }
+  ), [bulk, model.runId]);
   useEffect(() => {
-    if (!model.hasRun || !model.runId) return undefined;
-    const docItems = [];
-    for (const node of model.nodes) {
-      for (const doc of node.docs) {
-        if (doc.kind === 'doc' && !doc.content && doc.nodeId) {
-          docItems.push({ node: doc.nodeId, file: doc.path || doc.name, name: doc.name });
-        }
-      }
+    if (!model.hasRun || !model.runId) {
+      setBulk({ runId: model.runId || '', status: 'ready', files: new Map() });
+      return undefined;
     }
-    for (const doc of model.finals.docs) {
-      if (doc.kind === 'doc' && !doc.content && doc.nodeId) {
-        docItems.push({ node: doc.nodeId, file: doc.path || doc.name, name: doc.name });
-      }
-    }
-    if (!docItems.length) { setBulk(new Map()); return undefined; }
     let alive = true;
+    const controller = new AbortController();
+    let timedOut = false;
+    const timer = setTimeout(() => { timedOut = true; controller.abort(); }, DOC_FETCH_TIMEOUT_MS);
+    setBulk({ runId: model.runId, status: 'pending', files: new Map() });
+    if (!docItems.length) {
+      clearTimeout(timer);
+      setBulk({ runId: model.runId, status: 'ready', files: new Map() });
+      return () => controller.abort();
+    }
     fetch(apiUrl('/artifacts/content'), {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ runId: model.runId, items: docItems.map(({ node, file }) => ({ node, file })) }),
+      signal: controller.signal,
+      body: JSON.stringify({ runId: model.runId, items: docItems.map(({ node, file, artifactId }) => ({ node, file, artifactId })) }),
     }).then(async (res) => {
-      if (!res.ok) throw new Error(String(res.status));
+      if (!res.ok) {
+        const error = new Error(`HTTP ${res.status}`);
+        error.status = res.status;
+        throw error;
+      }
       return res.json();
     }).then((data) => {
       if (!alive) return;
       const map = new Map();
-      docItems.forEach(({ node, file, name }, i) => {
+      docItems.forEach(({ node, file, name }) => {
         map.set(`${node}\u0000${name}`, data.files?.[`${node}\u0000${file}`] || { omitted: true });
       });
-      setBulk(map);
-    }).catch(() => {
-      if (alive) setBulk(new Map()); // 失败不阻塞渲染：各卡回退单卡惰性拉取
-    });
-    return () => { alive = false; };
-  }, [model]);
-  useEffect(() => { // 换运行重置批量缓存
-    if (bulkRunRef.current !== (model.runId || '')) { bulkRunRef.current = model.runId || ''; setBulk(null); }
-  }, [model.runId]);
+      setBulk({ runId: model.runId, status: 'ready', files: map });
+    }).catch((error) => {
+      if (!alive || (error?.name === 'AbortError' && !timedOut)) return;
+      const map = new Map(docItems.map(({ node, name }) => [`${node}\u0000${name}`, { omitted: true }]));
+      setBulk({ runId: model.runId, status: 'failed', files: map });
+    }).finally(() => clearTimeout(timer));
+    return () => {
+      alive = false;
+      clearTimeout(timer);
+      controller.abort();
+    };
+  }, [model.hasRun, model.runId, docItemsSignature]);
 
   const onOpen = (doc) => { if (doc?.name) setPreviewDoc(doc); };
 
@@ -441,7 +522,7 @@ export function DocWallView({
   const visibleNodes = selected === 'overview' ? overviewNodes : selectedNode ? [filteredNodes.find((n) => n.nodeId === selected) || selectedNode] : [];
 
   return (
-    <BulkContext.Provider value={bulk}>
+    <BulkContext.Provider value={bulkContext}>
     <FilesContext.Provider value={runFiles}>
     <div className={`docwall docwall-density-${density}`}>
       <aside className="docwall-side" aria-label="节点列表">

--- a/web/src/DocWallView.jsx
+++ b/web/src/DocWallView.jsx
@@ -2,10 +2,11 @@
 // 数据原则 = 磁盘事实（run-results）投影 + SSE 实时叠加；异常恢复一律「重新投影」。
 // 性能红线（方案 v1.1 §四）：卡内 ≤2000 字符截断、懒挂载、视频不预载、React.memo 隔离重渲。
 import { memo, createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { AlertTriangle, Check, ChevronRight, Clock3, FileText, Film, ImageIcon, Loader2, RefreshCw } from 'lucide-react';
+import { AlertTriangle, Check, ChevronRight, Clock3, FileText, Film, ImageIcon, Loader2, MessageSquare, RefreshCw } from 'lucide-react';
 import { buildDocWallModel, clipDocContent } from './doc-wall-data.js';
 import MarkdownDocument from './MarkdownDocument.jsx';
 import { ArtifactPreviewButton, ArtifactPreviewModal, runArtifact } from './ArtifactPreview.jsx';
+import { FeedbackDrawer, feedbackKey, useArtifactFeedback } from './docwall-feedback.jsx';
 import { apiUrl } from './api.js';
 
 const STATUS_ICON = {
@@ -80,7 +81,7 @@ function useDocBody(doc) {
 }
 
 /* ---------- 文档卡（md 可读卡 / 图片 / 视频占位 / data chip 由 Strip 渲染） ---------- */
-const DocCard = memo(function DocCard({ doc, onOpen, fresh }) {
+const DocCard = memo(function DocCard({ doc, onOpen, fresh, onComment, commentCount, revisionCount, commenting }) {
   const open = () => onOpen?.(doc);
   const files = useContext(FilesContext);
   const { state, body: bodyText } = useDocBody(doc);
@@ -114,10 +115,20 @@ const DocCard = memo(function DocCard({ doc, onOpen, fresh }) {
   }
   const Icon = doc.kind === 'image' ? ImageIcon : doc.kind === 'video' ? Film : FileText;
   return (
-    <article className={`docwall-card docwall-card-${doc.kind} ${fresh ? 'docwall-card-fresh' : ''}`}>
+    <article className={`docwall-card docwall-card-${doc.kind} ${fresh ? 'docwall-card-fresh' : ''} ${commenting ? 'docwall-card-commenting' : ''}`}>
       <header className="docwall-card-head" onClick={open}>
         <Icon size={14} aria-hidden="true" />
         <span className="docwall-card-name" title={doc.name}>{doc.name}</span>
+        {revisionCount > 0 && <span className="docwall-card-badge" title={`${revisionCount} 个修订版本`}>✎{revisionCount}</span>}
+        {onComment && (
+          <button type="button"
+            className={`btn btn-icon docwall-card-cmt ${commentCount ? 'docwall-card-cmt-on' : ''}`}
+            title="评论 / 修改建议" aria-label={`评论 ${doc.name}`}
+            onClick={(e) => { e.stopPropagation(); onComment(doc); }}>
+            <MessageSquare size={13} />
+            {commentCount > 0 && <span className="docwall-card-cmt-n">{commentCount}</span>}
+          </button>
+        )}
         <ArtifactPreviewButton artifact={doc} className="docwall-card-pv">⤢</ArtifactPreviewButton>
       </header>
       {body}
@@ -151,11 +162,20 @@ function LiveCard({ progress, structured }) {
 }
 
 /* ---------- 单节点条带 ---------- */
-function NodeStrip({ node, liveProgress, onOpen, registerRef, freshIds }) {
+function NodeStrip({ node, liveProgress, onOpen, registerRef, freshIds, feedback, onComment, commentingKey }) {
   const [chipOpen, setChipOpen] = useState(false);
   const dataFiles = node.dataFiles || [];
   const strip = node.docs || [];
   const live = node.live && liveProgress !== undefined;
+  const cardProps = (doc) => {
+    const entry = feedback?.byArtifact.get(feedbackKey(doc));
+    return {
+      onComment,
+      commentCount: entry?.comments.length || 0,
+      revisionCount: entry?.revisions.length || 0,
+      commenting: commentingKey === feedbackKey(doc),
+    };
+  };
   return (
     <section className="docwall-strip" aria-label={node.nodeLabel} ref={registerRef}>
       <header className="docwall-strip-head">
@@ -167,7 +187,7 @@ function NodeStrip({ node, liveProgress, onOpen, registerRef, freshIds }) {
       </header>
       <div className={`docwall-strip-cards ${strip.length > 0 && strip.length <= 2 ? 'docwall-strip-cards-sparse' : ''}`}>
         {live && <LiveCard progress={liveProgress} structured={liveProgress?.structured} />}
-        {strip.map((doc) => <LazyMount key={doc.id}><DocCard doc={doc} onOpen={onOpen} fresh={freshIds?.has(doc.id)} /></LazyMount>)}
+        {strip.map((doc) => <LazyMount key={doc.id}><DocCard doc={doc} onOpen={onOpen} fresh={freshIds?.has(doc.id)} {...cardProps(doc)} /></LazyMount>)}
         {strip.length === 0 && !dataFiles.length && !live && (
           <div className="docwall-strip-empty">本节点无文件产物</div>
         )}
@@ -191,7 +211,7 @@ function NodeStrip({ node, liveProgress, onOpen, registerRef, freshIds }) {
 
 /* ---------- 主组件：模型计算 + 左右布局 ---------- */
 export function DocWallView({
-  runResults, progressByNode = {}, nodeStates = {}, inspectedRunId,
+  runResults, progressByNode = {}, nodeStates = {}, inspectedRunId, resultsReadyToken = 0,
   loading = false, loadError = '', onRetry, onRefresh,
   onRunHere, recentRuns = [], onInspectRun,
 }) {
@@ -208,6 +228,11 @@ export function DocWallView({
   const [selected, setSelected] = useState('overview'); // 'overview' | 'finals' | nodeId
   const [previewDoc, setPreviewDoc] = useState(null); // 点卡页内预览（ArtifactPreviewModal），不跳浏览器
   useEffect(() => { setSelected('overview'); }, [inspectedRunId]);
+
+  // 评论与修订（issue #97）：换 run 重置抽屉；revision-ready SSE 到达时经 refreshToken 重拉
+  const feedback = useArtifactFeedback(model.runId, resultsReadyToken);
+  const [commentDoc, setCommentDoc] = useState(null);
+  useEffect(() => { setCommentDoc(null); }, [model.runId]);
 
   // 批量预取：一次请求拉全 run 的 doc 产物截断正文（替代 37 卡 37 请求）。
   // 只对「无内联正文」的 doc 卡发起；key = `${nodeId}\u0000${name}`，与数据层去重键一致。
@@ -472,7 +497,14 @@ export function DocWallView({
           <section className="docwall-strip" aria-label="成果">
             <header className="docwall-strip-head docwall-strip-head-final"><strong>◆ 成果</strong><span className="docwall-strip-meta">{model.finals.docs.length} 文档 · {model.finals.links.length} 链接</span></header>
             <div className="docwall-strip-cards">
-              {model.finals.docs.map((doc) => <LazyMount key={doc.id}><DocCard doc={doc} onOpen={onOpen} fresh={freshIds.has(doc.id)} /></LazyMount>)}
+              {model.finals.docs.map((doc) => {
+                const entry = feedback.byArtifact.get(feedbackKey(doc));
+                return <LazyMount key={doc.id}><DocCard doc={doc} onOpen={onOpen} fresh={freshIds.has(doc.id)}
+                  onComment={setCommentDoc}
+                  commentCount={entry?.comments.length || 0}
+                  revisionCount={entry?.revisions.length || 0}
+                  commenting={commentDoc && feedbackKey(commentDoc) === feedbackKey(doc)} /></LazyMount>;
+              })}
               {model.finals.links.map((link) => (
                 <a key={link.url} className="docwall-card docwall-card-link" href={link.url} target="_blank" rel="noreferrer">🔗 {link.label}</a>
               ))}
@@ -483,6 +515,9 @@ export function DocWallView({
           visibleNodes.map((node) => (
             <NodeStrip key={node.nodeId} node={node} liveProgress={progressByNode[node.nodeId]} onOpen={onOpen}
               freshIds={freshIds}
+              feedback={feedback}
+              onComment={setCommentDoc}
+              commentingKey={commentDoc ? feedbackKey(commentDoc) : ''}
               registerRef={(el) => stripRefs.current.set(node.nodeId, el)} />
           ))
         )}
@@ -491,6 +526,7 @@ export function DocWallView({
         )}
       </div>
       {previewDoc && <PreviewExtra artifact={previewDoc} onClose={() => setPreviewDoc(null)} />}
+      {commentDoc && <FeedbackDrawer doc={commentDoc} runId={model.runId} feedback={feedback} onClose={() => setCommentDoc(null)} />}
     </div>
     </FilesContext.Provider>
     </BulkContext.Provider>

--- a/web/src/doc-wall-data.js
+++ b/web/src/doc-wall-data.js
@@ -33,6 +33,8 @@ function fileRow(file) {
     nodeId: file.nodeId || null,
     nodeLabel: file.nodeLabel || null,
     name: file.name,
+    path: file.path || file.relativePath || file.name,
+    hasContent: Object.prototype.hasOwnProperty.call(file, 'content'),
     size: file.size ?? null,
     kind,
     previewUrl: file.previewUrl || null,

--- a/web/src/doc-wall-data.test.mjs
+++ b/web/src/doc-wall-data.test.mjs
@@ -52,6 +52,7 @@ const model2 = buildDocWallModel({
 });
 assert.equal(model2.nodes[0].docs.length, 1, 'n1 一张卡（processFiles 与 stateArtifacts 同名去重）');
 assert.equal(model2.nodes[0].docs[0].kind, 'doc');
+assert.equal(model2.nodes[0].docs[0].path, 'workspace/事实底稿.md');
 assert.match(model2.nodes[0].docs[0].previewUrl, /\/wf1\/api\/artifact\?run=run1&node=n1/, '同名去重时带 downloadUrl 的 stateArtifacts 行胜出');
 assert.equal(model2.nodes[1].docs.length, 1, 'processFiles 的 md 进 n2 卡');
 assert.equal(model2.nodes[1].dataFiles.length, 2, 'html/sh 折成 dataFiles');
@@ -64,6 +65,7 @@ const scoped = buildDocWallModel({
   nodeStates: { a: { artifacts: ['ws/报告.md'] } },
 });
 assert.equal(scoped.nodes[0].docs.length, 1);
+assert.equal(scoped.nodes[0].docs[0].path, 'ws/报告.md');
 assert.match(scoped.nodes[0].docs[0].previewUrl, /\/wf1\/api\/artifact\?run=r9&node=a&file=ws%2F%E6%8A%A5%E5%91%8A\.md&preview=1/);
 assert.match(scoped.nodes[0].docs[0].downloadUrl, /\/wf1\/api\/artifact\?run=r9&node=a&file=/);
 

--- a/web/src/doc-wall.css
+++ b/web/src/doc-wall.css
@@ -126,3 +126,37 @@
 
 /* 文稿 tab 新文稿圆点（画布视图期间成果落盘提示） */
 .view-tab .docs-dot { display: inline-block; width: 7px; height: 7px; border-radius: 50%; background: var(--accent); margin-left: 6px; vertical-align: 2px; box-shadow: 0 0 6px color-mix(in srgb, var(--accent) 60%, transparent); }
+
+/* ---- 评论与修订（issue #97）---- */
+/* 卡头评论按钮：与预览按钮同几何，有评论时高亮 */
+.docwall-card-cmt { position: relative; }
+.docwall-card-cmt-n { position: absolute; top: -4px; right: -4px; min-width: 13px; height: 13px; border-radius: 999px; background: var(--accent); color: #fff; font-size: 9px; line-height: 13px; text-align: center; padding: 0 3px; }
+.docwall-card-cmt-on { color: var(--accent); }
+.docwall-card-badge { flex: none; font-size: 10px; color: var(--accent); background: color-mix(in srgb, var(--accent) 12%, transparent); border-radius: 999px; padding: 1px 6px; }
+.docwall-card-commenting { border-color: var(--accent); box-shadow: 0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent); }
+
+/* 评论/版本链抽屉：文稿视图右侧固定栏 */
+.docwall-fb { position: fixed; top: 0; right: 0; bottom: 0; width: 340px; z-index: 60; display: flex; flex-direction: column; gap: 10px; background: var(--bg-raised); border-left: 1px solid var(--border-strong); box-shadow: var(--shadow-2, -4px 0 16px rgba(0,0,0,.2)); padding: 12px 14px; overflow-y: auto; }
+.docwall-fb-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.docwall-fb-head strong { font-size: 13px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.docwall-fb-sec { display: flex; flex-direction: column; gap: 8px; }
+.docwall-fb-label { font-size: 11.5px; font-weight: 700; color: var(--fg-faint); display: flex; align-items: center; gap: 6px; }
+.docwall-fb-cnt { background: var(--accent); color: #fff; border-radius: 999px; font-size: 10px; padding: 0 6px; line-height: 15px; }
+.docwall-fb-list { display: flex; flex-direction: column; gap: 6px; }
+.docwall-fb-item { border: 1px solid var(--border); border-radius: 8px; padding: 7px 9px; font-size: 12.5px; }
+.docwall-fb-item p { margin: 0 0 5px; white-space: pre-wrap; word-break: break-word; }
+.docwall-fb-meta { display: flex; justify-content: space-between; align-items: center; font-size: 10.5px; color: var(--fg-faint); }
+.docwall-fb-del { border: none; background: none; color: var(--fg-faint); font-size: 10.5px; cursor: pointer; padding: 0; font-family: inherit; }
+.docwall-fb-del:hover { color: var(--danger-fg); }
+.docwall-fb-empty { font-size: 12px; color: var(--fg-faint); margin: 0; }
+.docwall-fb-empty-inline { font-size: 11px; color: var(--fg-faint); }
+.docwall-fb-input { resize: vertical; min-height: 58px; font-size: 12.5px; font-family: inherit; }
+.docwall-fb-err { color: var(--danger-fg); font-size: 12px; margin: 0; }
+.docwall-fb-actions { display: flex; gap: 8px; }
+.docwall-fb-pending { font-size: 11.5px; color: var(--accent); margin: 0; }
+.docwall-fb-vers { display: flex; flex-wrap: wrap; gap: 6px; }
+.docwall-fb-ver { border: 1px solid var(--border); background: var(--bg-raised); border-radius: 999px; font-size: 11px; padding: 2px 9px; cursor: pointer; font-family: inherit; }
+.docwall-fb-ver-on { border-color: var(--accent); color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, transparent); }
+.docwall-fb-preview { border: 1px solid var(--border); border-radius: 8px; padding: 8px 10px; }
+.docwall-fb-summary { font-size: 11.5px; color: var(--fg-faint); margin: 0 0 6px; }
+.docwall-fb-content { max-height: 40vh; overflow: auto; font-size: 12px; white-space: pre-wrap; word-break: break-word; margin: 0; }

--- a/web/src/docwall-feedback.jsx
+++ b/web/src/docwall-feedback.jsx
@@ -1,0 +1,244 @@
+// 文稿评论与修订（issue #97 P1）：评论数据拉取 + 评论/版本链抽屉。
+// 轻通道：POST /wf1/api/artifacts/revise 起改写 run（source='revision'），
+// pending 期轮询 /comments 直到 revision_run_id 出现在版本链或 run 失败。
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { apiUrl } from './api.js';
+
+const POLL_MS = 4000;
+
+export function feedbackKey(doc) {
+  return `${doc.nodeId || ''}\u0000${doc.name}`;
+}
+
+// run 级评论/修订状态：换 run 重拉；改写 pending 期间轮询
+export function useArtifactFeedback(runId, refreshToken = 0) {
+  const [feedback, setFeedback] = useState({ comments: [], revisions: [] });
+  const [pendingRevisions, setPendingRevisions] = useState(() => new Map()); // key → revisionRunId
+  const [revisionErrors, setRevisionErrors] = useState(() => new Map()); // key → { revisionRunId, message }
+  const runIdRef = useRef('');
+  const aliveRef = useRef(true);
+
+  const load = useCallback(async () => {
+    if (!runId) return;
+    try {
+      const res = await fetch(apiUrl(`/comments?runId=${encodeURIComponent(runId)}`));
+      if (!res.ok) throw new Error(String(res.status));
+      const data = await res.json();
+      if (!aliveRef.current || runIdRef.current !== runId) return;
+      const done = new Set((data.revisions || []).map((r) => r.revision_run_id));
+      setFeedback({ comments: data.comments || [], revisions: data.revisions || [] });
+      setPendingRevisions((prev) => {
+        if (!prev.size) return prev;
+        const next = new Map([...prev].filter(([, rid]) => !done.has(rid)));
+        return next.size === prev.size ? prev : next;
+      });
+      setRevisionErrors((prev) => {
+        if (!prev.size) return prev;
+        const next = new Map([...prev].filter(([, state]) => !done.has(state.revisionRunId)));
+        return next.size === prev.size ? prev : next;
+      });
+    } catch { /* 拉取失败保持现状，轮询会重试 */ }
+  }, [runId]);
+
+  // 改写 run 终态但未产出修订（失败/取消）：解除 pending，避免无限轮询
+  const sweepSettled = useCallback(async (pendingMap) => {
+    for (const [key, rid] of pendingMap) {
+      try {
+        const res = await fetch(apiUrl(`/runs/detail?id=${encodeURIComponent(rid)}`));
+        if (!res.ok) continue;
+        const run = await res.json();
+        if (run.status === 'running') continue;
+        const done = feedback.revisions.some((revision) => revision.revision_run_id === rid);
+        setPendingRevisions((prev) => {
+          if (prev.get(key) !== rid) return prev;
+          const next = new Map(prev);
+          next.delete(key);
+          return next;
+        });
+        if (!done) {
+          const message = run.error
+            || (run.status === 'success' ? '改写完成但没有生成修订版本' : run.status === 'canceled' ? '改写已取消' : `改写失败（${run.status}）`);
+          setRevisionErrors((prev) => new Map(prev).set(key, { revisionRunId: rid, message }));
+        }
+      } catch { /* 状态查不到：保留 pending，轮询继续 */ }
+    }
+  }, [feedback.revisions]);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    runIdRef.current = runId || '';
+    setFeedback({ comments: [], revisions: [] });
+    setPendingRevisions(new Map());
+    setRevisionErrors(new Map());
+    if (runId) load();
+    return () => { aliveRef.current = false; };
+  }, [runId, load]);
+
+  useEffect(() => { if (runId && refreshToken) load(); }, [runId, refreshToken, load]);
+
+  // pending 改写轮询：任一改写 run 未进版本链则持续刷新；终态未产出的 sweep 解除
+  useEffect(() => {
+    if (!pendingRevisions.size) return undefined;
+    sweepSettled(pendingRevisions);
+    const timer = setInterval(() => { load(); sweepSettled(pendingRevisions); }, POLL_MS);
+    return () => clearInterval(timer);
+  }, [pendingRevisions, load, sweepSettled]);
+  const byArtifact = useMemo(() => {
+    const map = new Map(); // key → { comments: [], revisions: [] }
+    const bucket = (nodeId, artifactId) => {
+      const key = `${nodeId}\u0000${artifactId}`;
+      if (!map.has(key)) map.set(key, { comments: [], revisions: [] });
+      return map.get(key);
+    };
+    for (const c of feedback.comments) bucket(c.node_id, c.artifact_id).comments.push(c);
+    for (const r of feedback.revisions) bucket(r.node_id, r.artifact_id).revisions.push(r);
+    for (const entry of map.values()) entry.revisions.sort((a, b) => a.id - b.id);
+    return map;
+  }, [feedback]);
+
+  const addComment = useCallback(async (doc, body) => {
+    const res = await fetch(apiUrl('/comments/add'), {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ runId, nodeId: doc.nodeId, artifactId: doc.name, body }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || '评论失败');
+    load();
+    return data.comment;
+  }, [runId, load]);
+
+  const deleteComment = useCallback(async (id) => {
+    await fetch(apiUrl('/comments/delete'), {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id }),
+    });
+    load();
+  }, [load]);
+
+  const revise = useCallback(async (doc, instruction) => {
+    const res = await fetch(apiUrl('/artifacts/revise'), {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ runId, nodeId: doc.nodeId, artifactId: doc.name, instruction }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || '改写发起失败');
+    const key = feedbackKey(doc);
+    setRevisionErrors((prev) => {
+      if (!prev.has(key)) return prev;
+      const next = new Map(prev);
+      next.delete(key);
+      return next;
+    });
+    setPendingRevisions((prev) => new Map(prev).set(key, data.revisionRunId));
+    return data.revisionRunId;
+  }, [runId]);
+
+  return { byArtifact, pendingRevisions, revisionErrors, addComment, deleteComment, revise, reload: load };
+}
+
+/* ---------- 评论/版本链抽屉：挂在文稿视图右侧 ---------- */
+export function FeedbackDrawer({ doc, runId, feedback, onClose }) {
+  const key = feedbackKey(doc);
+  const entry = feedback.byArtifact.get(key) || { comments: [], revisions: [] };
+  const pendingId = feedback.pendingRevisions.get(key);
+  const revisionError = feedback.revisionErrors.get(key);
+  const [text, setText] = useState('');
+  const [busy, setBusy] = useState('');
+  const [error, setError] = useState('');
+  const [viewIndex, setViewIndex] = useState(-1); // -1 原稿；0..n 版本链
+
+  const submitComment = async () => {
+    const body = text.trim();
+    if (!body || busy) return;
+    setBusy('comment');
+    setError('');
+    try { await feedback.addComment(doc, body); setText(''); }
+    catch (e) { setError(String(e.message || e)); }
+    finally { setBusy(''); }
+  };
+
+  const submitRevise = async () => {
+    if (busy) return;
+    setBusy('revise');
+    setError('');
+    try { await feedback.revise(doc, text.trim()); setText(''); }
+    catch (e) { setError(String(e.message || e)); }
+    finally { setBusy(''); }
+  };
+
+  const shown = viewIndex >= 0 ? entry.revisions[viewIndex] : null;
+
+  return (
+    <aside className="docwall-fb" aria-label={`评论：${doc.name}`}>
+      <header className="docwall-fb-head">
+        <strong title={doc.name}>{doc.name}</strong>
+        <button type="button" className="btn btn-icon" aria-label="关闭评论" onClick={onClose}>✕</button>
+      </header>
+
+      <section className="docwall-fb-sec">
+        <div className="docwall-fb-label">
+          评论 / 修改建议
+          {entry.comments.length > 0 && <span className="docwall-fb-cnt">{entry.comments.length}</span>}
+        </div>
+        <div className="docwall-fb-list">
+          {entry.comments.length === 0 && <p className="docwall-fb-empty">还没有评论。写下修改建议，AI 可按评论重出修订稿。</p>}
+          {entry.comments.map((c) => (
+            <div key={c.id} className="docwall-fb-item">
+              <p>{c.body}</p>
+              <div className="docwall-fb-meta">
+                <span>{new Date(c.created_at).toLocaleString()}</span>
+                <button type="button" className="docwall-fb-del" onClick={() => feedback.deleteComment(c.id)}>删除</button>
+              </div>
+            </div>
+          ))}
+        </div>
+        <textarea
+          className="docwall-fb-input" rows={3} placeholder="如：语气改正式些；第二段补充数据来源…"
+          value={text} onChange={(e) => setText(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) submitComment(); }}
+        />
+        {error && <p className="docwall-fb-err">{error}</p>}
+        <div className="docwall-fb-actions">
+          <button type="button" className="btn btn-sm" disabled={!text.trim() || Boolean(busy)} onClick={submitComment}>
+            {busy === 'comment' ? '…' : '保存评论'}
+          </button>
+          {doc.kind === 'doc' && (
+            <button type="button" className="btn btn-sm btn-primary" disabled={Boolean(busy) || (!entry.comments.length && !text.trim())} onClick={submitRevise} title="只改这一篇，不动工作流">
+              {pendingId ? '改写中…' : busy === 'revise' ? '发起中…' : '✎ 按评论改写这一篇'}
+            </button>
+          )}
+        </div>
+        {pendingId && <p className="docwall-fb-pending">改写运行中（{pendingId.slice(-6)}），完成后自动出现在版本链…</p>}
+        {revisionError && !pendingId && (
+          <p className="docwall-fb-err" role="alert">
+            改写未完成：{revisionError.message}
+          </p>
+        )}
+      </section>
+
+      {doc.kind === 'doc' && (
+        <section className="docwall-fb-sec">
+          <div className="docwall-fb-label">版本链</div>
+          <div className="docwall-fb-vers">
+            <button type="button" className={`docwall-fb-ver ${viewIndex === -1 ? 'docwall-fb-ver-on' : ''}`} onClick={() => setViewIndex(-1)}>原稿</button>
+            {entry.revisions.map((r, i) => (
+              <button key={r.id} type="button" className={`docwall-fb-ver ${viewIndex === i ? 'docwall-fb-ver-on' : ''}`}
+                onClick={() => setViewIndex(i)} title={r.summary || ''}>
+                v{i + 1} · {new Date(r.created_at).toLocaleTimeString()}
+              </button>
+            ))}
+            {entry.revisions.length === 0 && <span className="docwall-fb-empty-inline">暂无修订</span>}
+          </div>
+          {shown && (
+            <div className="docwall-fb-preview">
+              {shown.summary && <p className="docwall-fb-summary">{shown.summary}</p>}
+              {shown.content
+                ? <pre className="docwall-fb-content">{shown.content}</pre>
+                : <p className="docwall-fb-empty-inline">修订正文未入库（可从改写运行下载）</p>}
+            </div>
+          )}
+        </section>
+      )}
+    </aside>
+  );
+}

--- a/web/src/run-switcher.js
+++ b/web/src/run-switcher.js
@@ -1,8 +1,8 @@
 // RunSwitcher 胶囊模型（纯函数，可单测）：
 // 合并 /runs 列表与本地已见运行，按「LIVE 优先、开始时间倒序」排序，截断展示。
 
-export const SOURCE_ICON = { manual: '▶', schedule: '⏰', webhook: '🪝', resume: '↻', replay: '↺', assistant: '✦', 'catch-up': '⏱' };
-export const SOURCE_LABEL = { manual: '手动', schedule: '定时', webhook: 'Webhook', resume: '续跑', replay: '重放', assistant: '助手', 'catch-up': '补跑' };
+export const SOURCE_ICON = { manual: '▶', schedule: '⏰', webhook: '🪝', resume: '↻', replay: '↺', assistant: '✦', 'catch-up': '⏱', revision: '✎' };
+export const SOURCE_LABEL = { manual: '手动', schedule: '定时', webhook: 'Webhook', resume: '续跑', replay: '重放', assistant: '助手', 'catch-up': '补跑', revision: '修订' };
 
 export function switcherCapsules(runs, { max = 6 } = {}) {
   const list = [...(runs || [])];


### PR DESCRIPTION
## 背景
文稿视图需要支持用户评论/修改建议，并基于评论生成独立修订版本，同时保留原稿不可变。

## 方案
- 新增工作区 SQLite `artifact_comments` 与 `artifact_revisions` 表及 v1→v2 安全迁移。
- 新增轻通道 `/wf1/api/comments*` 与 `/wf1/api/artifacts/revise`。修订通过单 agent 微图运行，原 run 不变，revision run 不进入普通运行列表。
- 文稿卡片增加评论入口、评论计数、版本链与修订正文预览。
- revision-ready SSE 接入文稿墙刷新；失败/取消/成功但无版本均在抽屉显示原因。
- 原稿副本使用输入专用文件名并从产物收集中排除，避免生成假版本。
- pruneRuns 级联清理评论/修订数据，并保护版本链仍引用的 revision run。

## 验证
- `npm test`：全部通过。
- `sh dsh-plugins/build-web.sh`：document-preview、`web-dist`（`/wf1/` base）与 `web/dist`（根 base）均构建完成。
- 真实 dsh desktop @ 4021：评论写入、重启后持久化、卡片入口和 revise 200 接受已验证；本机模型额度耗尽返回 429，已验证 revision run 错误状态可见，未将其误报为成功版本链。
- 真实 run 保持原稿不变；revision run source/revises 字段和普通运行列表过滤已验证。

Closes #97