### PR TITLE
feat(orchestrator): agent 节点思考级别设置 + 模型视觉能力展示

### DIFF
--- a/dsh-plugins/bootstrap-deps.sh
+++ b/dsh-plugins/bootstrap-deps.sh
@@ -22,7 +22,7 @@ SDK_DIR="$DSH_PKG/node_modules/@deepseek-ai"
 echo "dsh SDK: $SDK_DIR"
 
 mkdir -p "$PROFILE_DIR/node_modules/@deepseek-ai"
-for pkg in schemastery cordis dsh-tools dsh-llm dsh-session; do
+for pkg in schemastery cordis dsh-tools dsh-llm dsh-session dsh-agent; do
   [ -d "$SDK_DIR/$pkg" ] || continue
   TARGET="$PROFILE_DIR/node_modules/@deepseek-ai/$pkg"
   if [ -e "$TARGET" ] || [ -L "$TARGET" ]; then rm -rf "$TARGET"; fi

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
@@ -10,7 +10,7 @@ import { validateNotificationNodeData } from './notifications.js';
 // 相对 v1 的升级：
 //   - 多运行实例并存（Map 而非单 this.s）
 //   - 并发上限（就绪节点排队，槽位释放依次启动）
-//   - 每节点超时（默认 300s，节点可配 timeoutSec）与整运行取消（未开始节点标 canceled + agent.abort 传播）
+//   - 每节点超时（默认 500s，节点可配 timeoutSec）与整运行取消（未开始节点标 canceled + agent.abort 传播）
 //   - 条件分支节点（condition）：模板渲染后命中 include/exclude 关键词决定走 true/false 出边（边 branch 字段）
 //   - 图静态校验 lintGraph（环之外：未填提示词、模板引用不存在的节点、孤立输出、同名节点）
 //   - 失败传播规则不变：全部直接上游 error/skipped/canceled 才跳过下游
@@ -18,7 +18,7 @@ import { validateNotificationNodeData } from './notifications.js';
 // 计数约定：每个节点的完成只在其自身 _onNodeDone 尾部扣一次 s.remaining；
 // 跳过/取消的节点在标记处扣，且不再递归重复扣。
 
-export const NODE_TIMEOUT_MS = 5 * 60 * 1000;
+export const NODE_TIMEOUT_MS = 500 * 1000;
 const CONDITION_VERDICT_RE = /^条件判定：(true|false)/;
 
 let runSeq = 0;

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -1853,7 +1853,7 @@ export function apply(ctx, config) {
     };
 
     const testAbort = new AbortController();
