### PR TITLE
build(one): 准备 0.7.2 发版

### DIFF
--- a/dsh-plugins/dsh-ccpg-brand/package.json
+++ b/dsh-plugins/dsh-ccpg-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-brand",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-harness-one",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.7.1",
-    "dsh-ccpg-document-preview": "0.7.1",
-    "dsh-ccpg-larkauth": "0.7.1",
-    "dsh-ccpg-llm-guard": "0.7.1",
-    "dsh-ccpg-orchestrator": "0.7.1",
-    "dsh-ccpg-tools": "0.7.1",
-    "dsh-ccpg-web": "0.7.1"
+    "dsh-ccpg-canvasui": "0.7.2",
+    "dsh-ccpg-document-preview": "0.7.2",
+    "dsh-ccpg-larkauth": "0.7.2",
+    "dsh-ccpg-llm-guard": "0.7.2",
+    "dsh-ccpg-orchestrator": "0.7.2",
+    "dsh-ccpg-tools": "0.7.2",
+    "dsh-ccpg-web": "0.7.2"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
@@ -274,7 +274,7 @@ console.log('system-upgrade tests:');
       assert.match(plan.actions[0].title, /更新/);
       const calls = [];
       const realFetch = globalThis.fetch;
-      globalThis.fetch = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '0.7.1' } }) });
+      globalThis.fetch = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '0.7.2' } }) });
       try {
         await executePlan(plan, {
           dshBin: '/fake/dsh',
@@ -285,7 +285,7 @@ console.log('system-upgrade tests:');
       }
       const up = calls.find((c) => c[4] === 'up');
       assert.ok(up, '在装用户用 up 原地更新');
-      assert.equal(up[5], `${PACKAGE}@0.7.1`);
+      assert.equal(up[5], `${PACKAGE}@0.7.2`);
       assert.ok(!calls.some((c) => c[4] === 'remove'), 'up 路径不 remove 任何包');
       assert.ok(calls.some((c) => c[4] === 'add' && String(c[5] || '').startsWith(SIDEBAR)), '纯净安装兜底：依赖表无 sidebar 时补 add 注册 bundle');
     } finally {

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 背景

main 上已积累 #98（文稿评论与 AI 修订，含正文加载/预览稳定性修复）与 #99（评论输入框主题适配），准备发 0.7.2。

## 改动

- 10 个 package.json 0.7.1 → 0.7.2，dsh-ccpg-one（npm 包名 dsh-harness-one）依赖表 7 子包 pin 同步
- system-upgrade 测试两处版本引用同步

## 验证

- 全量 `npm test` 绿
- `assemble-one.sh` 装配通过（dsh-harness-one@0.7.2）
- `publish-npm.sh --dry-run` 通过

合并后打 `v0.7.2` tag 触发 release.yml 发布 npm + GitHub Release。