### PR TITLE
feat(web): 画布运行面板默认激活「过程」tab

### DIFF
--- a/web/src/ResultPanel.jsx
+++ b/web/src/ResultPanel.jsx
@@ -159,7 +159,7 @@ export function ResultPanel({
   className = '',
 }) {
   const runId = getRunId(runDetail, status, results);
-  const [activeTab, setActiveTab] = useState('result');
+  const [activeTab, setActiveTab] = useState('process');
   const [remoteResults, setRemoteResults] = useState(undefined);
   const [selectedOutputId, setSelectedOutputId] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -194,7 +194,7 @@ export function ResultPanel({
   useEffect(() => {
     setRemoteResults(undefined);
     setSelectedOutputId(null);
-    setActiveTab('result');
+    setActiveTab('process');
     setSaveError('');
     setSavedNames([]);
   }, [runId, results]);

--- a/web/src/result-adapter.test.mjs
+++ b/web/src/result-adapter.test.mjs
@@ -196,7 +196,7 @@ assert.equal(artifactPreviewKind('archive.zip'), null);
 assert.equal(artifactPreviewKind('unsafe.svg'), null);
 
 const state = deriveRunViewState(fallback, 'bad-tab');
-assert.equal(state.activeTab, 'result');
+assert.equal(state.activeTab, 'process');
 assert.deepEqual(state.counts, { result: 2, process: 3, issues: 0 });
 assert.equal(state.canExport, true);
 assert.equal(state.isEmpty, false);

--- a/web/src/run-view-state.js
+++ b/web/src/run-view-state.js
@@ -1,6 +1,6 @@
 export const RESULT_TABS = Object.freeze([
-  { id: 'result', label: '成果' },
   { id: 'process', label: '过程' },
+  { id: 'result', label: '成果' },
   { id: 'issues', label: '问题' },
 ]);
 
@@ -19,7 +19,7 @@ export function getRunStatusMeta(status) {
   return STATUS_META[status] || { label: status || '未知状态', tone: 'neutral' };
 }
 
-export function deriveRunViewState(model, activeTab = 'result') {
+export function deriveRunViewState(model, activeTab = 'process') {
   const safe = model || {};
   const successfulOutputs = (safe.outputResults || []).filter((row) => row.status === 'success' && row.output);
   const counts = {
@@ -27,7 +27,7 @@ export function deriveRunViewState(model, activeTab = 'result') {
     process: safe.nodeTimeline?.length || 0,
     issues: safe.issues?.length || 0,
   };
-  const normalizedTab = RESULT_TABS.some((tab) => tab.id === activeTab) ? activeTab : 'result';
+  const normalizedTab = RESULT_TABS.some((tab) => tab.id === activeTab) ? activeTab : 'process';
   return {
     activeTab: normalizedTab,
     counts,


### PR DESCRIPTION
Closes #119

## 背景

运行面板三个 tab 原顺序为「成果 / 过程 / 问题」，默认激活「成果」。发起运行后用户第一诉求是看执行进度（哪个节点在跑、跑到哪了），长任务/失败场景下默认落在「成果」还会先看到空态。

## 方案

- `RESULT_TABS` 顺序调整为「过程 / 成果 / 问题」，默认激活项与第一项对齐
- `ResultPanel.jsx`：初始 `useState('process')` + 切换运行的重置 `setActiveTab('process')`
- `run-view-state.js`：`deriveRunViewState` 默认参数与非法 tab fallback 改 `'process'`
- `result-adapter.test.mjs`：`bad-tab` 断言同步更新

注：RESULT_TABS 重排在工作区已有未提交改动（subworkflow 批）中先行出现，与 #119 目标一致，本 PR 一并收编；其余 subworkflow 工作未包含在本 PR。

## 验证

- `cd web && npm test`：14 套全绿（含更新后的 result-adapter 断言）
- `sh dsh-plugins/build-web.sh` 双构建通过
- 用户手动切 tab 与 node-detail 自动进「执行过程」逻辑不受影响（后者依赖的「用户未动过 tab」语义未变）