### PR TITLE
fix(web): 评论输入框跟随深浅主题

### DIFF
--- a/web/src/doc-wall.css
+++ b/web/src/doc-wall.css
@@ -143,14 +143,16 @@
 .docwall-fb-label { font-size: 11.5px; font-weight: 700; color: var(--fg-faint); display: flex; align-items: center; gap: 6px; }
 .docwall-fb-cnt { background: var(--accent); color: #fff; border-radius: 999px; font-size: 10px; padding: 0 6px; line-height: 15px; }
 .docwall-fb-list { display: flex; flex-direction: column; gap: 6px; }
-.docwall-fb-item { border: 1px solid var(--border); border-radius: 8px; padding: 7px 9px; font-size: 12.5px; }
+.docwall-fb-item { border: 1px solid var(--border); border-radius: 8px; padding: 7px 9px; font-size: 12.5px; background: var(--bg-panel); }
 .docwall-fb-item p { margin: 0 0 5px; white-space: pre-wrap; word-break: break-word; }
 .docwall-fb-meta { display: flex; justify-content: space-between; align-items: center; font-size: 10.5px; color: var(--fg-faint); }
 .docwall-fb-del { border: none; background: none; color: var(--fg-faint); font-size: 10.5px; cursor: pointer; padding: 0; font-family: inherit; }
 .docwall-fb-del:hover { color: var(--danger-fg); }
 .docwall-fb-empty { font-size: 12px; color: var(--fg-faint); margin: 0; }
 .docwall-fb-empty-inline { font-size: 11px; color: var(--fg-faint); }
-.docwall-fb-input { resize: vertical; min-height: 58px; font-size: 12.5px; font-family: inherit; }
+.docwall-fb-input { resize: vertical; min-height: 58px; font-size: 12.5px; font-family: inherit; width: 100%; border: 1px solid var(--border-strong); border-radius: 8px; padding: 7px 10px; background: var(--bg-raised); color: var(--fg); line-height: 1.55; transition: border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease); }
+.docwall-fb-input:focus { outline: none; border-color: var(--primary); box-shadow: var(--shadow-glow); }
+.docwall-fb-input::placeholder { color: var(--fg-faint); }
 .docwall-fb-err { color: var(--danger-fg); font-size: 12px; margin: 0; }
 .docwall-fb-actions { display: flex; gap: 8px; }
 .docwall-fb-pending { font-size: 11.5px; color: var(--accent); margin: 0; }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -158,6 +158,10 @@ html[data-theme='light'] {
 
 
 * { box-sizing: border-box; }
+/* 原生控件（textarea/滚动条/下拉）跟随主题：不声明时浏览器按亮色渲染，
+   暗色主题下评论框等会出现默认白底 */
+html { color-scheme: dark; }
+html[data-theme='light'] { color-scheme: light; }
 html, body, #root { height: 100%; margin: 0; }
 body {
   font-family: var(--font-ui);


### PR DESCRIPTION
## 背景

文稿视图的评论抽屉里，评论输入框在浅色主题下仍是浏览器默认白底黑字，与面板底色割裂；深色主题下更刺眼。用户实测反馈「评论输入框没有按照主题适配」。

## 根因

`.docwall-fb-input`（doc-wall.css）只定义了 resize/min-height/font，没声明 `background`/`color`/`border`。全局表单主题规则选择器是 `.panel textarea` 这类容器限定，覆盖不到 fixed 定位的评论抽屉，于是 textarea 走了 UA 默认样式（白底）。

另一个同源问题：全站从未声明 `color-scheme`，浏览器原生控件（textarea、滚动条、下拉箭头）一律按亮色渲染，`data-theme='dark'` 时同样露白。

## 方案

- `.docwall-fb-input` 补齐与 `.panel` 输入控件同源的令牌样式：`--bg-raised` 底、`--border-strong` 边、`--fg` 文字、focus 光环 `--shadow-glow`、placeholder `--fg-faint`；评论条目 `.docwall-fb-item` 加 `--bg-panel` 底色区分层次。
- `html { color-scheme: dark }` + `html[data-theme='light'] { color-scheme: light }`，原生控件跟随主题。

## 验证

- `cd web && npm test`：14 套全过（0 fail）
- `sh dsh-plugins/build-web.sh`：双 base 构建通过
- 真机验证：dark/light 两主题下评论框底色、边框、文字、placeholder、focus 光环均随主题切换（截图见合并前自查）