### PR TITLE
fix(docwall): 流卡实时预览乱码与 HTML 源码墙

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/doc-tail.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/doc-tail.js
@@ -1,0 +1,23 @@
+// 文稿墙流卡 docTail 的纯逻辑层（零依赖，可 node 直测）：
+// 字节尾部窗口 → 安全 UTF-8 文本。窗口起点按字节截断，落在多字节字符中间时
+// toString('utf8') 会产出 U+FFFD 乱码（中文文档必踩），先跳过起点处不完整的
+// 字符序列再解码；文件正在写入时窗口末尾也可能停在半个字符上，一并丢掉。
+// 两处各最多丢 3 字节（UTF-8 最长 4 字节），正文无损。
+export function decodeTailWindow(buf, { trimStart = false } = {}) {
+  let begin = 0;
+  if (trimStart) {
+    while (begin < buf.length && (buf[begin] & 0xc0) === 0x80) begin += 1;
+    const lead = begin < buf.length ? buf[begin] : 0;
+    const need = lead >= 0xf0 ? 4 : lead >= 0xe0 ? 3 : lead >= 0xc0 ? 2 : 1;
+    if (need > 1 && need > buf.length - begin) begin += 1;
+  }
+  let end = buf.length;
+  for (let back = 1; back <= 4 && end - back >= begin; back += 1) {
+    const b = buf[end - back];
+    if ((b & 0xc0) === 0x80) continue;
+    const need = b >= 0xf0 ? 4 : b >= 0xe0 ? 3 : b >= 0xc0 ? 2 : 1;
+    if (need > back) end -= back;
+    break;
+  }
+  return begin >= end ? '' : buf.toString('utf8', begin, end);
+}

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
@@ -10,7 +10,7 @@ import { validateNotificationNodeData } from './notifications.js';
 // 相对 v1 的升级：
 //   - 多运行实例并存（Map 而非单 this.s）
 //   - 并发上限（就绪节点排队，槽位释放依次启动）
-//   - 每节点超时（默认 300s，节点可配 timeoutSec）与整运行取消（未开始节点标 canceled + agent.abort 传播）
+//   - 每节点超时（默认 500s，节点可配 timeoutSec）与整运行取消（未开始节点标 canceled + agent.abort 传播）
 //   - 条件分支节点（condition）：模板渲染后命中 include/exclude 关键词决定走 true/false 出边（边 branch 字段）
 //   - 图静态校验 lintGraph（环之外：未填提示词、模板引用不存在的节点、孤立输出、同名节点）
 //   - 失败传播规则不变：全部直接上游 error/skipped/canceled 才跳过下游
@@ -18,7 +18,7 @@ import { validateNotificationNodeData } from './notifications.js';
 // 计数约定：每个节点的完成只在其自身 _onNodeDone 尾部扣一次 s.remaining；
 // 跳过/取消的节点在标记处扣，且不再递归重复扣。
 
-export const NODE_TIMEOUT_MS = 5 * 60 * 1000;
+export const NODE_TIMEOUT_MS = 500 * 1000;
 const CONDITION_VERDICT_RE = /^条件判定：(true|false)/;
 
 let runSeq = 0;

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -26,6 +26,7 @@ import { SessionId } from '@deepseek-ai/dsh-session';
 import { renderTemplate, validateTemplate } from './template.js';
 import { describeNodeOutput, normalizeExecutionResult, RUN_SCHEMA_VERSION } from './output-contract.js';
 import { resolveInside, safeFileId, safeFilename } from './safe-path.js';
+import { decodeTailWindow } from './doc-tail.js';
 import { runScript } from './script-runner.js';
 import {
   artifactId as runArtifactId,
@@ -1291,7 +1292,9 @@ export function apply(ctx, config) {
           try {
             const buf = Buffer.alloc(stat.size - start);
             readSync(fd, buf, 0, buf.length, start);
-            return { name: basename(String(newest.full)), size: stat.size, tail: buf.toString('utf8'), growing: true };
+            // 起点按字节截断可能劈开多字节字符（中文必踩）：跳到字符边界再解码
+            const tail = decodeTailWindow(buf, { trimStart: start > 0 });
+            return { name: basename(String(newest.full)), size: stat.size, tail, growing: true };
           } finally { closeSync(fd); }
         } catch { return undefined; }
       };

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -1808,7 +1808,7 @@ export function apply(ctx, config) {
     };
 
     const testAbort = new AbortController();