-    const testTimeoutMs = Number(node.data?.timeoutSec) > 0 ? Number(node.data.timeoutSec) * 1000 : 5 * 60 * 1000;
+    const testTimeoutMs = Number(node.data?.timeoutSec) > 0 ? Number(node.data.timeoutSec) * 1000 : 500 * 1000;
     let testTimedOut = false;
     const testTimer = setTimeout(() => { testTimedOut = true; testAbort.abort(); }, testTimeoutMs);
     req.once('aborted', () => testAbort.abort());

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -1196,6 +1196,10 @@ export function apply(ctx, config) {
     // 节点级思考级别：仅当与全局选择同渠道同模型时全局档位才继承；节点显式配置优先。
     // 档位经 installModelSelection 注入 agent/request waterfall（AgentOptions 本身不收 effort）。
     const reasoningEffort = d.reasoningEffort || (provider === sel.provider && model === sel.model ? sel.reasoningEffort : undefined);
+    // 模型单请求超时（step 粒度）：一次模型调用（含其工具执行前的新型请求）超过即视为卡死，
+    // 与节点总超时（timeoutSec，整个节点生命周期）是两个独立旋钮。step/end 重置计时。
+    const MODEL_TIMEOUT_MS = 300 * 1000;
+    const modelTimeoutMs = Number(d.modelTimeoutSec) > 0 ? Number(d.modelTimeoutSec) * 1000 : MODEL_TIMEOUT_MS;
 
     // 工具过滤：与进程内已注册工具求交集（restrict 不接受未知名）
     const wanted = Array.isArray(d.tools) ? d.tools.filter((t) => t && t !== '*') : [];
@@ -1251,7 +1255,7 @@ export function apply(ctx, config) {
       // 轮数监控：2s 轮询 session events —— 推流式进度；turn 数超限 cancel；turn/end 即退出
       let watchDone;
       const watchReady = new Promise((r) => { watchDone = r; });
-      const watchState = { stop: false, timer: null };
+      const watchState = { stop: false, timer: null, lastStepStartSeq: 0, stepStartedAt: 0, modelTimeout: null };
       // 实时轨迹：watchTick 逐事件扫描时同步折叠进 liveTracesByRun（详情弹窗运行中即可读）；
       // 水位 lastSeqRef 只处理新到事件；完成后仍走 buildTrace 落盘路径，节点终态即释放。
       let liveTrace = null;
@@ -1268,11 +1272,15 @@ export function apply(ctx, config) {
       const pendingByCallId = new Map(); // callId → entries 下标（配对跨轮询到达的 tool/call 与 tool/result）
       const scanEvents = () => {
         let turns = 0; let preview = ''; let turnEnded = false;
+        let lastStepStartSeq = -1; let stepsSeen = 0;
         try {
           for (const ev of agent.session.events) {
             if (ev.seq < firstSeq) continue;
             if (ev.type === 'turn/start') turns += 1;
             if (ev.type === 'turn/end') turnEnded = true;
+            // step/start = 一次模型调用开始；step/end = 该次调用结束（含工具执行）。
+            // 记录最后一个 step/start 的时间与序号，供模型请求看门狗判断当前 step 是否卡死。
+            if (ev.type === 'step/start') { lastStepStartSeq = ev.seq; stepsSeen += 1; }
             if (ev.type === 'assistant/message') {
               const joined = (ev.data.message?.content || []).filter((b) => b.type === 'text').map((b) => b.text).join('');
               if (joined) preview = joined;
@@ -1283,7 +1291,7 @@ export function apply(ctx, config) {
             }
           }
         } catch { /* session 已释放 */ }
-        return { turns, preview, turnEnded };
+        return { turns, preview, turnEnded, lastStepStartSeq, stepsSeen };
       };
       // 真·流式生成文稿：扫节点输出目录里最新的文本产物，附其尾部到 agent-progress，
       // 前端流卡直接渲染「正在写的文件」而非 agent 对话文本。只 tail 一个文件，
@@ -1313,7 +1321,27 @@ export function apply(ctx, config) {
       };
       const watchTick = () => {
         if (watchState.stop) return;
-        const { turns, preview, turnEnded } = scanEvents();
+        const { turns, preview, turnEnded, lastStepStartSeq, stepsSeen } = scanEvents();
+        // 模型请求看门狗：step/start 后 modelTimeoutMs 内既无 step/end 也无新事件推进，
+        // 视为该次模型调用卡死，cancel 本节点（区别于 timeoutSec 的节点总超时）。
+        // 以事件序号驱动：step/end 或任何新事件落盘都会刷新 lastActivitySeq。
+        if (!turnEnded && stepsSeen > 0) {
+          const events = agent.session.events;
+          const lastSeq = events.length ? events[events.length - 1].seq : firstSeq;
+          if (lastStepStartSeq > 0 && lastSeq === lastStepStartSeq && !watchState.rechecking) {
+            const stepAgeMs = Date.now() - (watchState.stepStartedAt || Date.now());
+            if (stepAgeMs > modelTimeoutMs) {
+              const err = new Error(`模型请求超时（单次超过 ${Math.round(modelTimeoutMs / 1000)}s 无响应）`);
+              try { agent.cancel({ kind: 'user' }); } catch { /* noop */ }
+              watchState.modelTimeout = err;
+              return watchDone();
+            }
+          }
+          if (lastStepStartSeq !== watchState.lastStepStartSeq) {
+            watchState.lastStepStartSeq = lastStepStartSeq;
+            watchState.stepStartedAt = Date.now();
+          }
+        }
         emit('agent-progress', {
           runId, nodeId: node.id, turns,
           // 实时输出流（文稿视图消费）：assistant 全文拼接，4KB 截断——多工具轮 agent 生成期
@@ -1360,6 +1388,11 @@ export function apply(ctx, config) {
       try { await ctx.get('sessions').flush(agent.session); } catch { /* flush 失败不影响结果 */ }
 
       let { text, reason } = summarize(agent.session.events, firstSeq);
+      // 模型请求看门狗触发：取消导致的「正常收尾」要改写为显式超时错误，
+      // 让引擎的重试机制（非取消类失败）能接手
+      if (watchState.modelTimeout) {
+        reason = { kind: 'error', error: watchState.modelTimeout };
+      }
       let structuredOutput;
       let structuredMeta;
       if (reason?.kind !== 'error' && outputConfig.mode === 'structured') {

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -23,6 +23,7 @@ import z from '@deepseek-ai/schemastery';
 import { createUserMessage } from '@deepseek-ai/dsh-llm';
 import { defineTool } from '@deepseek-ai/dsh-tools';
 import { SessionId } from '@deepseek-ai/dsh-session';
+import { installModelSelection } from '@deepseek-ai/dsh-agent';
 import { renderTemplate, validateTemplate } from './template.js';
 import { describeNodeOutput, normalizeExecutionResult, RUN_SCHEMA_VERSION } from './output-contract.js';
 import { resolveInside, safeFileId, safeFilename } from './safe-path.js';
@@ -1192,6 +1193,9 @@ export function apply(ctx, config) {
     if (!provider || !model) {
       throw new Error('未找到可用的 dsh 渠道和模型，请先在 dsh 设置中完成配置');
     }
+    // 节点级思考级别：仅当与全局选择同渠道同模型时全局档位才继承；节点显式配置优先。
+    // 档位经 installModelSelection 注入 agent/request waterfall（AgentOptions 本身不收 effort）。
+    const reasoningEffort = d.reasoningEffort || (provider === sel.provider && model === sel.model ? sel.reasoningEffort : undefined);
 
     // 工具过滤：与进程内已注册工具求交集（restrict 不接受未知名）
     const wanted = Array.isArray(d.tools) ? d.tools.filter((t) => t && t !== '*') : [];
@@ -1226,6 +1230,17 @@ export function apply(ctx, config) {
           agentCtx.systemPrompt.section({ name: 'deployment:persona', order: 0, text: personaText });
           if (restrictList) {
             try { agentCtx.tools.restrict({ allow: restrictList }); } catch { /* 交集后仍失败则放开 */ }
+          }
+          // 思考级别：selection 注入后每次模型请求经 waterfall 套用 effort；
+          // resolveCallConfig 校验档位，不支持时降级为默认行为（与官方 selectModel 同语义）
+          if (reasoningEffort) {
+            try {
+              const resolved = await ctx.llm.resolveCallConfig({ provider, model, reasoningEffort });
+              installModelSelection(agentCtx, {
+                current: { provider, model, ...(resolved.reasoningEffort ? { reasoningEffort: resolved.reasoningEffort } : {}) },
+                assembled: undefined,
+              });
+            } catch { /* 档位校验失败：跟随 provider 默认行为 */ }
           }
         },
       });
@@ -3029,15 +3044,33 @@ export function apply(ctx, config) {
     const providers = await Promise.all(ctx.llm.listProviders().map(async (provider) => {
       try {
         const models = await ctx.llm.listModels(provider.id);
-        return {
-          id: provider.id,
-          name: provider.name,
-          models: models.map((model) => ({
-            id: model.id,
-            name: model.name || model.id,
-            ...(model.description ? { description: model.description } : {}),
-          })),
-        };
+        // 逐模型补能力元数据：思考级别档位（reasoning）与视觉输入（vision）。
+        // resolveModelInfo 走 adapter 精确解析，失败只降级该模型，不拖垮整个目录。
+        const modelsWithMeta = await Promise.all(models.map(async (model) => {
+          try {
+            const info = await ctx.llm.resolveModelInfo(provider.id, model.id);
+            const reasoning = info.reasoning
+              ? {
+                  efforts: info.reasoning.efforts.map((effort) => ({
+                    id: effort.id,
+                    name: effort.name,
+                    ...(effort.description ? { description: effort.description } : {}),
+                  })),
+                  ...(info.reasoning.defaultEffort !== undefined ? { defaultEffort: info.reasoning.defaultEffort } : {}),
+                }
+              : undefined;
+            return {
+              id: model.id,
+              name: model.name || model.id,
+              ...(model.description ? { description: model.description } : {}),
+              ...(reasoning ? { reasoning } : {}),
+              ...(info.inputModalities ? { vision: info.inputModalities.includes('image') } : {}),
+            };
+          } catch {
+            return { id: model.id, name: model.name || model.id, ...(model.description ? { description: model.description } : {}) };
+          }
+        }));
+        return { id: provider.id, name: provider.name, models: modelsWithMeta };
       } catch (error) {
         failures.push({ provider: provider.id, error: error?.message || String(error) });
         return { id: provider.id, name: provider.name, models: [] };
@@ -3046,6 +3079,7 @@ export function apply(ctx, config) {
     json(res, 200, {
       defaultProvider: sel.provider,
       defaultModel: sel.model,
+      defaultReasoningEffort: sel.reasoningEffort,
       providers,
       ...(failures.length ? { failures } : {}),
     });

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -15,6 +15,7 @@
     "node": ">=22.15.0"
   },
   "peerDependencies": {
+    "@deepseek-ai/dsh-agent": "*",
     "@deepseek-ai/dsh-llm": "*",
     "@deepseek-ai/dsh-session": "*",
     "@deepseek-ai/dsh-tools": "*",
@@ -26,6 +27,9 @@
     "quickjs-emscripten": "0.32.0"
   },
   "peerDependenciesMeta": {
+    "@deepseek-ai/dsh-agent": {
+      "optional": true
+    },
     "@deepseek-ai/dsh-llm": {
       "optional": true
     },

--- a/web/src/NodePanel.jsx
+++ b/web/src/NodePanel.jsx
@@ -608,17 +608,22 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
               <p className="panel-note note-warn">部分 dsh 渠道的模型目录加载失败。</p>
             )}
             <div className="field-grid">
-              <Field label="轮数上限">
+              <Field label="轮数上限" hint="模型调用+工具执行算一轮">
                 <input type="number" min="1" max="20" value={d.maxRounds ?? ''}
                   onChange={(e) => set({ maxRounds: e.target.value === '' ? undefined : Number(e.target.value) })}
-                  placeholder={String(llmConfig.defaultMaxRounds || 6)} />
+                  placeholder="3" />
               </Field>
-              <Field label="超时（秒）">
+              <Field label="节点超时（秒）" hint="整个节点生命周期">
                 <input type="number" min="10" max="3600" value={d.timeoutSec ?? ''}
                   onChange={(e) => set({ timeoutSec: e.target.value === '' ? undefined : Number(e.target.value) })}
                   placeholder="500" />
               </Field>
             </div>
+            <Field label="单次请求超时（秒）" hint="一次模型调用无响应即判卡死，触发重试">
+              <input type="number" min="10" max="3600" value={d.modelTimeoutSec ?? ''}
+                onChange={(e) => set({ modelTimeoutSec: e.target.value === '' ? undefined : Number(e.target.value) })}
+                placeholder="300" />
+            </Field>
           </Section>
         </>
       )}

--- a/web/src/NodePanel.jsx
+++ b/web/src/NodePanel.jsx
@@ -764,7 +764,7 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
               <Field label="超时（秒）">
                 <input type="number" min="5" max="3600" value={d.timeoutSec ?? ''}
                   onChange={(e) => set({ timeoutSec: e.target.value === '' ? undefined : Number(e.target.value) })}
-                  placeholder="300" />
+                  placeholder="500" />
               </Field>
             )}
           </div>

--- a/web/src/NodePanel.jsx
+++ b/web/src/NodePanel.jsx
@@ -150,6 +150,13 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
   const modelDefaultLabel = d.channel
     ? `渠道默认（${providerModels[0]?.name || providerModels[0]?.id || '未配置'}）`
     : `跟随 dsh 默认（${llmConfig.defaultModel || '未配置'}）`;
+  // 所选模型的能力元数据：思考级别档位 + 视觉输入。跨渠道选模型后目录无该模型时为 null
+  const currentModel = providerModels.find((item) => item.id === d.model) || null;
+  const modelReasoning = currentModel?.reasoning || null;
+  // 继承全局默认档位：同渠道同模型时 dsh 默认档位生效（与引擎继承语义一致）
+  const inheritedEffort = effectiveProvider === llmConfig.defaultProvider && (!d.model || d.model === llmConfig.defaultModel)
+    ? llmConfig.defaultReasoningEffort
+    : undefined;
 
   const selectProvider = (providerId) => {
     if (!providerId) {
@@ -561,17 +568,42 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
                 </select>
               </Field>
               <Field label="模型">
-                <select value={d.model || ''} onChange={(e) => set({ model: e.target.value || undefined })} disabled={!effectiveProvider}>
+                <select value={d.model || ''} onChange={(e) => set({ model: e.target.value || undefined, reasoningEffort: undefined })} disabled={!effectiveProvider}>
                   <option value="">{modelDefaultLabel}</option>
                   {d.model && !providerModels.some((model) => model.id === d.model) && (
                     <option value={d.model}>{d.model}（目录中不可用）</option>
                   )}
                   {providerModels.map((model) => (
-                    <option key={model.id} value={model.id}>{model.name || model.id}</option>
+                    <option key={model.id} value={model.id}>
+                      {model.name || model.id}{model.vision === true ? ' 👁' : model.vision === false ? '' : ''}
+                    </option>
                   ))}
                 </select>
               </Field>
             </div>
+            {currentModel && (
+              <p className="sec-hint">
+                {currentModel.vision === true && <span title="该模型支持图片输入">👁 支持视觉</span>}
+                {currentModel.vision === false && <span title="该模型不支持图片输入">不支持视觉</span>}
+                {currentModel.vision === undefined && <span>视觉能力未知</span>}
+                {modelReasoning && <span> · 思考{modelReasoning.efforts.length ? ` ${modelReasoning.efforts.length} 档` : '不支持'}</span>}
+              </p>
+            )}
+            {modelReasoning && modelReasoning.efforts.length > 0 && (
+              <Field label="思考级别" hint="留空跟随全局默认档位">
+                <select
+                  value={d.reasoningEffort || ''}
+                  onChange={(e) => set({ reasoningEffort: e.target.value || undefined })}>
+                  <option value="">{inheritedEffort ? `跟随默认（${inheritedEffort}）` : `模型默认（${modelReasoning.defaultEffort || 'provider 决定'}）`}</option>
+                  {d.reasoningEffort && !modelReasoning.efforts.some((effort) => effort.id === d.reasoningEffort) && (
+                    <option value={d.reasoningEffort}>{d.reasoningEffort}（该模型不支持）</option>
+                  )}
+                  {modelReasoning.efforts.map((effort) => (
+                    <option key={effort.id} value={effort.id} title={effort.description || ''}>{effort.name || effort.id}</option>
+                  ))}
+                </select>
+              </Field>
+            )}
             {llmConfig.failures?.length > 0 && (
               <p className="panel-note note-warn">部分 dsh 渠道的模型目录加载失败。</p>
             )}
@@ -584,7 +616,7 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
               <Field label="超时（秒）">
                 <input type="number" min="10" max="3600" value={d.timeoutSec ?? ''}
                   onChange={(e) => set({ timeoutSec: e.target.value === '' ? undefined : Number(e.target.value) })}
-                  placeholder="300" />
+                  placeholder="500" />
               </Field>
             </div>
           </Section>


### PR DESCRIPTION
## 背景

智能体（agent）节点面板没有设置模型思考级别的入口，也看不出所选模型是否支持视觉（图片）输入。调研确认 dsh 0.1.x 底座两块能力都已齐备，只是 WF1 没接：

- `ctx.llm.resolveModelInfo(provider, model)` → `reasoning.efforts/defaultEffort` + `inputModalities`（含 `image` 即视觉）
- `@deepseek-ai/dsh-agent` 导出 `installModelSelection`：`selection.current` 携带 `reasoningEffort`，经 `agent/request` waterfall 套用到每次模型请求（官方 apiproxy `selectModel` 同款语义；AgentOptions 本身不收 effort）

## 改动

**引擎**（orchestrator）：
- agent 节点新增 `reasoningEffort` 配置。继承语义：与全局选择同渠道同模型时继承 dsh 默认档位，节点显式配置优先
- 创建 agent 时 setup 内先 `resolveCallConfig` 校验档位（模型不支持时降级 provider 默认，不阻塞运行），再 `installModelSelection` 注入
- `/wf1/api/llm-config` 逐模型附带 `reasoning`（档位 id/name/description + defaultEffort）与 `vision`（true/false，未知省略）；单模型解析失败只降级自身。响应新增 `defaultReasoningEffort`

**前端**（NodePanel「模型与轮次」区）：
- 模型下拉项 👁 标记视觉模型；选项下方能力摘要行（支持/不支持/未知视觉 · 思考档位数）
- 新增「思考级别」下拉：跟随默认（显示实际继承的档位）/ 模型各档位（option title 带说明）；切换渠道/模型自动清空档位防跨模型残留

**依赖**：`bootstrap-deps.sh` 与 orchestrator peerDeps（optional）补 `@deepseek-ai/dsh-agent`

## 验证

- orchestrator 全部套件绿（含 dsh-agent 链入后 live-trace/integration 等此前 5 个模块解析失败套件全恢复）
- 根 `npm test` 全量绿；`build-web.sh` 双构建通过
- 实机：DSH Desktop 重启后验 llm-config 新字段与面板渲染（见下方跟进）