### PR TITLE
feat(one): 设置面板可配 agent 节点默认渠道/模型/思考级别

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -918,6 +918,9 @@ window.__ModuleLoader__.load({
     var SYSTEM_INFO_API = "/wf1/api/system/info";
     var SYSTEM_CHECK_API = "/wf1/api/system/check-update";
     var SYSTEM_UPGRADE_API = "/wf1/api/system/upgrade";
+    // agent 节点默认值（渠道/模型/思考级别）：与 llm-config 目录配套使用
+    var AGENT_DEFAULTS_API = "/wf1/api/agent-defaults";
+    var LLM_CONFIG_API = "/wf1/api/llm-config";
 
     function systemGet(api) {
       return fetch(api, { headers: { accept: "application/json" } }).then(function (r) {
@@ -1001,6 +1004,214 @@ window.__ModuleLoader__.load({
       if (entry.kind === "registry") return "聚合安装（npm " + (entry.spec || "") + "）";
       if (entry.gitRoot) return "聚合安装（源码 link）";
       return "聚合安装（离线包）";
+    }
+
+    // ================= Agent 节点默认值（渠道 / 模型 / 思考级别） =================
+    // 语义：节点自身没配置时的兜底，再往下才是 dsh 全局选择（与 runAgentNode 同一解析链）。
+
+    function modelOptionsFor(llmConfig, providerId) {
+      var providers = (llmConfig && llmConfig.providers) || [];
+      for (var i = 0; i < providers.length; i++) {
+        if (providers[i].id === providerId) return providers[i].models || [];
+      }
+      return [];
+    }
+
+    function effortOptionsFor(llmConfig, providerId, modelId) {
+      var models = modelOptionsFor(llmConfig, providerId);
+      for (var i = 0; i < models.length; i++) {
+        if (models[i].id === modelId) return (models[i].reasoning && models[i].reasoning.efforts) || [];
+      }
+      return [];
+    }
+
+    function providerNameOf(llmConfig, providerId) {
+      var providers = (llmConfig && llmConfig.providers) || [];
+      for (var i = 0; i < providers.length; i++) {
+        if (providers[i].id === providerId) return providers[i].name || providers[i].id;
+      }
+      return providerId || "";
+    }
+
+    var selectStyle = {
+      width: "100%", padding: "6px 8px", borderRadius: "8px", fontSize: "13px",
+      border: "1px solid var(--dsw-alias-border-secondary, rgba(128,128,128,.3))",
+      background: "var(--dsw-alias-bg-primary, transparent)", color: "var(--dsw-alias-label-primary)",
+    };
+
+    function defaultsField(label, control) {
+      return react.createElement(
+        "div",
+        { key: label, style: { display: "flex", alignItems: "center", gap: "10px" } },
+        react.createElement(
+          "div",
+          { style: { width: "72px", flexShrink: 0, fontSize: "13px", color: "var(--dsw-alias-text-secondary)" } },
+          label,
+        ),
+        react.createElement("div", { style: { flex: 1 } }, control),
+      );
+    }
+
+    function AgentDefaultsCard() {
+      var a = s2(null), llmConfig = a[0], setLlmConfig = a[1];
+      var b = s2(null), saved = b[0], setSaved = b[1]; // GET/PUT 回包 {defaults, effective, dsh}
+      var c = s2({ provider: "", model: "", reasoningEffort: "" }), draft = c[0], setDraft = c[1];
+      var e = s2(false), saving = e[0], setSaving = e[1];
+      var f = s2(null), message = f[0], setMessage = f[1]; // {kind:'ok'|'err', text}
+
+      react.useEffect(function () {
+        var dead = false;
+        systemGet(LLM_CONFIG_API).then(function (d2) { if (!dead) setLlmConfig(d2); }).catch(function () {
+          if (!dead) setLlmConfig({ providers: [] });
+        });
+        systemGet(AGENT_DEFAULTS_API).then(function (d2) {
+          if (dead || !d2 || !d2.ok) return;
+          setSaved(d2);
+          setDraft(Object.assign({ provider: "", model: "", reasoningEffort: "" }, d2.defaults));
+        }).catch(function () {});
+        return function () { dead = true; };
+      }, []);
+
+      var providers = (llmConfig && llmConfig.providers) || [];
+      var dirty = !!saved && (
+        draft.provider !== saved.defaults.provider
+        || draft.model !== saved.defaults.model
+        || draft.reasoningEffort !== saved.defaults.reasoningEffort
+      );
+
+      var patchDraft = function (patch) {
+        setMessage(null);
+        setDraft(function (prev) { return Object.assign({}, prev, patch); });
+      };
+
+      var save = function () {
+        setSaving(true);
+        setMessage(null);
+        fetch(AGENT_DEFAULTS_API, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(draft),
+        })
+          .then(function (r) { return r.json(); })
+          .then(function (r2) {
+            if (r2 && r2.ok) {
+              setSaved(r2);
+              setDraft(Object.assign({ provider: "", model: "", reasoningEffort: "" }, r2.defaults));
+              setMessage({ kind: "ok", text: "已保存，新发起的运行立即生效" });
+            } else {
+              setMessage({ kind: "err", text: (r2 && r2.error) || "保存失败" });
+            }
+          })
+          .catch(function () { setMessage({ kind: "err", text: "连接不上本地服务，请确认 dsh 正在运行" }); })
+          .finally(function () { setSaving(false); });
+      };
+
+      // —— 选项装配 ——
+      var dshProvider = saved && saved.dsh && saved.dsh.provider;
+      var providerOptions = [{ value: "", label: "跟随 dsh 默认" + (dshProvider ? "（" + providerNameOf(llmConfig, dshProvider) + "）" : "") }]
+        .concat(providers.map(function (p) { return { value: p.id, label: p.name || p.id }; }));
+
+      var models = modelOptionsFor(llmConfig, draft.provider);
+      var modelOptions = [{ value: "", label: draft.provider ? "渠道首选模型" : "跟随渠道" }]
+        .concat(models.map(function (m) { return { value: m.id, label: (m.name || m.id) + (m.vision ? " 👁" : "") }; }));
+      // 已保存的模型从目录下线时保留原值展示，避免静默改写用户配置
+      if (draft.model && !models.some(function (m) { return m.id === draft.model; })) {
+        modelOptions.push({ value: draft.model, label: draft.model + "（目录中不可用）" });
+      }
+
+      var efforts = effortOptionsFor(llmConfig, draft.provider, draft.model);
+      var effortOptions = [{ value: "", label: "跟随模型默认" }]
+        .concat(efforts.map(function (e2) { return { value: e2.id, label: e2.name || e2.id }; }));
+      if (draft.reasoningEffort && !efforts.some(function (e2) { return e2.id === draft.reasoningEffort; })) {
+        effortOptions.push({ value: draft.reasoningEffort, label: draft.reasoningEffort + "（模型不支持）" });
+      }
+
+      var effective = saved && saved.effective;
+      var effectiveText = !effective || !effective.provider
+        ? null
+        : "当前生效：" + providerNameOf(llmConfig, effective.provider)
+          + " / " + (effective.model || "渠道首选模型")
+          + (effective.reasoningEffort ? " / 思考级别 " + effective.reasoningEffort : "");
+
+      var mkSelect = function (value, options, disabled, onChange) {
+        return react.createElement(
+          "select",
+          {
+            style: selectStyle,
+            value: value,
+            disabled: disabled,
+            onChange: function (ev) { onChange(ev.target.value); },
+          },
+          options.map(function (o) {
+            return react.createElement("option", { key: o.value || "__default", value: o.value }, o.label);
+          }),
+        );
+      };
+
+      return react.createElement(
+        "div",
+        {
+          style: {
+            border: "1px solid var(--dsw-alias-border-secondary, rgba(128,128,128,.25))",
+            borderRadius: "10px", padding: "12px 14px", display: "flex",
+            flexDirection: "column", gap: "10px",
+          },
+        },
+        react.createElement("div", { style: { fontSize: "13px", fontWeight: 600 } }, "Agent 节点默认值"),
+        react.createElement(
+          "div",
+          { style: { fontSize: "12px", color: "var(--dsw-alias-text-secondary)", lineHeight: "18px" } },
+          "节点没有单独配置渠道/模型/思考级别时，按这里的默认值运行；都没有时跟随 dsh 全局选择。",
+        ),
+        !llmConfig
+          ? react.createElement("div", { style: { fontSize: "12px", color: "var(--dsw-alias-text-secondary)" } }, "正在读取渠道目录…")
+          : !providers.length
+            ? react.createElement("div", { style: { fontSize: "12px", color: "var(--dsw-alias-text-secondary)" } }, "还没有可用的模型渠道，请先在 dsh 设置里完成配置。")
+            : [
+                defaultsField("渠道", mkSelect(draft.provider, providerOptions, saving, function (v) {
+                  patchDraft({ provider: v, model: "", reasoningEffort: "" });
+                })),
+                defaultsField("模型", mkSelect(draft.model, modelOptions, saving || !draft.provider, function (v) {
+                  patchDraft({ model: v, reasoningEffort: "" });
+                })),
+                defaultsField("思考级别", mkSelect(
+                  draft.reasoningEffort,
+                  effortOptions,
+                  saving || !draft.model || !efforts.length,
+                  function (v) { patchDraft({ reasoningEffort: v }); },
+                )),
+              ],
+        react.createElement(
+          "div",
+          { style: { display: "flex", alignItems: "center", gap: "10px", minHeight: "22px" } },
+          providers.length
+            ? react.createElement(
+                "button",
+                {
+                  style: {
+                    cursor: dirty && !saving ? "pointer" : "default",
+                    borderRadius: "8px", padding: "5px 14px", fontSize: "13px",
+                    border: "1px solid transparent",
+                    background: "var(--dsw-alias-accent-bg, #4F46E5)", color: "#fff",
+                    opacity: dirty && !saving ? 1 : 0.45,
+                  },
+                  disabled: !dirty || saving,
+                  onClick: save,
+                },
+                saving ? "保存中…" : "保存",
+              )
+            : null,
+          message
+            ? react.createElement(
+                "span",
+                { style: { fontSize: "12px", color: message.kind === "ok" ? "rgba(52,211,153,1)" : "rgba(248,113,113,1)" } },
+                (message.kind === "ok" ? "✓ " : "✗ ") + message.text,
+              )
+            : effectiveText
+              ? react.createElement("span", { style: { fontSize: "12px", color: "var(--dsw-alias-text-secondary)" } }, effectiveText)
+              : null,
+        ),
+      );
     }
 
     function WorkflowOneSection() {
@@ -1091,6 +1302,9 @@ window.__ModuleLoader__.load({
       return react.createElement(
         "div",
         { style: { display: "flex", flexDirection: "column", gap: "14px", maxWidth: "560px" } },
+
+        // —— Agent 节点默认值：渠道 / 模型 / 思考级别 ——
+        react.createElement(AgentDefaultsCard),
 
         // —— 第一眼：当前版本大字 + 状态一句话 ——
         react.createElement(
@@ -1596,6 +1810,9 @@ window.__ModuleLoader__.load({
       graphThumbnail: graphThumbnail,
       WorkflowRunCard: WorkflowRunCard,
       GraphPatchCard: GraphPatchCard,
+      modelOptionsFor: modelOptionsFor,
+      effortOptionsFor: effortOptionsFor,
+      providerNameOf: providerNameOf,
     };
 
     return exports;

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -655,4 +655,44 @@ for (const [body, expected] of [
   assert.equal(fetchCalls.length, before, "缺目标不发请求");
 }
 
+// ---- 设置面板「Agent 节点默认值」选项装配 ----
+{
+  const catalog = {
+    providers: [
+      {
+        id: "deepseek",
+        name: "DeepSeek",
+        models: [
+          { id: "deepseek-chat", name: "Chat" },
+          {
+            id: "deepseek-reasoner",
+            name: "Reasoner",
+            vision: true,
+            reasoning: { efforts: [{ id: "low" }, { id: "high", name: "高" }] },
+          },
+        ],
+      },
+      { id: "glm", name: "智谱", models: [{ id: "glm-5" }] },
+    ],
+  };
+  assert.equal(client.__test.providerNameOf(catalog, "glm"), "智谱");
+  assert.equal(client.__test.providerNameOf(catalog, "ghost"), "ghost");
+  // __test 函数返回的数组来自 vm realm，先 Array.from 回宿主 realm 再 deepEqual
+  assert.deepEqual(
+    Array.from(client.__test.modelOptionsFor(catalog, "deepseek"), (m) => m.id),
+    ["deepseek-chat", "deepseek-reasoner"],
+  );
+  assert.deepEqual(Array.from(client.__test.modelOptionsFor(catalog, "ghost")), []);
+  assert.deepEqual(
+    Array.from(client.__test.effortOptionsFor(catalog, "deepseek", "deepseek-reasoner"), (e) => e.id),
+    ["low", "high"],
+  );
+  assert.deepEqual(Array.from(client.__test.effortOptionsFor(catalog, "deepseek", "deepseek-chat")), []);
+  assert.deepEqual(Array.from(client.__test.effortOptionsFor(catalog, "ghost", "x")), []);
+  assert.deepEqual(Array.from(client.__test.effortOptionsFor(null, "deepseek", "deepseek-reasoner")), []);
+  // 设置面板数据源：默认值接口与模型目录接口都要在 bundle 里
+  assert.equal(bundle.includes('"/wf1/api/agent-defaults"'), true);
+  assert.equal(bundle.includes('"/wf1/api/llm-config"'), true);
+}
+
 console.log("canvasui client tests: passed");

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/agent-defaults.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/agent-defaults.js
@@ -1,0 +1,144 @@
+// agent 节点默认值存储：用户在 dsh 设置面板「Workflow One」里配置的兜底
+// 渠道/模型/思考级别。语义是「节点没显式配置时的第二顺位」——优先级链为
+// 节点自身 data > 本文件 > dsh 全局模型选择（agentDefaultModel.currentSelection）。
+//
+// 存放位置与飞书凭据同为 dsh 用户级（~/.dsh/plugin-data/.../state/），不进
+// 工作区 .workflow-one/：它是跨工作区的用户偏好，且设置面板没有会话工作区上下文。
+
+import {
+  chmodSync, closeSync, existsSync, fsyncSync, mkdirSync, openSync, readFileSync, renameSync, unlinkSync, writeFileSync,
+} from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+const MAX_FIELD_LENGTH = 200;
+const ALLOWED_KEYS = new Set(['provider', 'model', 'reasoningEffort']);
+
+export class AgentDefaultsError extends Error {
+  constructor(message, { code = 'invalid-agent-defaults', status = 400 } = {}) {
+    super(message);
+    this.name = 'AgentDefaultsError';
+    this.code = code;
+    this.status = status;
+  }
+}
+
+const fail = (message, options) => {
+  throw new AgentDefaultsError(message, options);
+};
+
+export const agentDefaultsFile = () => join(
+  process.env.DSH_HOME || join(homedir(), '.dsh'),
+  'plugin-data', 'dsh-ccpg-orchestrator', 'state', 'agent-defaults.json',
+);
+
+export const EMPTY_AGENT_DEFAULTS = Object.freeze({ provider: '', model: '', reasoningEffort: '' });
+
+/** 输入整形：只收三个字符串字段，空串 = 不设置（跟随 dsh 全局选择）。 */
+export function normalizeAgentDefaults(source) {
+  if (source === null || typeof source !== 'object' || Array.isArray(source)) fail('请求体必须是对象');
+  for (const key of Object.keys(source)) {
+    if (!ALLOWED_KEYS.has(key)) fail(`不支持的字段 ${key}`);
+  }
+  const result = { ...EMPTY_AGENT_DEFAULTS };
+  for (const key of ALLOWED_KEYS) {
+    const value = source[key];
+    if (value === undefined || value === null) continue;
+    if (typeof value !== 'string') fail(`${key} 必须是字符串`);
+    const trimmed = value.trim();
+    if (trimmed.length > MAX_FIELD_LENGTH) fail(`${key} 最长 ${MAX_FIELD_LENGTH} 个字符`);
+    result[key] = trimmed;
+  }
+  // 依赖关系：model 依附 provider，思考级别依附具体模型
+  if (result.model && !result.provider) fail('设置默认模型前必须先选默认渠道');
+  if (result.reasoningEffort && !result.model) fail('设置默认思考级别前必须先选默认渠道和模型');
+  return result;
+}
+
+/**
+ * 对照 dsh LLM 目录校验：渠道/模型必须真实存在，思考级别必须是该模型支持的档位。
+ * llm 形状 = ctx.llm（listProviders/listModels/resolveModelInfo）。目录查询失败
+ * 原样抛出（路由层转 500），语义校验失败抛 AgentDefaultsError（400）。
+ */
+export async function validateAgentDefaults(defaults, llm) {
+  if (!defaults.provider) return defaults;
+  const providers = await llm.listProviders();
+  if (!providers.some((p) => p.id === defaults.provider)) fail(`渠道不存在：${defaults.provider}`);
+  if (!defaults.model) return defaults;
+  const models = await llm.listModels(defaults.provider);
+  if (!models.some((m) => m.id === defaults.model)) fail(`渠道 ${defaults.provider} 下不存在模型：${defaults.model}`);
+  if (!defaults.reasoningEffort) return defaults;
+  let info;
+  try {
+    info = await llm.resolveModelInfo(defaults.provider, defaults.model);
+  } catch {
+    // 元数据解析失败不代表配置错误（adapter 可能没实现），放行档位
+    return defaults;
+  }
+  const efforts = info?.reasoning?.efforts || [];
+  if (!efforts.length) fail(`模型 ${defaults.model} 不支持思考级别设置`);
+  if (!efforts.some((e) => e.id === defaults.reasoningEffort)) {
+    fail(`模型 ${defaults.model} 不支持思考级别 ${defaults.reasoningEffort}（可选：${efforts.map((e) => e.id).join(', ')}）`);
+  }
+  return defaults;
+}
+
+export class AgentDefaultsStore {
+  constructor(filePath = agentDefaultsFile()) {
+    this.filePath = filePath;
+  }
+
+  /** 缺文件/损坏都回退空默认值：偏好配置不该阻塞运行。 */
+  read() {
+    if (!existsSync(this.filePath)) return { ...EMPTY_AGENT_DEFAULTS };
+    try {
+      const doc = JSON.parse(readFileSync(this.filePath, 'utf8'));
+      if (doc === null || typeof doc !== 'object' || Array.isArray(doc)) return { ...EMPTY_AGENT_DEFAULTS };
+      const { version: _version, ...defaults } = doc; // version 是信封字段，不是配置项
+      return normalizeAgentDefaults(defaults);
+    } catch {
+      return { ...EMPTY_AGENT_DEFAULTS };
+    }
+  }
+
+  write(defaults) {
+    const normalized = normalizeAgentDefaults(defaults);
+    const data = `${JSON.stringify({ version: 1, ...normalized }, null, 2)}\n`;
+    mkdirSync(dirname(this.filePath), { recursive: true, mode: 0o700 });
+    const tmp = `${this.filePath}.tmp-${process.pid}-${randomUUID()}`;
+    let fd;
+    try {
+      fd = openSync(tmp, 'wx', 0o600);
+      writeFileSync(fd, data, 'utf8');
+      fsyncSync(fd);
+      closeSync(fd); fd = undefined;
+      renameSync(tmp, this.filePath);
+      chmodSync(this.filePath, 0o600);
+    } catch (error) {
+      if (fd !== undefined) { try { closeSync(fd); } catch { /* already closed */ } }
+      try { unlinkSync(tmp); } catch { /* no temp file */ }
+      throw error;
+    }
+    return normalized;
+  }
+}
+
+/**
+ * 节点未显式配置时的完整解析链：节点 data > 本默认值 > dsh 全局选择。
+ * 配套约束：默认模型只在默认渠道生效（跨渠道不错配）；dsh 全局模型只在
+ * 最终渠道恰为 dsh 全局渠道时继承。返回 { provider, model, reasoningEffort }，
+ * 任一字段 undefined 表示「该层没有提供，由调用方继续解析」。
+ */
+export function resolveAgentModelSelection({ node = {}, defaults = EMPTY_AGENT_DEFAULTS, dshSelection = {} } = {}) {
+  const sel = dshSelection || {};
+  const provider = node.channel || defaults.provider || sel.provider || undefined;
+  let model = node.model || undefined;
+  if (!model && !node.channel && defaults.provider) model = defaults.model || undefined;
+  if (!model && provider && provider === sel.provider) model = sel.model || undefined;
+  const reasoningEffort = node.reasoningEffort
+    || (provider && provider === defaults.provider && model && model === defaults.model ? defaults.reasoningEffort : undefined)
+    || (provider === sel.provider && model === sel.model ? sel.reasoningEffort : undefined)
+    || undefined;
+  return { provider, model, reasoningEffort };
+}

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -66,6 +66,10 @@ import {
 } from './assistant.js';
 import { ensureWorkflowSkill } from './skill-seed.js';
 import {
+  AgentDefaultsError, AgentDefaultsStore, normalizeAgentDefaults, resolveAgentModelSelection,
+  validateAgentDefaults,
+} from './agent-defaults.js';
+import {
   assertNonSensitiveVariableDefinitions, assertSafeContextObject, GlobalVariableStore, VariableStoreError,
   variableDefinitionsToValues,
 } from './variable-store.js';
@@ -211,6 +215,8 @@ export function apply(ctx, config) {
       return typeof value === 'function' ? value.bind(store) : value;
     },
   });
+  // agent 节点默认值是 dsh 用户级偏好（跨工作区共享），不随 workspace store 走
+  const agentDefaultsStore = new AgentDefaultsStore();
   const currentPaths = () => currentStore().paths;
   const currentDatabase = () => currentStore().database;
   const currentHooks = () => currentStore().hooks;
@@ -1181,12 +1187,13 @@ export function apply(ctx, config) {
       userPrompt += `\n\n可用附件已放入节点输出目录 ${outputDir}，用 read 工具读取：${attachments.map((a) => `${outputDir}/${a.filename}`).join(', ')}`;
     }
 
-    // 节点级模型：默认取全局选择；channel 仅透传给支持的 provider
+    // 节点级模型解析链：节点显式配置 > 设置面板「Workflow One」默认值 > dsh 全局选择；
+    // channel 仅透传给支持的 provider。默认值与全局模型都只在渠道匹配时继承（跨渠道不错配）。
     const defaultModel = ctx.get('agentDefaultModel');
     const sel = defaultModel?.currentSelection?.() || {};
-    const provider = d.channel || sel.provider;
-    let model = d.model;
-    if (!model && (!d.channel || provider === sel.provider)) model = sel.model;
+    const resolved = resolveAgentModelSelection({ node: d, defaults: agentDefaultsStore.read(), dshSelection: sel });
+    const provider = resolved.provider;
+    let model = resolved.model;
     if (!model && provider) {
       const models = await ctx.llm.listModels(provider);
       model = models[0]?.id;
@@ -1194,9 +1201,9 @@ export function apply(ctx, config) {
     if (!provider || !model) {
       throw new Error('未找到可用的 dsh 渠道和模型，请先在 dsh 设置中完成配置');
     }
-    // 节点级思考级别：仅当与全局选择同渠道同模型时全局档位才继承；节点显式配置优先。
+    // 节点级思考级别：节点显式配置 > Workflow One 默认档位 > 全局档位（均需同渠道同模型）。
     // 档位经 installModelSelection 注入 agent/request waterfall（AgentOptions 本身不收 effort）。
-    const reasoningEffort = d.reasoningEffort || (provider === sel.provider && model === sel.model ? sel.reasoningEffort : undefined);
+    const reasoningEffort = resolved.reasoningEffort;
     // 模型单请求超时（step 粒度）：一次模型调用（含其工具执行前的新型请求）超过即视为卡死，
     // 与节点总超时（timeoutSec，整个节点生命周期）是两个独立旋钮。step/end 重置计时。
     const MODEL_TIMEOUT_MS = 300 * 1000;
@@ -3074,6 +3081,8 @@ export function apply(ctx, config) {
   } });
 
   // ---- LLM 配置：直接读取 dsh 运行时注册的渠道和模型目录 ----
+  // 目录只依赖 dsh 运行时（ctx.llm），与工作区无关——scoped:false 让设置面板（无会话上下文）也能读；
+  // 画布请求带 sessionId 时 scoped:false 只是跳过工作区绑定，handler 本就不读工作区状态。
   register({ kind: 'exact', path: '/wf1/api/llm-config', async handler(_req, res) {
     const sel = ctx.get('agentDefaultModel')?.currentSelection?.() || {};
     const failures = [];
@@ -3119,12 +3128,59 @@ export function apply(ctx, config) {
       providers,
       ...(failures.length ? { failures } : {}),
     });
-  } });
+  } }, { scoped: false });
 
   // runtime 徽标数据源：插件形态下 agent 恒走 dsh 底座
   register({ kind: 'exact', path: '/wf1/api/runtime-config', handler(_req, res) {
     json(res, 200, { runtime: { available: true, runtime: 'dsh-plugin', reasons: [] } });
   } });
+
+  // ---- agent 节点默认值（设置面板「Workflow One」）：渠道/模型/思考级别 ----
+  // dsh 用户级偏好，不依赖会话工作区（设置面板无 session 上下文），故 scoped: false。
+  // PUT 整体替换三字段；空串 = 该层不设置，回退到 dsh 全局模型选择。
+  const agentDefaultsPayload = async () => {
+    const sel = ctx.get('agentDefaultModel')?.currentSelection?.() || {};
+    const defaults = agentDefaultsStore.read();
+    const effective = resolveAgentModelSelection({ node: {}, defaults, dshSelection: sel });
+    return {
+      ok: true,
+      defaults,
+      // effective 与 runAgentNode 同一解析链（节点层为空时的结果）；model 缺省表示「渠道首选」
+      effective: {
+        provider: effective.provider || null,
+        model: effective.model || null,
+        reasoningEffort: effective.reasoningEffort || null,
+      },
+      dsh: { provider: sel.provider || null, model: sel.model || null, reasoningEffort: sel.reasoningEffort || null },
+    };
+  };
+  register({ kind: 'exact', path: '/wf1/api/agent-defaults', async handler(req, res) {
+    try {
+      if (req.method === 'GET') return json(res, 200, await agentDefaultsPayload());
+      if (req.method === 'PUT') {
+        const body = await readBody(req);
+        try {
+          const defaults = normalizeAgentDefaults(body);
+          await validateAgentDefaults(defaults, ctx.llm);
+          agentDefaultsStore.write(defaults);
+          return json(res, 200, await agentDefaultsPayload());
+        } catch (error) {
+          if (error instanceof AgentDefaultsError) {
+            return json(res, error.status || 400, { ok: false, error: error.message, code: error.code });
+          }
+          throw error;
+        }
+      }
+      return json(res, 405, { ok: false, error: '仅支持 GET/PUT', code: 'method-not-allowed' });
+    } catch (error) {
+      // scoped:false 没有统一兜底：请求体错误归 400，目录查询等失败落 500
+      if (error instanceof RequestBodyError) {
+        return json(res, Number(error.status) || 400, { ok: false, error: String(error.message || error), code: error.code || 'invalid-request' });
+      }
+      ctx.logger?.error?.(`agent-defaults 接口失败：${error.stack || error.message || error}`);
+      return json(res, 500, { ok: false, error: '读取 dsh 模型目录失败', code: 'internal-error' });
+    }
+  } }, { scoped: false });
 
   register({ kind: 'exact', path: '/wf1/api/tools', handler(_req, res) {
     try {

--- a/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.1.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-ccpg-orchestrator",
-      "version": "0.1.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",
@@ -17,12 +17,16 @@
         "node": ">=22.15.0"
       },
       "peerDependencies": {
+        "@deepseek-ai/dsh-agent": "*",
         "@deepseek-ai/dsh-llm": "*",
         "@deepseek-ai/dsh-session": "*",
         "@deepseek-ai/dsh-tools": "*",
         "@deepseek-ai/schemastery": "*"
       },
       "peerDependenciesMeta": {
+        "@deepseek-ai/dsh-agent": {
+          "optional": true
+        },
         "@deepseek-ai/dsh-llm": {
           "optional": true
         },

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults-api.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults-api.integration.test.mjs
@@ -1,0 +1,149 @@
+// /wf1/api/agent-defaults 集成测试（假 webServer 直调路由，与 schedule-api 同模式）。
+// 端点是 scoped:false（设置面板无会话上下文），存储落在 DSH_HOME 用户级目录。
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { apply } from '../lib/index.js';
+
+function responseCapture() {
+  return {
+    status: 0,
+    chunks: [],
+    writableEnded: false,
+    writeHead(status) { this.status = status; },
+    write(chunk) { this.chunks.push(Buffer.from(chunk)); },
+    end(chunk) { if (chunk) this.chunks.push(Buffer.from(chunk)); this.writableEnded = true; },
+    on() { return this; },
+    once() { return this; },
+    json() { return JSON.parse(Buffer.concat(this.chunks).toString('utf8') || '{}'); },
+  };
+}
+
+function request(method, url, body) {
+  const req = new EventEmitter();
+  req.method = method;
+  req.url = url;
+  req.headers = {};
+  queueMicrotask(() => {
+    if (body !== undefined) req.emit('data', Buffer.from(typeof body === 'string' ? body : JSON.stringify(body)));
+    req.emit('end');
+  });
+  return req;
+}
+
+const dshHome = mkdtempSync(join(tmpdir(), 'wf1-ad-home-'));
+const workspace = mkdtempSync(join(tmpdir(), 'wf1-ad-ws-'));
+const originalEnv = { DSH_HOME: process.env.DSH_HOME, WF1_LEGACY_DATA_DIR: process.env.WF1_LEGACY_DATA_DIR };
+process.env.DSH_HOME = dshHome;
+const packageLegacyDir = join(dshHome, 'package-legacy');
+mkdirSync(join(packageLegacyDir, 'state'), { recursive: true });
+process.env.WF1_LEGACY_DATA_DIR = packageLegacyDir;
+writeFileSync(join(packageLegacyDir, 'state', 'graph.json'), JSON.stringify({ nodes: [], edges: [] }));
+
+const ctx = {
+  webServer: { register(route) { this.routes.push(route); }, routes: [] },
+  tools: { register() {}, schemas() { return []; } },
+  get(name) {
+    if (name === 'sessions') return { get: () => ({ header: { cwd: workspace } }), flush: async () => {} };
+    if (name === 'agentDefaultModel') {
+      return { currentSelection: () => ({ provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium' }) };
+    }
+    return null;
+  },
+  skills: { async list() { return []; } },
+  llm: {
+    listProviders() { return [{ id: 'deepseek', name: 'DeepSeek' }, { id: 'glm', name: '智谱' }]; },
+    async listModels(provider) {
+      return provider === 'deepseek' ? [{ id: 'deepseek-chat' }, { id: 'deepseek-reasoner' }] : [{ id: 'glm-5' }];
+    },
+    async resolveModelInfo(_provider, model) {
+      return model === 'deepseek-reasoner'
+        ? { reasoning: { efforts: [{ id: 'low' }, { id: 'high' }], defaultEffort: 'low' }, inputModalities: ['text'] }
+        : { inputModalities: ['text'] };
+    },
+  },
+  agentPresets: { async mount() {} },
+  logger: { info() {}, warn() {}, error() {} },
+  effect() {},
+};
+apply(ctx, {});
+const route = ctx.webServer.routes.find((entry) => entry.kind === 'exact' && entry.path === '/wf1/api/agent-defaults')?.handler;
+assert.ok(route, 'agent-defaults 路由已注册');
+
+const call = async (method, body) => {
+  const res = responseCapture();
+  await route(request(method, '/wf1/api/agent-defaults', body), res);
+  return { status: res.status, body: res.json() };
+};
+
+const results = [];
+const test = async (name, fn) => {
+  try { await fn(); results.push(['✓', name]); }
+  catch (error) { results.push(['✗', name, error]); }
+};
+
+await test('GET 初始为空默认值，effective 跟随 dsh 全局选择', async () => {
+  const { status, body } = await call('GET');
+  assert.equal(status, 200);
+  assert.deepEqual(body.defaults, { provider: '', model: '', reasoningEffort: '' });
+  assert.deepEqual(body.effective, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium' });
+  assert.deepEqual(body.dsh, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium' });
+});
+
+await test('PUT 未知渠道 400 且不落盘', async () => {
+  const { status, body } = await call('PUT', { provider: 'nope' });
+  assert.equal(status, 400);
+  assert.match(body.error, /渠道不存在/);
+  assert.equal(existsSync(join(dshHome, 'plugin-data', 'dsh-ccpg-orchestrator', 'state', 'agent-defaults.json')), false);
+});
+
+await test('PUT 合法三件套 200，effective 生效且 GET 可读回', async () => {
+  const put = await call('PUT', { provider: 'glm', model: 'glm-5', reasoningEffort: '' });
+  assert.equal(put.status, 200);
+  assert.deepEqual(put.body.effective, { provider: 'glm', model: 'glm-5', reasoningEffort: null });
+  const get = await call('GET');
+  assert.deepEqual(get.body.defaults, { provider: 'glm', model: 'glm-5', reasoningEffort: '' });
+});
+
+await test('PUT 思考级别校验：支持的放行、不支持的 400', async () => {
+  const bad = await call('PUT', { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'high' });
+  assert.equal(bad.status, 400);
+  assert.match(bad.body.error, /不支持思考级别/);
+  const good = await call('PUT', { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' });
+  assert.equal(good.status, 200);
+  assert.deepEqual(good.body.effective, { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' });
+});
+
+await test('PUT 缺依赖字段 400；清空回退 dsh 全局', async () => {
+  const bad = await call('PUT', { model: 'glm-5' });
+  assert.equal(bad.status, 400);
+  assert.match(bad.body.error, /先选默认渠道/);
+  const cleared = await call('PUT', {});
+  assert.equal(cleared.status, 200);
+  assert.deepEqual(cleared.body.effective, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium' });
+});
+
+await test('POST 方法 405', async () => {
+  const { status } = await call('POST', {});
+  assert.equal(status, 405);
+});
+
+await test('PUT 畸形 JSON 请求体 400（scoped:false 路由也要有请求体错误兜底）', async () => {
+  const { status, body } = await call('PUT', 'not-json{{{');
+  assert.equal(status, 400);
+  assert.match(body.error, /JSON/);
+});
+
+if (originalEnv.DSH_HOME === undefined) delete process.env.DSH_HOME; else process.env.DSH_HOME = originalEnv.DSH_HOME;
+if (originalEnv.WF1_LEGACY_DATA_DIR === undefined) delete process.env.WF1_LEGACY_DATA_DIR;
+else process.env.WF1_LEGACY_DATA_DIR = originalEnv.WF1_LEGACY_DATA_DIR;
+
+let failed = 0;
+for (const [mark, name, error] of results) {
+  console.log(`${mark} ${name}`);
+  if (error) { failed += 1; console.error(error); }
+}
+if (failed) process.exit(1);
+console.log(`${results.length} tests passed`);

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults.test.mjs
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  AgentDefaultsError,
+  AgentDefaultsStore,
+  EMPTY_AGENT_DEFAULTS,
+  normalizeAgentDefaults,
+  resolveAgentModelSelection,
+  validateAgentDefaults,
+} from '../lib/agent-defaults.js';
+
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+// ---- normalizeAgentDefaults ----
+
+test('normalize: 空对象与缺省字段都落成空默认值', () => {
+  assert.deepEqual(normalizeAgentDefaults({}), EMPTY_AGENT_DEFAULTS);
+  assert.deepEqual(normalizeAgentDefaults({ provider: undefined, model: null }), EMPTY_AGENT_DEFAULTS);
+});
+
+test('normalize: 正常字段保留并 trim', () => {
+  assert.deepEqual(
+    normalizeAgentDefaults({ provider: ' deepseek ', model: 'deepseek-chat', reasoningEffort: 'high' }),
+    { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'high' },
+  );
+});
+
+test('normalize: 拒绝未知字段 / 非字符串 / 非对象', () => {
+  assert.throws(() => normalizeAgentDefaults({ provider: 'a', extra: 1 }), AgentDefaultsError);
+  assert.throws(() => normalizeAgentDefaults({ provider: 42 }), AgentDefaultsError);
+  assert.throws(() => normalizeAgentDefaults(null), AgentDefaultsError);
+  assert.throws(() => normalizeAgentDefaults('x'), AgentDefaultsError);
+});
+
+test('normalize: model 依赖 provider、思考级别依赖 model', () => {
+  assert.throws(() => normalizeAgentDefaults({ model: 'm' }), /先选默认渠道/);
+  assert.throws(() => normalizeAgentDefaults({ provider: 'p', reasoningEffort: 'high' }), /先选默认渠道和模型/);
+});
+
+// ---- validateAgentDefaults ----
+
+const fakeLlm = (overrides = {}) => ({
+  async listProviders() { return [{ id: 'deepseek', name: 'DeepSeek' }, { id: 'glm', name: '智谱' }]; },
+  async listModels(provider) {
+    return provider === 'deepseek' ? [{ id: 'deepseek-chat' }, { id: 'deepseek-reasoner' }] : [{ id: 'glm-5' }];
+  },
+  async resolveModelInfo(provider, model) {
+    if (model === 'deepseek-reasoner') {
+      return { reasoning: { efforts: [{ id: 'low' }, { id: 'high' }], defaultEffort: 'low' } };
+    }
+    return {};
+  },
+  ...overrides,
+});
+
+test('validate: 全空（跟随 dsh）直接放行', async () => {
+  await validateAgentDefaults(EMPTY_AGENT_DEFAULTS, fakeLlm());
+});
+
+test('validate: 未知渠道 / 未知模型 / 不支持的档位都 400', async () => {
+  await assert.rejects(() => validateAgentDefaults({ provider: 'nope', model: '', reasoningEffort: '' }, fakeLlm()), /渠道不存在/);
+  await assert.rejects(
+    () => validateAgentDefaults({ provider: 'deepseek', model: 'nope', reasoningEffort: '' }, fakeLlm()),
+    /不存在模型/,
+  );
+  await assert.rejects(
+    () => validateAgentDefaults({ provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'max' }, fakeLlm()),
+    /不支持思考级别 max/,
+  );
+  await assert.rejects(
+    () => validateAgentDefaults({ provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'high' }, fakeLlm()),
+    /不支持思考级别设置/,
+  );
+});
+
+test('validate: 支持的档位放行；元数据解析失败降级放行', async () => {
+  await validateAgentDefaults({ provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' }, fakeLlm());
+  await validateAgentDefaults(
+    { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' },
+    fakeLlm({ async resolveModelInfo() { throw new Error('adapter 缺失'); } }),
+  );
+});
+
+// ---- AgentDefaultsStore ----
+
+test('store: 缺文件 / 损坏文件都回退空默认值', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'wf1-agent-defaults-'));
+  const file = join(dir, 'agent-defaults.json');
+  const store = new AgentDefaultsStore(file);
+  assert.deepEqual(store.read(), EMPTY_AGENT_DEFAULTS);
+  writeFileSync(file, '{broken json', 'utf8');
+  assert.deepEqual(store.read(), EMPTY_AGENT_DEFAULTS);
+  writeFileSync(file, JSON.stringify({ provider: 'p', hacker: true }), 'utf8');
+  assert.deepEqual(store.read(), EMPTY_AGENT_DEFAULTS);
+});
+
+test('store: 写入后可读回，落盘 0600', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'wf1-agent-defaults-'));
+  const file = join(dir, 'sub', 'agent-defaults.json');
+  const store = new AgentDefaultsStore(file);
+  store.write({ provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' });
+  assert.deepEqual(store.read(), { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' });
+  const doc = JSON.parse(readFileSync(file, 'utf8'));
+  assert.equal(doc.version, 1);
+  assert.equal(doc.provider, 'deepseek');
+});
+
+// ---- resolveAgentModelSelection（与 runAgentNode 同一解析链）----
+
+const SEL = { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium' };
+
+test('resolve: 节点显式配置永远优先', () => {
+  const r = resolveAgentModelSelection({
+    node: { channel: 'glm', model: 'glm-5', reasoningEffort: 'low' },
+    defaults: { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' },
+    dshSelection: SEL,
+  });
+  assert.deepEqual(r, { provider: 'glm', model: 'glm-5', reasoningEffort: 'low' });
+});
+
+test('resolve: 节点未配置时取 Workflow One 默认值（含档位）', () => {
+  const r = resolveAgentModelSelection({
+    node: {},
+    defaults: { provider: 'glm', model: 'glm-5', reasoningEffort: 'high' },
+    dshSelection: SEL,
+  });
+  assert.deepEqual(r, { provider: 'glm', model: 'glm-5', reasoningEffort: 'high' });
+});
+
+test('resolve: 无默认值时维持 dsh 全局选择旧行为', () => {
+  const r = resolveAgentModelSelection({ node: {}, defaults: EMPTY_AGENT_DEFAULTS, dshSelection: SEL });
+  assert.deepEqual(r, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium' });
+});
+
+test('resolve: 默认渠道下的默认模型为空 → model 留空（由调用方取渠道首选），不错配 dsh 模型', () => {
+  const r = resolveAgentModelSelection({
+    node: {},
+    defaults: { provider: 'glm', model: '', reasoningEffort: '' },
+    dshSelection: SEL,
+  });
+  assert.equal(r.provider, 'glm');
+  assert.equal(r.model, undefined); // 不能回退成 deepseek-chat
+  assert.equal(r.reasoningEffort, undefined);
+});
+
+test('resolve: 节点指定了渠道 → 不继承 Workflow One 默认模型', () => {
+  const r = resolveAgentModelSelection({
+    node: { channel: 'glm' },
+    defaults: { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' },
+    dshSelection: SEL,
+  });
+  assert.equal(r.provider, 'glm');
+  assert.equal(r.model, undefined);
+  assert.equal(r.reasoningEffort, undefined);
+});
+
+test('resolve: 默认档位只在同渠道同模型时继承', () => {
+  const r = resolveAgentModelSelection({
+    node: { channel: 'glm', model: 'glm-5-air' }, // 同渠道不同模型
+    defaults: { provider: 'glm', model: 'glm-5', reasoningEffort: 'high' },
+    dshSelection: SEL,
+  });
+  assert.equal(r.reasoningEffort, undefined);
+});
+
+test('resolve: 默认档位的下一顺位是 dsh 全局档位', () => {
+  const r = resolveAgentModelSelection({
+    node: {},
+    defaults: { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: '' }, // 与 dsh 同渠道同模型但未设档位
+    dshSelection: SEL,
+  });
+  assert.equal(r.reasoningEffort, 'medium');
+});
+
+let failed = 0;
+for (const [name, fn] of tests) {
+  try {
+    await fn();
+    console.log(`ok - ${name}`);
+  } catch (error) {
+    failed += 1;
+    console.error(`not ok - ${name}`);
+    console.error(error);
+  }
+}
+if (failed) process.exit(1);
+console.log(`${tests.length} tests passed`);


### PR DESCRIPTION
## 背景

dsh 设置 →「Workflow One」此前只有版本/升级卡片。agent 节点的渠道/模型/思考级别只能逐节点配置，或整体跟随 dsh 全局选择——缺少一层「Workflow One 自己的默认值」。

## 方案

新增解析链中间层：**节点显式配置 > Workflow One 默认值 > dsh 全局选择**（跨渠道不错配：默认模型只在默认渠道生效，全局模型只在最终渠道恰为全局渠道时继承）。

- **orchestrator**：`lib/agent-defaults.js`（normalize/validate/原子落盘 0600 + 解析链纯函数）；新端点 `GET/PUT /wf1/api/agent-defaults`；`/wf1/api/llm-config` 改 `scoped:false`（目录只读 `ctx.llm`，设置面板无会话上下文）；runAgentNode 切到统一解析链
- **存储位置**：dsh 用户级 `plugin-data/dsh-ccpg-orchestrator/state/agent-defaults.json`（与飞书凭据同层级）——跨工作区偏好，且设置面板没有 workspace 上下文
- **canvasui**：设置面板「Workflow One」顶部新增「Agent 节点默认值」卡片：三下拉里连重置、视觉模型 👁、目录下线值保留展示、「当前生效」回显
- 顺带同步 orchestrator package-lock 到 0.8.0 + dsh-agent peer（#114 漏更）

## 验证

- 单测：agent-defaults 16 例 + 路由集成 7 例 + canvasui client 装配用例；`npm test` 全量绿
- `build-web.sh` 双构建通过；canvasui bundle `--check` 逐字一致
- **真 dsh 实测**（profile dsh-ccpg-adtest / :3080）：
  - 设置面板三下拉真实点选 + 保存，落盘回读一致；渠道/模型/档位非法值均 400
  - **真跑两次单节点运行做 A/B**：默认值 `deepseek-official/deepseek-v4-flash` + High → 节点实际模型正是它（全局选择是 tokenhub-deepseek，证明默认值层生效），`reasoningTokens: 1705`；改成 Off 再跑 → `reasoningTokens: 0`。思考级别默认值真实影响 LLM 调用