-    const testTimeoutMs = Number(node.data?.timeoutSec) > 0 ? Number(node.data.timeoutSec) * 1000 : 5 * 60 * 1000;
+    const testTimeoutMs = Number(node.data?.timeoutSec) > 0 ? Number(node.data.timeoutSec) * 1000 : 500 * 1000;
     let testTimedOut = false;
     const testTimer = setTimeout(() => { testTimedOut = true; testAbort.abort(); }, testTimeoutMs);
     req.once('aborted', () => testAbort.abort());

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/doc-tail.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/doc-tail.test.mjs
@@ -1,0 +1,87 @@
+// doc-tail 单测：字节尾部窗口 → 安全 UTF-8 文本的边界行为。
+// 背景：scanDocTail 按 2KB 字节窗口截尾部，起点劈开多字节字符时
+// toString('utf8') 产出 U+FFFD 乱码（中文文档必踩，issue 反馈「��圾」）。
+import assert from 'node:assert/strict';
+
+const { decodeTailWindow } = await import('../lib/doc-tail.js');
+
+let passed = 0;
+const test = (name, fn) => Promise.resolve()
+  .then(fn)
+  .then(() => { passed += 1; console.log(`  ✓ ${name}`); })
+  .catch((error) => { console.error(`  ✗ ${name}\n${error.message}`); process.exitCode = 1; });
+
+const text = (s) => Buffer.from(s, 'utf8');
+
+await test('完整窗口原样解码（trimStart=false）', () => {
+  assert.equal(decodeTailWindow(text('你好世界')), '你好世界');
+  assert.equal(decodeTailWindow(text('plain ascii')), 'plain ascii');
+  assert.equal(decodeTailWindow(text('')), '');
+});
+
+await test('起点劈开多字节字符：跳过续字节与其不完整的首字节（trimStart=true）', () => {
+  // 「你好」各 3 字节；从第 1 字节起是「你」的后两个续字节 + 完整「好」
+  const buf = text('你好').subarray(1);
+  assert.equal(decodeTailWindow(buf, { trimStart: true }), '好');
+  // 整段只剩「界」的后两个续字节 → 全部丢弃
+  const buf2 = text('世界').subarray(4);
+  assert.equal(decodeTailWindow(buf2, { trimStart: true }), '');
+});
+
+await test('trimStart=false 时起点续字节产出 U+FFFD（调用方没跳边界就维持原生行为）', () => {
+  const buf = text('你好').subarray(1);
+  assert.ok(decodeTailWindow(buf).includes('\uFFFD'));
+});
+
+await test('末尾半个字符（写入中）：截掉不完整序列，正文无损', () => {
+  const buf = text('你好世界');
+  assert.equal(decodeTailWindow(buf.subarray(0, buf.length - 1)), '你好世');
+  assert.equal(decodeTailWindow(buf.subarray(0, buf.length - 2)), '你好世');
+  assert.equal(decodeTailWindow(buf.subarray(0, buf.length - 4)), '你好');
+  assert.equal(decodeTailWindow(text('你好').subarray(0, 1)), '');
+});
+
+await test('ASCII 末尾截断不受影响', () => {
+  assert.equal(decodeTailWindow(text('abcde').subarray(0, 3)), 'abc');
+});
+
+await test('全窗口都是残字节时返回空串', () => {
+  assert.equal(decodeTailWindow(text('你').subarray(1), { trimStart: true }), '');
+});
+
+await test('混合中英数字（agent 文稿常态）首尾劈字均无损', () => {
+  const s = '1、清扫B1车库地面垃圾；<br/>2、设备充电。2026-08-30 更新';
+  const buf = text(s);
+  assert.equal(decodeTailWindow(buf, { trimStart: true }), s);
+});
+
+await test('混合文本劈字：字节窗口解码结果 = 原文对应字符切片', () => {
+  const s = 'A中B文C测试D文本';
+  const buf = text(s);
+  // 逐字节起点 + 逐字节终点，解码结果必须恰好等于对应字符串切片（无 U+FFFD）
+  for (let start = 0; start <= buf.length; start += 1) {
+    for (let end = start; end <= buf.length; end += 1) {
+      const got = decodeTailWindow(buf.subarray(start, end), { trimStart: true });
+      assert.ok(!got.includes('\uFFFD'), `start=${start} end=${end} 产出乱码: ${JSON.stringify(got)}`);
+      // 起点：若 start 落在字符中间，字符被整体丢弃；终点：不完整序列被截掉
+      let expectStart = start;
+      while (expectStart < end && (buf[expectStart] & 0xc0) === 0x80) expectStart += 1;
+      if (expectStart < end) {
+        const lead = buf[expectStart];
+        const need = lead >= 0xf0 ? 4 : lead >= 0xe0 ? 3 : lead >= 0xc0 ? 2 : 1;
+        if (need > end - expectStart) return; // 整段只有半个字符，期望空
+      }
+      let expectEnd = end;
+      if (expectEnd > expectStart) {
+        let back = 1;
+        while (expectEnd - back >= expectStart && (buf[expectEnd - back] & 0xc0) === 0x80) back += 1;
+        const b = buf[expectEnd - back];
+        const need = b >= 0xf0 ? 4 : b >= 0xe0 ? 3 : b >= 0xc0 ? 2 : 1;
+        if (need > back) expectEnd -= back;
+      }
+      assert.equal(got, buf.toString('utf8', expectStart, expectEnd), `start=${start} end=${end}`);
+    }
+  }
+});
+
+console.log(`\ndoc-tail: ${passed} passed`);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,8 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
         "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
