### PR TITLE
build(one): 准备 0.8.0 发版

### DIFF
--- a/dsh-plugins/dsh-ccpg-brand/package.json
+++ b/dsh-plugins/dsh-ccpg-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-brand",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-harness-one",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.7.2",
-    "dsh-ccpg-document-preview": "0.7.2",
-    "dsh-ccpg-larkauth": "0.7.2",
-    "dsh-ccpg-llm-guard": "0.7.2",
-    "dsh-ccpg-orchestrator": "0.7.2",
-    "dsh-ccpg-tools": "0.7.2",
-    "dsh-ccpg-web": "0.7.2"
+    "dsh-ccpg-canvasui": "0.8.0",
+    "dsh-ccpg-document-preview": "0.8.0",
+    "dsh-ccpg-larkauth": "0.8.0",
+    "dsh-ccpg-llm-guard": "0.8.0",
+    "dsh-ccpg-orchestrator": "0.8.0",
+    "dsh-ccpg-tools": "0.8.0",
+    "dsh-ccpg-web": "0.8.0"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/system-upgrade.test.mjs
@@ -274,7 +274,7 @@ console.log('system-upgrade tests:');
       assert.match(plan.actions[0].title, /更新/);
       const calls = [];
       const realFetch = globalThis.fetch;
-      globalThis.fetch = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '0.7.2' } }) });
+      globalThis.fetch = async () => ({ ok: true, json: async () => ({ 'dist-tags': { latest: '0.8.0' } }) });
       try {
         await executePlan(plan, {
           dshBin: '/fake/dsh',
@@ -285,7 +285,7 @@ console.log('system-upgrade tests:');
       }
       const up = calls.find((c) => c[4] === 'up');
       assert.ok(up, '在装用户用 up 原地更新');
-      assert.equal(up[5], `${PACKAGE}@0.7.2`);
+      assert.equal(up[5], `${PACKAGE}@0.8.0`);
       assert.ok(!calls.some((c) => c[4] === 'remove'), 'up 路径不 remove 任何包');
       assert.ok(calls.some((c) => c[4] === 'add' && String(c[5] || '').startsWith(SIDEBAR)), '纯净安装兜底：依赖表无 sidebar 时补 add 注册 bundle');
     } finally {

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 发版内容（v0.7.2 → v0.8.0）

- **文稿直接编辑**（#112）：Tiptap v2 所见即所得富文本——真表格（点格改字/Tab 切格/行列增删合并）、标题/列表/引用/代码块/链接；保存序列化回 Markdown 写入版本链（`revision_run_id=NULL` 手工修订，与 AI 修订同链），run 历史不可变
- 新端点 `POST /wf1/api/artifacts/save` + sqlite schema v3 迁移（`revision_run_id` 放开非空）
- 附：重开运行中工作流画布节点动画即时恢复修复（#112 内）
- 依赖：web 新增 @tiptap/* 2.27.2 全家桶 + tiptap-markdown 0.8.10

## 升版面

10 个 package.json（7 子插件 + one 依赖表 pin + brand + 根）+ system-upgrade 测试两处引用。

## 验证（合并门槛）

- 全量单测 ✓；assemble-one 装配 dsh-harness-one@0.8.0 ✓；publish-npm --dry-run ✓
- pack v0.8.0 + verify-plugin-packages ✓
- **boot-smoke 隔离冒烟 ✓**：tarball 全新 profile 安装启动，官方 UI / 独立画布 200、better-sidebar 0.16.1 挂载

合并后打 tag `v0.8.0` 触发 release（发布 npm 8 包 + GitHub Release asset）。