@@ -29,13 +31,16 @@
       }
     },
     "../dsh-plugins/dsh-ccpg-document-preview": {
-      "version": "0.1.0",
+      "version": "0.7.2",
+      "license": "MIT",
       "dependencies": {
         "@file-viewer/pptx": "2.3.0",
         "docx-preview": "0.4.0",
         "lucide-react": "^1.32.0",
         "pdfjs-dist": "5.6.205",
-        "xlsx": "https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz"
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1",
+        "xlsx": "0.18.5"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "4.3.4",
@@ -43,10 +48,15 @@
         "react-dom": "18.3.1",
         "vite": "5.4.19"
       },
+      "engines": {
+        "node": ">=22.15.0"
+      },
       "peerDependencies": {
         "@deepseek-ai/schemastery": "*",
         "react": ">=18",
-        "react-dom": ">=18"
+        "react-dom": ">=18",
+        "react-markdown": ">=9",
+        "remark-gfm": ">=4"
       },
       "peerDependenciesMeta": {
         "@deepseek-ai/schemastery": {
@@ -1857,6 +1867,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.21.5.tgz",
@@ -1959,6 +1981,79 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmmirror.com/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmmirror.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -1986,6 +2081,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -1993,6 +2107,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmmirror.com/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2007,6 +2138,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/inline-style-parser": {
@@ -3047,6 +3188,18 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmmirror.com/picocolors/-/picocolors-1.1.1.tgz",
@@ -3153,6 +3306,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {
@@ -3505,6 +3687,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmmirror.com/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -3584,6 +3780,16 @@
       "resolved": "https://registry.npmmirror.com/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "license": "MIT"
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -26,6 +26,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1"
   },
   "devDependencies": {

--- a/web/src/MarkdownDocument.jsx
+++ b/web/src/MarkdownDocument.jsx
@@ -1,7 +1,24 @@
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import { DocumentPreviewButton } from 'dsh-ccpg-document-preview/react';
 import { findArtifactByName } from './ArtifactPreview.jsx';
+
+// agent 产出的文稿常见「markdown 套 HTML 表格」混合格式：不开 raw 解析时
+// <table>/<br/> 等标签整面转义成源码墙。rehype-raw 放行原始 HTML，
+// rehype-sanitize 白名单收口防脚本注入；td/th 的 vertical-align 等内联样式属性放行。
+const sanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [
+    ...(defaultSchema.tagNames || []),
+    'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'col', 'colgroup', 'caption', 'br',
+  ],
+  attributes: {
+    ...defaultSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] || []), 'style', 'align', 'colspan', 'rowspan'],
+  },
+};
 
 // files：本次运行的产物清单。正文里用行内 code 引用的产物文件名（`xxx.md`）
 // 命中清单时渲染成可点击按钮，点击直接开预览弹窗。
@@ -9,6 +26,7 @@ export default function MarkdownDocument({ content, files = [] }) {
   return (
     <ReactMarkdown
       remarkPlugins={[remarkGfm]}
+      rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}
       components={{
         a: ({ children, ...props }) => <a {...props} target="_blank" rel="noreferrer">{children}</a>,
         // 窄面板里表格列被挤压错位：套一层横向滚动容器，表格保持自然宽度

--- a/web/src/NodePanel.jsx
+++ b/web/src/NodePanel.jsx
@@ -584,7 +584,7 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
               <Field label="超时（秒）">
                 <input type="number" min="10" max="3600" value={d.timeoutSec ?? ''}
                   onChange={(e) => set({ timeoutSec: e.target.value === '' ? undefined : Number(e.target.value) })}
-                  placeholder="300" />
+                  placeholder="500" />
               </Field>
             </div>
           </Section>
@@ -727,7 +727,7 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
               <Field label="超时（秒）">
                 <input type="number" min="5" max="3600" value={d.timeoutSec ?? ''}
                   onChange={(e) => set({ timeoutSec: e.target.value === '' ? undefined : Number(e.target.value) })}
-                  placeholder="300" />
+                  placeholder="500" />
               </Field>
             )}
           </div>


### PR DESCRIPTION
## 背景

文稿墙流卡（agent 运行中的实时预览）对中文文稿出现两类展示问题：

1. **乱码**：正文开头出现「��圾；2、设备充电」——引擎 `scanDocTail` 以 2KB **字节**窗口截文件尾部，切点落在多字节汉字中间，`toString('utf8')` 产出 U+FFFD
2. **HTML 源码墙**：\.txt 文稿内容是 markdown 套 HTML 表格（飞书/Excel 导出常态），react-markdown 未开 raw 解析，`<tr><td>` 整面转义成字面文本

## 方案

**引擎**（2b1bd4f）：抽零依赖纯函数 `lib/doc-tail.js decodeTailWindow`——窗口起点跳过续字节与残缺首字节，末尾不完整序列截掉，各最多丢 3 字节、正文无损；写作中的半个字符乱码一并消灭。

**前端**（36c9acc）：`MarkdownDocument` 接入 `rehype-raw + rehype-sanitize`——原始 HTML 渲染成真实 DOM（表格走 `md-table-wrap` 横向滚动），sanitize 白名单剥离 script/事件属性防注入，放行 style/colspan/rowspan。作用面：流卡 docTail、结果面板、节点运行输出（共用组件）。

## 验证

- `node test/doc-tail.test.mjs`：8/8，含全字节起止组合 × 字符串切片的穷举对照（无 U+FFFD、解码结果恰等于对应切片）
- SSR 渲染验证：完整 HTML 表格 → 真 `<table>`；`<script>alert(1)</script>` 与 `onerror` 被剥离；`<br/>` 正常换行
- orchestrator 全部套件绿（含新 doc-tail 套）；`cd web && npm test` 绿；根 `npm test` 全量绿
- `sh dsh-plugins/build-web.sh` 双构建通过

> 注：无 `<table>` 包裹的散落 `<tr>` 片段，按 HTML 解析规范仍显示为文本（非转义源码墙）；成品文档走预览弹窗（TextRenderer/plain 分支）不受影响。