### PR TITLE
feat(web): 工作流列表实时运行状态与运行控制

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
@@ -178,6 +178,8 @@ export class Orchestrator {
 
     this.emit('run-start', {
       runId: id, nodeIds: graph.nodes.map((n) => n.id),
+      // 业务节点数（排除 notify）：列表/切换器进度口径与 runProgressOf 一致
+      nodeCount: graph.nodes.filter((n) => n.type !== 'notify').length,
       workflowId: run.workflowId, workflowName: run.workflowName,
       canvasId: run.canvasId, source: run.source,
     });

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -56,6 +56,7 @@ import { collectInstallReport, compareSemver, executePlan, planUpgrade, PACKAGE 
 import { NotificationChannelRegistry, WorkflowNotificationManager } from './notifications.js';
 import { listFeishuCreds, addFeishuCred, removeFeishuCred, setDefaultFeishuCred, getFeishuCredOrEnv } from './credentials.js';
 import { Orchestrator, lintGraph, getKind } from './engine.js';
+import { validateWorkflowInputs } from './workflow-inputs.js';
 import { createWorkflowExportManifest, importWorkflowDocument, normalizeWorkflowDocument } from './workflow-document.js';
 import { saveArtifactsToWorkspace } from './artifact-save.js';
 import { buildRevisionGraph, extractRevision, revisionAgentNodeId } from './artifact-feedback.js';
@@ -365,10 +366,16 @@ export function apply(ctx, config) {
     const lint = lintWorkflowGraph(wf.graph);
     if (!lint.ok) {
       const err = lint.issues.find((i) => i.level === 'error')?.message || '图存在错误';
-      return { ok: false, error: `图有错误不能运行：${err}` };
+      return { ok: false, error: `图有错误不能运行：${err}`, code: 'workflow-invalid-graph', issues: lint.issues };
     }
-    let globals; try { globals = globalContext(); } catch (error) { return { ok: false, error: String(error.message || error) }; }
-    let inputs; try { inputs = assertSafeContextObject(runInputs, 'runInputs'); } catch (error) { return { ok: false, error: String(error.message || error) }; }
+    let globals; try { globals = globalContext(); } catch (error) { return { ok: false, error: String(error.message || error), code: error.code }; }
+    let inputs;
+    try {
+      inputs = assertSafeContextObject(runInputs, 'runInputs');
+      inputs = validateWorkflowInputs(inputs, wf.inputSchema, { label: `工作流「${wf.name || wf.id || '未命名'}」` });
+    } catch (error) {
+      return { ok: false, error: String(error.message || error), code: error.code || 'workflow-input-invalid' };
+    }
     const { runId } = startRun(wf.graph, {
       triggerInput, workflowName: wf.name, workflowId: wf.id,
       canvasId,
@@ -1631,9 +1638,42 @@ export function apply(ctx, config) {
   } });
 
   // ---- 工作流库 ----
+  // 列表运行概览（与 /runs、workflow_runs 工具同一进度口径）：liveRuns 取内存实时态，
+  // lastRun 在最新 live 与最近持久化终态间按开始时间取新；只暴露状态/进度/时间，不带输出正文。
+  const workflowRunSummary = (r, live = false) => {
+    const nodeMap = new Map((r.graph?.nodes || []).map((node) => [node.id, node]));
+    const progress = runProgressOf(r);
+    const currentNodes = Object.entries(r.nodeStates || {})
+      .filter(([, state]) => ['running', 'waiting'].includes(state?.status))
+      .map(([id]) => ({ id, label: nodeMap.get(id)?.data?.label || id }));
+    return {
+      runId: r.runId,
+      status: live ? 'running' : r.status,
+      live: Boolean(live),
+      source: r.source ?? null,
+      startedAt: r.startedAt ?? null,
+      finishedAt: r.finishedAt ?? null,
+      durationMs: r.durationMs ?? null,
+      progress,
+      currentNodes,
+    };
+  };
+  const workflowRuntimeSummary = (workflowId) => {
+    const liveRuns = [...orch.runs.values()]
+      .filter((entry) => entry.run.workspaceRoot === currentStore().workspaceRoot && entry.run.workflowId === workflowId)
+      .map((entry) => workflowRunSummary({ ...entry.run, graph: { nodes: [...entry.s.nodes.values()], edges: entry.s.graph.edges } }, true))
+      .sort((a, b) => String(b.startedAt || '').localeCompare(String(a.startedAt || '')));
+    const latest = recentRuns(RUNS_KEEP, workflowId).find((run) => run.workflowId === workflowId);
+    const latestLive = liveRuns[0] || null;
+    const lastRun = latestLive && (!latest || String(latestLive.startedAt || '') >= String(latest.startedAt || ''))
+      ? latestLive
+      : latest ? workflowRunSummary(latest, false) : null;
+    return { liveRuns, lastRun };
+  };
   register({ kind: 'exact', path: '/wf1/api/workflows', async handler(req, res) {
     if (req.method === 'GET') {
-      return json(res, 200, { workflows: currentDatabase().listWorkflows() });
+      const workflows = currentDatabase().listWorkflows().map((wf) => ({ ...wf, ...workflowRuntimeSummary(wf.id) }));
+      return json(res, 200, { workflows });
     }
     if (req.method === 'POST') {
       const body = await readBody(req);
@@ -1684,6 +1724,28 @@ export function apply(ctx, config) {
     json(res, 405, { error: 'method' });
   } });
 
+  // 列表专用启动：只按 workflowId 使用持久化图/变量/输入 Schema（不收前端图覆盖），
+  // 与画布运行/助手工具共享 startWorkflowRun 的 lint、安全与 Schema 校验。
+  register({ kind: 'exact', path: '/wf1/api/workflows/run', async handler(req, res) {
+    if (req.method !== 'POST') return json(res, 405, { error: 'method' });
+    const body = await readBody(req);
+    const workflowId = String(body?.workflowId || '').trim();
+    if (!workflowId) return json(res, 400, { error: '缺少 workflowId', code: 'workflow-required' });
+    const wf = readWf(workflowId);
+    if (!wf) return json(res, 404, { error: '工作流不存在', code: 'workflow-not-found' });
+    try { rejectInlineGlobalContext(body); } catch (error) { return routeError(res, error); }
+    const started = startWorkflowRun(wf, {
+      triggerInput: body?.triggerInput ?? '',
+      runInputs: body?.runInputs ?? {},
+      source: 'workflow-list',
+    });
+    if (!started.ok) return json(res, 400, {
+      ok: false, error: started.error, code: started.code || 'workflow-run-invalid',
+      ...(started.issues ? { issues: started.issues } : {}),
+    });
+    return json(res, 200, { started: true, runId: started.runId });
+  } });
+
   register({ kind: 'exact', path: '/wf1/api/workflows/detail', async handler(req, res) {
     const url = new URL(req.url, 'http://x');
     const id = url.searchParams.get('id') || '';
@@ -1722,14 +1784,15 @@ export function apply(ctx, config) {
     let graph = body.graph;
     let workflowName = body.workflowName || null;
     let workflowId = body.workflowId || null;
+    let persistedWorkflow = null;
     let definitions = inlineWorkflowDefinitions(body) || [];
     if (workflowId) {
-      const persisted = readWf(workflowId);
-      if (!persisted) return json(res, 404, { error: '工作流不存在' });
+      persistedWorkflow = readWf(workflowId);
+      if (!persistedWorkflow) return json(res, 404, { error: '工作流不存在' });
       if (hasOwn(body, 'workflowVariableDefinitions') || hasOwn(body, 'workflowVariables') || hasOwn(body, 'variables') || hasOwn(body, 'inputSchema')) {
         return json(res, 400, { error: '命名工作流运行必须使用已保存的变量声明和输入 Schema', code: 'persisted-workflow-authority' });
       }
-      const persistedFingerprint = graphFingerprint(persisted.graph);
+      const persistedFingerprint = graphFingerprint(persistedWorkflow.graph);
       if (!body.graphFingerprint || body.graphFingerprint !== persistedFingerprint) {
         return json(res, 409, {
           error: '画布内容尚未保存成功，请保存后重试',
@@ -1737,11 +1800,15 @@ export function apply(ctx, config) {
           graphFingerprint: persistedFingerprint,
         });
       }
-      graph = persisted.graph;
-      workflowName = persisted.name;
-      definitions = persisted.variables;
+      graph = persistedWorkflow.graph;
+      workflowName = persistedWorkflow.name;
+      definitions = persistedWorkflow.variables;
     }
     try { assertNonSensitiveVariableDefinitions(definitions, '工作流变量定义'); } catch (error) { return routeError(res, error); }
+    if (workflowId) {
+      try { runInputs = validateWorkflowInputs(runInputs, persistedWorkflow?.inputSchema, { label: `工作流「${workflowName || workflowId}」` }); }
+      catch (error) { return routeError(res, error); }
+    }
     if (!graph || !Array.isArray(graph.nodes)) return json(res, 400, { error: '缺少 graph' });
     const lint = lintWorkflowGraph(graph);
     if (!lint.ok) return json(res, 400, { error: lint.issues.find((i) => i.level === 'error').message, lint });

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/workflow-inputs.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/workflow-inputs.js
@@ -1,0 +1,51 @@
+// 命名工作流运行输入校验（列表启动 / 画布命名工作流运行 / 助手 workflow_run 共用）：
+// 按 inputSchema.fields 校验 required、defaultValue、类型与未知字段，返回 toJsonSafe 后的运行输入。
+// 空 schema 允许任意普通 JSON 对象；有字段声明时拒绝未知字段。
+import { toJsonSafe } from './output-contract.js';
+
+export class WorkflowInputError extends Error {
+  constructor(message, code = 'WORKFLOW_INPUT_INVALID') {
+    super(message);
+    this.name = 'WorkflowInputError';
+    this.code = code;
+  }
+}
+
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+
+export function validateWorkflowInputs(runInputs, inputSchema = {}, { label = '工作流' } = {}) {
+  if (!isObject(runInputs)) throw new WorkflowInputError(`${label} runInputs 必须是对象`, 'WORKFLOW_INPUT_INVALID');
+  const fields = Array.isArray(inputSchema?.fields) ? inputSchema.fields : [];
+  const known = new Set();
+  const output = { ...runInputs };
+  for (const field of fields) {
+    const key = String(field?.key ?? field?.name ?? '').trim();
+    if (!key) continue;
+    known.add(key);
+    const has = Object.prototype.hasOwnProperty.call(output, key);
+    if (!has && field.required === true && field.defaultValue === undefined) {
+      throw new WorkflowInputError(`${label}缺少必填输入：${key}`, 'WORKFLOW_INPUT_REQUIRED');
+    }
+    if (!has && field.defaultValue !== undefined) output[key] = structuredClone(field.defaultValue);
+    if (!Object.prototype.hasOwnProperty.call(output, key)) continue;
+    const value = output[key];
+    const type = String(field.type || 'json');
+    const valid = type === 'string' ? typeof value === 'string'
+      : type === 'number' ? typeof value === 'number' && Number.isFinite(value)
+        : type === 'boolean' ? typeof value === 'boolean'
+          : type === 'string[]' ? Array.isArray(value) && value.every((item) => typeof item === 'string')
+            : type === 'object' ? isObject(value)
+              : type === 'json' ? value !== undefined
+                : type === 'array' ? Array.isArray(value)
+                : true;
+    if (!valid) throw new WorkflowInputError(`${label}输入 ${key} 类型不匹配：需要 ${type}`, 'WORKFLOW_INPUT_TYPE');
+    if (Array.isArray(field.enum) && !field.enum.includes(value)) {
+      throw new WorkflowInputError(`${label}输入 ${key} 不在允许值范围内`, 'WORKFLOW_INPUT_ENUM');
+    }
+  }
+  for (const key of Object.keys(output)) {
+    if (known.has(key)) continue;
+    if (fields.length) throw new WorkflowInputError(`${label}不支持输入字段：${key}`, 'WORKFLOW_INPUT_UNKNOWN');
+  }
+  return toJsonSafe(output, '$.runInputs');
+}

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/workflow-tools.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/workflow-tools.integration.test.mjs
@@ -105,6 +105,26 @@ assert.equal(created.status, 200);
 const created2 = await call('POST', '/wf1/api/workflows', { id: 'wf_t2', name: '另一个工作流', graph: wfGraph });
 assert.equal(created2.status, 200);
 
+await test('HTTP workflow list：返回运行概览且列表专用启动按保存工作流执行', async () => {
+  const list = await call('GET', '/wf1/api/workflows');
+  assert.equal(list.status, 200);
+  const row = list.body.workflows.find((item) => item.id === 'wf_t1');
+  assert.ok(row && Array.isArray(row.liveRuns) && Object.prototype.hasOwnProperty.call(row, 'lastRun'));
+  const missing = await call('POST', '/wf1/api/workflows/run', { workflowId: 'wf_missing' });
+  assert.equal(missing.status, 404);
+  assert.equal(missing.body.code, 'workflow-not-found');
+  const started = await call('POST', '/wf1/api/workflows/run', { workflowId: 'wf_t1', triggerInput: 'list-start' });
+  assert.equal(started.status, 200);
+  assert.equal(started.body.started, true);
+  assert.match(started.body.runId, /^run_/);
+  // 输入节点跑得极快，等一拍后验证终态对账：lastRun 指向本次运行且成功
+  await new Promise((resolve) => setTimeout(resolve, 30));
+  const finished = await call('GET', '/wf1/api/workflows');
+  const finishedRow = finished.body.workflows.find((item) => item.id === 'wf_t1');
+  assert.equal(finishedRow.lastRun.runId, started.body.runId);
+  assert.equal(finishedRow.lastRun.status, 'success');
+});
+
 await test('workflow_list：列出工作流含 id/名称/liveRuns', async () => {
   const out = await runTool('workflow_list', {});
   const rows = maybeJson(out);

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -18,6 +18,7 @@ import {
   stripCanvasRuntimeNodeData,
 } from './workflow-serialization.js';
 import { eventBelongsToCanvas, eventBelongsToRun, shouldFollowRunStart } from './run-event-routing.js';
+import { applyRunEvent } from './workflow-list-state.js';
 import { adoptRunStatusPatch, projectRunNodeStates, seedTerminalNodeIds } from './live-run-adopt.js';
 import { useThemePalette } from './theme.js';
 import { useToast, PromptModal, ConfirmModal, Modal } from './ui.jsx';
@@ -336,12 +337,43 @@ export default function App() {
   // SSE run-start/run-end 触发即时刷新；存在 live 运行时 5s 轮询兜底刷新进度。
   const refreshRunList = useCallback(async () => {
     try {
-      const res = await fetch(apiUrl('/runs'));
+      const res = await fetch(apiUrl('/runs?limit=100'));
       if (!res.ok) return;
       const data = await res.json();
       setRunList(data.runs || []);
     } catch { /* 列表拉不到维持现状 */ }
   }, []);
+
+  // 列表专用启动/取消/查看：复用工作区级 runList 与 inspectedRunId，不另建监听
+  const startWorkflowFromList = useCallback(async (workflow, input = {}) => {
+    const res = await fetch(apiUrl('/workflows/run'), {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workflowId: workflow.id, triggerInput: input.triggerInput || '', runInputs: input.runInputs || {} }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) throw new Error(data.error || `启动失败（HTTP ${res.status}）`);
+    toast(`已启动「${workflow.name}」`, 'success');
+    refreshRunList();
+    return data.runId;
+  }, [refreshRunList, toast]);
+
+  const cancelRunById = useCallback(async (runId) => {
+    if (!runId) return false;
+    const res = await fetch(apiUrl('/run/cancel'), {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ runId }),
+    });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok || !data.ok) throw new Error(data.error || '运行已结束或取消失败');
+    toast('已发送取消请求', 'warn');
+    refreshRunList();
+    return true;
+  }, [refreshRunList, toast]);
+
+  const inspectWorkflowRun = useCallback(async (workflow, runId) => {
+    if (currentWfIdRef.current !== workflow.id) await openWorkflowRef.current?.(workflow);
+    selectRunForView(runId);
+    setView('canvas');
+  }, [selectRunForView]);
   // live 标记经 ref 读（不能进依赖：runList 变化会重建 effect → 轮询变请求风暴）
   const runListRef = useRef([]);
   useEffect(() => { runListRef.current = runList; }, [runList]);
@@ -482,9 +514,14 @@ export default function App() {
       }
     };
 
-    es.addEventListener('node-status', (e) => applyStatus(JSON.parse(e.data)));
+    es.addEventListener('node-status', (e) => {
+      const p = JSON.parse(e.data);
+      setRunList((current) => applyRunEvent(current, 'node-status', p));
+      applyStatus(p);
+    });
     es.addEventListener('agent-progress', (e) => {
       const p = JSON.parse(e.data);
+      setRunList((current) => applyRunEvent(current, 'agent-progress', p));
       if (!appliesToActiveRun(p)) return;
       setProgress((prev) => ({ ...prev, [p.nodeId]: p }));
       setNodes((nds) => nds.map((n) => (n.id === p.nodeId ? { ...n, data: { ...n.data, livePreview: p.preview, liveTurns: p.turns } } : n)));
@@ -522,6 +559,7 @@ export default function App() {
     });
     es.addEventListener('run-start', (e) => {
       const p = JSON.parse(e.data);
+      setRunList((current) => applyRunEvent(current, 'run-start', p));
       // 任何运行起停都刷新切换器列表（不过画布闸门：定时/webhook 运行无 canvasId）
       refreshRunList();
       // 只跟随本画布发起的运行（手动/续跑/助手）；定时/webhook 触发不抢占视图
@@ -543,6 +581,7 @@ export default function App() {
     });
     es.addEventListener('run-end', (e) => {
       const p = JSON.parse(e.data);
+      setRunList((current) => applyRunEvent(current, 'run-end', p));
       refreshRunList();
       if (!appliesToActiveRun(p)) return;
       runningRef.current = false;
@@ -602,6 +641,7 @@ export default function App() {
     });
     es.addEventListener('run-error', (e) => {
       const p = JSON.parse(e.data);
+      setRunList((current) => applyRunEvent(current, 'run-error', p));
       const adopted = appliesToActiveRun(p);
       if (!adopted && !belongsToCurrentCanvas(p)) return;
       if (!adopted) activeRunIdRef.current = p.runId;
@@ -616,6 +656,7 @@ export default function App() {
       // 节点投影只采纳「当前画布最近的 live run」一条，其余运行经切换器查看。
       const p = JSON.parse(e.data);
       if (!p.runId) return;
+      setRunList((current) => applyRunEvent(current, 'snapshot', p));
       setRunDetails((current) => ({ ...current, [p.runId]: { ...p, runId: p.runId } }));
       if (!belongsToCurrentCanvas(p)) return;
       const adopted = p.status === 'running'
@@ -1638,7 +1679,16 @@ export default function App() {
       <div className="main">
         {view === 'workflows' ? (
           <div className="wf-view">
-            <WorkflowList currentId={currentWf?.id} onOpen={openWorkflow} onNew={newWorkflow} />
+            <WorkflowList
+              currentId={currentWf?.id}
+              onOpen={openWorkflow}
+              onNew={newWorkflow}
+              runs={runList}
+              onStartRun={startWorkflowFromList}
+              onCancelRun={cancelRunById}
+              onInspectRun={inspectWorkflowRun}
+              onRefresh={refreshRunList}
+            />
           </div>
         ) : view === 'docs' ? (
           <div className="docwall-view">

--- a/web/src/RunWorkflowModal.jsx
+++ b/web/src/RunWorkflowModal.jsx
@@ -1,0 +1,69 @@
+import { useMemo, useState } from 'react';
+import { Modal } from './ui.jsx';
+import { fieldKey, initialRunInputValues, schemaFields, serializeRunInputValues } from './workflow-run-inputs.js';
+
+function displayValue(value, type) {
+  if (value === undefined || value === null) return '';
+  if (type === 'object' || type === 'json' || type === 'array') return JSON.stringify(value, null, 2);
+  if (type === 'string[]') return Array.isArray(value) ? value.join('\n') : String(value);
+  return String(value);
+}
+
+export function RunWorkflowModal({ workflow, onClose, onStart }) {
+  const fields = useMemo(() => schemaFields(workflow?.inputSchema), [workflow]);
+  const [triggerInput, setTriggerInput] = useState('');
+  const [values, setValues] = useState(() => initialRunInputValues(workflow?.inputSchema));
+  const [rawJson, setRawJson] = useState('{}');
+  const [error, setError] = useState('');
+  const [busy, setBusy] = useState(false);
+
+  const setField = (field, value) => setValues((current) => ({ ...current, [fieldKey(field)]: value }));
+  const submit = async () => {
+    let runInputs;
+    try {
+      if (fields.length) runInputs = serializeRunInputValues(workflow.inputSchema, values);
+      else {
+        runInputs = rawJson.trim() ? JSON.parse(rawJson) : {};
+        if (!runInputs || typeof runInputs !== 'object' || Array.isArray(runInputs)) throw new Error('运行参数必须是 JSON 对象');
+      }
+    } catch (e) {
+      setError(e.message || '运行参数不正确');
+      return;
+    }
+    setBusy(true);
+    setError('');
+    try {
+      await onStart({ triggerInput, runInputs });
+      onClose();
+    } catch (e) {
+      setError(e.message || '启动失败');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Modal title={`启动「${workflow?.name || '工作流'}」`} onClose={busy ? undefined : onClose} className="run-workflow-modal" footer={(
+      <>
+        <button className="btn" disabled={busy} onClick={onClose}>取消</button>
+        <button className="btn btn-primary" disabled={busy} onClick={submit}>{busy ? '启动中…' : '▶ 启动'}</button>
+      </>
+    )}>
+      <div className="run-workflow-form">
+        <p className="modal-message">{workflow?.nodeCount ?? workflow?.graph?.nodes?.length ?? 0} 个节点 · 本次启动不会切换当前画布。</p>
+        <label className="run-workflow-field"><span>触发输入 <em>可选</em></span><textarea rows={3} value={triggerInput} onChange={(e) => setTriggerInput(e.target.value)} placeholder="传给输入节点的文本" /></label>
+        {fields.length > 0 ? fields.map((field) => {
+          const key = fieldKey(field);
+          const type = String(field.type || 'string').toLowerCase();
+          const value = values[key];
+          const label = field.label || key;
+          if (Array.isArray(field.enum)) return <label className="run-workflow-field" key={key}><span>{label}{field.required && <b> *</b>}</span><select value={value ?? ''} onChange={(e) => setField(field, e.target.value)}><option value="">请选择</option>{field.enum.map((item) => <option key={item} value={item}>{item}</option>)}</select>{field.description && <small>{field.description}</small>}</label>;
+          if (type === 'boolean') return <label className="run-workflow-check" key={key}><input type="checkbox" checked={value === true || value === 'true'} onChange={(e) => setField(field, e.target.checked)} /><span>{label}{field.required && <b> *</b>}</span>{field.description && <small>{field.description}</small>}</label>;
+          const complex = type === 'object' || type === 'json' || type === 'array';
+          return <label className="run-workflow-field" key={key}><span>{label}{field.required && <b> *</b>}</span>{complex || type === 'string[]' ? <textarea rows={complex ? 5 : 3} value={displayValue(value, type)} onChange={(e) => setField(field, e.target.value)} placeholder={complex ? 'JSON' : '每行一个值'} /> : <input type={type === 'number' ? 'number' : 'text'} value={displayValue(value, type)} onChange={(e) => setField(field, e.target.value)} />}{field.description && <small>{field.description}</small>}</label>;
+        }) : <label className="run-workflow-field"><span>运行参数 <em>JSON，可选</em></span><textarea className="run-workflow-json" rows={8} value={rawJson} onChange={(e) => setRawJson(e.target.value)} placeholder={'{\n  "key": "value"\n}'} /></label>}
+        {error && <div className="run-workflow-error">{error}</div>}
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/WorkflowList.jsx
+++ b/web/src/WorkflowList.jsx
@@ -1,163 +1,147 @@
-// 工作流列表页：搜索 + 复制 + 导出/导入 JSON + 打开/重命名/删除（弹窗替代原生 prompt/confirm）。
+// 工作流列表页：管理工作流，并提供运行状态、启动、取消和运行详情入口。
 
 import { useEffect, useMemo, useRef, useState } from 'react';
-import { Download, Upload } from 'lucide-react';
+import { Download, Eye, Play, Square, Upload } from 'lucide-react';
 import { apiUrl } from './api.js';
 import { createWorkflowDocument } from './workflow-serialization.js';
+import { workflowCards } from './workflow-list-state.js';
+import { RunWorkflowModal } from './RunWorkflowModal.jsx';
 import { useToast, PromptModal, ConfirmModal } from './ui.jsx';
 
-export function WorkflowList({ currentId, onOpen, onNew }) {
+const STATUS_LABEL = { running: '运行中', success: '成功', error: '失败', canceled: '已取消', interrupted: '异常中断' };
+const STATUS_CLASS = { running: 'running', success: 'success', error: 'error', canceled: 'canceled', interrupted: 'error' };
+
+function runTime(run) {
+  if (!run?.startedAt) return '';
+  if (run.live) return `开始于 ${new Date(run.startedAt).toLocaleTimeString('zh-CN', { hour12: false })}`;
+  if (run.durationMs != null) return `${(run.durationMs / 1000).toFixed(1)}s`;
+  return new Date(run.startedAt).toLocaleString('zh-CN', { hour12: false });
+}
+
+export function WorkflowList({ currentId, onOpen, onNew, runs = [], onStartRun, onCancelRun, onInspectRun, onRefresh }) {
   const toast = useToast();
   const [list, setList] = useState([]);
   const [busy, setBusy] = useState(false);
+  const [rowBusy, setRowBusy] = useState({});
   const [query, setQuery] = useState('');
   const [modal, setModal] = useState(null);
+  const [runWorkflow, setRunWorkflow] = useState(null);
   const importRef = useRef(null);
 
-  const load = () => {
-    fetch(apiUrl('/workflows')).then((r) => r.json()).then((d) => setList(d.workflows || [])).catch(() => {});
+  const load = async () => {
+    try {
+      const res = await fetch(apiUrl('/workflows'));
+      if (!res.ok) throw new Error(`加载失败（HTTP ${res.status}）`);
+      const data = await res.json();
+      setList(data.workflows || []);
+    } catch (error) { toast(error.message || '工作流列表加载失败', 'error'); }
   };
-  useEffect(load, []);
+  useEffect(() => { load(); }, []);
 
+  const cards = useMemo(() => workflowCards(list, runs), [list, runs]);
   const filtered = useMemo(() => {
     const q = query.trim().toLowerCase();
-    if (!q) return list;
-    return list.filter((wf) => wf.name.toLowerCase().includes(q));
-  }, [list, query]);
+    if (!q) return cards;
+    return cards.filter((wf) => wf.name.toLowerCase().includes(q) || wf.id.toLowerCase().includes(q));
+  }, [cards, query]);
+
+  const refresh = () => { load(); onRefresh?.(); };
+  const setActionBusy = (key, value) => setRowBusy((current) => ({ ...current, [key]: value }));
+
+  const openRun = async (wf) => {
+    setActionBusy(`${wf.id}:run`, true);
+    try {
+      const res = await fetch(apiUrl(`/workflows/detail?id=${encodeURIComponent(wf.id)}`));
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || '无法读取工作流');
+      setRunWorkflow(data);
+    } catch (error) { toast(error.message || '无法读取工作流', 'error'); }
+    finally { setActionBusy(`${wf.id}:run`, false); }
+  };
+
+  const start = async (input) => {
+    if (!runWorkflow) return;
+    await onStartRun?.(runWorkflow, input);
+    refresh();
+  };
+
+  const askCancel = (wf, run) => setModal({ type: 'confirm', title: '取消运行', message: `取消「${wf.name}」的运行？\n${run.runId} · ${runTime(run)}`, danger: true, confirmText: '取消运行', onConfirm: async () => {
+    setModal(null);
+    const key = `${wf.id}:${run.runId}`;
+    setActionBusy(key, true);
+    try { await onCancelRun?.(run.runId); refresh(); }
+    catch (error) { toast(error.message || '取消失败', 'error'); }
+    finally { setActionBusy(key, false); }
+  } });
 
   const createNew = () => setModal({ type: 'prompt', title: '新建工作流', initial: '新工作流', confirmText: '创建', onConfirm: async (name) => {
-    setModal(null);
-    setBusy(true);
-    const res = await fetch(apiUrl('/workflows'), {
-      method: 'POST', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name, ...createWorkflowDocument() }),
-    });
-    const data = await res.json();
-    setBusy(false);
-    if (res.ok) { load(); onNew?.(data); }
-    else toast(data.error || '创建失败', 'error');
+    setModal(null); setBusy(true);
+    try {
+      const res = await fetch(apiUrl('/workflows'), { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name, ...createWorkflowDocument() }) });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || '创建失败');
+      refresh(); onNew?.(data);
+    } catch (error) { toast(error.message || '创建失败', 'error'); }
+    finally { setBusy(false); }
   } });
 
   const rename = (wf) => setModal({ type: 'prompt', title: '重命名工作流', initial: wf.name, confirmText: '重命名', onConfirm: async (name) => {
     setModal(null);
-    await fetch(apiUrl(`/workflows/detail?id=${encodeURIComponent(wf.id)}`), {
-      method: 'PATCH', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name }),
-    });
-    load();
+    const res = await fetch(apiUrl(`/workflows/detail?id=${encodeURIComponent(wf.id)}`), { method: 'PATCH', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ name }) });
+    if (!res.ok) toast('重命名失败', 'error'); else refresh();
   } });
 
   const remove = (wf) => setModal({ type: 'confirm', title: '删除工作流', message: `删除「${wf.name}」？不可恢复。`, danger: true, confirmText: '删除', onConfirm: async () => {
     setModal(null);
-    await fetch(apiUrl(`/workflows/detail?id=${encodeURIComponent(wf.id)}`), { method: 'DELETE' });
-    toast(`已删除「${wf.name}」`, 'warn');
-    load();
+    const res = await fetch(apiUrl(`/workflows/detail?id=${encodeURIComponent(wf.id)}`), { method: 'DELETE' });
+    const data = await res.json().catch(() => ({}));
+    if (!res.ok) toast(data.error || '删除失败', 'error'); else { toast(`已删除「${wf.name}」`, 'warn'); refresh(); }
   } });
 
   const duplicate = async (wf) => {
-    const res = await fetch(apiUrl('/workflows'), {
-      method: 'PUT', headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id: wf.id }),
-    });
-    if (res.ok) { toast('已创建副本', 'success'); load(); }
+    const res = await fetch(apiUrl('/workflows'), { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ id: wf.id }) });
+    if (res.ok) { toast('已创建副本', 'success'); refresh(); } else toast('复制失败', 'error');
   };
 
   const exportWf = async (wf) => {
     setBusy(true);
     try {
       const res = await fetch(apiUrl(`/workflows/transfer?id=${encodeURIComponent(wf.id)}`));
-      if (!res.ok) {
-        const out = await res.json().catch(() => ({}));
-        throw new Error(out.error || `请求失败（HTTP ${res.status}）`);
-      }
-      if (!res.headers.get('content-type')?.includes('application/json')) {
-        throw new Error('服务返回的不是工作流 JSON');
-      }
-      const url = URL.createObjectURL(await res.blob());
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `${wf.name}.workflow-one.json`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
+      if (!res.ok) { const out = await res.json().catch(() => ({})); throw new Error(out.error || `请求失败（HTTP ${res.status}）`); }
+      if (!res.headers.get('content-type')?.includes('application/json')) throw new Error('服务返回的不是工作流 JSON');
+      const url = URL.createObjectURL(await res.blob()); const a = document.createElement('a'); a.href = url; a.download = `${wf.name}.workflow-one.json`; document.body.appendChild(a); a.click(); a.remove(); setTimeout(() => URL.revokeObjectURL(url), 0);
       toast(`已导出「${wf.name}」`, 'success');
-    } catch (err) {
-      toast(`导出失败：${err.message}`, 'error');
-    } finally {
-      setBusy(false);
-    }
+    } catch (error) { toast(`导出失败：${error.message}`, 'error'); }
+    finally { setBusy(false); }
   };
 
   const importWf = async (e) => {
-    const file = e.target.files?.[0];
-    e.target.value = '';
-    if (!file) return;
+    const file = e.target.files?.[0]; e.target.value = ''; if (!file) return;
     setBusy(true);
     try {
-      const text = await file.text();
-      let data;
-      try { data = JSON.parse(text); } catch { throw new Error('文件不是有效的 JSON'); }
-      const res = await fetch(apiUrl('/workflows/transfer'), {
-        method: 'POST', headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(data),
-      });
-      const out = await res.json();
-      if (!res.ok) throw new Error(out.error || '导入失败');
-      toast(`已导入「${out.name}」${out.warnings ? `（${out.warnings} 条警告）` : ''}`, 'success');
-      load();
-      await onOpen?.(out);
-    } catch (err) {
-      toast(`导入失败：${err.message}`, 'error');
-    } finally {
-      setBusy(false);
-    }
+      const text = await file.text(); let data; try { data = JSON.parse(text); } catch { throw new Error('文件不是有效的 JSON'); }
+      const res = await fetch(apiUrl('/workflows/transfer'), { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(data) });
+      const out = await res.json(); if (!res.ok) throw new Error(out.error || '导入失败');
+      toast(`已导入「${out.name}」${out.warnings ? `（${out.warnings} 条警告）` : ''}`, 'success'); refresh(); await onOpen?.(out);
+    } catch (error) { toast(`导入失败：${error.message}`, 'error'); }
+    finally { setBusy(false); }
   };
 
   return (
     <div className="wf-list-page">
-      <div className="wf-list-head">
-        <h3>我的工作流 <span className="sec-hint">{list.length} 个</span></h3>
-        <input className="wf-search" placeholder="搜索名称…" value={query} onChange={(e) => setQuery(e.target.value)} />
-        <button className="btn btn-sm" disabled={busy} onClick={() => importRef.current?.click()}>
-          <Upload size={14} aria-hidden="true" />导入
-        </button>
-        <input ref={importRef} type="file" accept=".json" style={{ display: 'none' }} onChange={importWf} />
-        <button className="btn btn-primary btn-sm" disabled={busy} onClick={createNew}>＋ 新建</button>
-      </div>
+      <div className="wf-list-head"><h3>我的工作流 <span className="sec-hint">{list.length} 个</span></h3><input className="wf-search" placeholder="搜索名称或 ID…" value={query} onChange={(e) => setQuery(e.target.value)} /><button className="btn btn-sm" disabled={busy} onClick={() => importRef.current?.click()}><Upload size={14} aria-hidden="true" />导入</button><input ref={importRef} type="file" accept=".json" style={{ display: 'none' }} onChange={importWf} /><button className="btn btn-primary btn-sm" disabled={busy} onClick={createNew}>＋ 新建</button></div>
       {list.length === 0 && <p className="panel-empty">还没有工作流。点「新建」创建一个，或在画布保存。</p>}
       {list.length > 0 && filtered.length === 0 && <p className="panel-empty">没有匹配「{query}」的工作流。</p>}
-      <div className="wf-cards">
-        {filtered.map((wf) => (
-          <div key={wf.id} className={`wf-card ${wf.id === currentId ? 'wf-card-current' : ''}`}>
-            <div className="wf-card-main" onClick={() => onOpen(wf)} title="打开到画布编辑">
-              <div className="wf-card-name">{wf.name}</div>
-              <div className="wf-card-meta">
-                🤖 {wf.agentCount} 智能体 · {wf.nodeCount} 节点
-                <span className="sec-hint"> · {new Date(wf.updatedAt).toLocaleString('zh-CN', { hour12: false })}</span>
-              </div>
-            </div>
-            <div className="wf-card-actions">
-              <button className="btn-icon" title="打开" onClick={() => onOpen(wf)}>↗</button>
-              <button className="btn-icon" title="复制副本" onClick={() => duplicate(wf)}>⧉</button>
-              <button className="btn-icon" title="导出工作流" aria-label={`导出「${wf.name}」`} disabled={busy} onClick={() => exportWf(wf)}>
-                <Download size={15} aria-hidden="true" />
-              </button>
-              <button className="btn-icon" title="重命名" onClick={() => rename(wf)}>✏️</button>
-              <button className="btn-icon" title="删除" onClick={() => remove(wf)}>🗑</button>
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {modal?.type === 'prompt' && (
-        <PromptModal title={modal.title} initial={modal.initial} confirmText={modal.confirmText}
-          onCancel={() => setModal(null)} onConfirm={modal.onConfirm} />
-      )}
-      {modal?.type === 'confirm' && (
-        <ConfirmModal title={modal.title} message={modal.message} danger={modal.danger} confirmText={modal.confirmText}
-          onCancel={() => setModal(null)} onConfirm={modal.onConfirm} />
-      )}
+      <div className="wf-cards">{filtered.map((wf) => <div key={wf.id} className={`wf-card ${wf.id === currentId ? 'wf-card-current' : ''}`}>
+        <div className="wf-card-main" onClick={() => onOpen(wf)} title="打开到画布编辑"><div className="wf-card-name">{wf.name}</div><div className="wf-card-meta">🤖 {wf.agentCount} 智能体 · {wf.nodeCount} 节点 <span className="sec-hint"> · {new Date(wf.updatedAt).toLocaleString('zh-CN', { hour12: false })}</span></div></div>
+        <div className="wf-card-runtime">
+          {wf.liveRuns?.length ? <>{wf.liveRuns.map((run) => <div className="wf-live-run" key={run.runId}><span className="wf-run-status running">LIVE · {run.progress?.done ?? 0}/{run.progress?.total ?? wf.nodeCount}</span><span className="wf-run-current">{run.currentNodes?.map((node) => node.label).join('、') || '准备中'}</span><span className="wf-run-time">{runTime(run)}</span><button className="btn-icon" title="查看运行" aria-label={`查看运行 ${run.runId}`} disabled={rowBusy[`${wf.id}:${run.runId}`]} onClick={() => onInspectRun?.(wf, run.runId)}><Eye size={14} /></button><button className="btn-icon wf-cancel-btn" title="取消运行" aria-label={`取消运行 ${run.runId}`} disabled={rowBusy[`${wf.id}:${run.runId}`]} onClick={() => askCancel(wf, run)}><Square size={13} /></button></div>)}</> : <div className="wf-run-empty">{wf.lastRun ? <><span className={`wf-run-status ${STATUS_CLASS[wf.lastRun.status] || ''}`}>{STATUS_LABEL[wf.lastRun.status] || wf.lastRun.status}</span><span className="wf-run-time">{runTime(wf.lastRun)}</span><button className="btn-icon" title="查看最近运行" aria-label="查看最近运行" onClick={() => onInspectRun?.(wf, wf.lastRun.runId)}><Eye size={14} /></button></> : <span className="sec-hint">尚未运行</span>}</div>}
+        </div>
+        <div className="wf-card-actions"><button className="btn btn-primary btn-sm" disabled={rowBusy[`${wf.id}:run`]} onClick={() => openRun(wf)}><Play size={13} />启动</button><button className="btn-icon" title="打开" onClick={() => onOpen(wf)}>↗</button><button className="btn-icon" title="复制副本" onClick={() => duplicate(wf)}>⧉</button><button className="btn-icon" title="导出工作流" aria-label={`导出「${wf.name}」`} disabled={busy} onClick={() => exportWf(wf)}><Download size={15} aria-hidden="true" /></button><button className="btn-icon" title="重命名" onClick={() => rename(wf)}>✏️</button><button className="btn-icon" title="删除" onClick={() => remove(wf)}>🗑</button></div>
+      </div>)}</div>
+      {modal?.type === 'prompt' && <PromptModal title={modal.title} initial={modal.initial} confirmText={modal.confirmText} onCancel={() => setModal(null)} onConfirm={modal.onConfirm} />}
+      {modal?.type === 'confirm' && <ConfirmModal title={modal.title} message={modal.message} danger={modal.danger} confirmText={modal.confirmText} onCancel={() => setModal(null)} onConfirm={modal.onConfirm} />}
+      {runWorkflow && <RunWorkflowModal workflow={runWorkflow} onClose={() => setRunWorkflow(null)} onStart={start} />}
     </div>
   );
 }

--- a/web/src/run-event-routing.js
+++ b/web/src/run-event-routing.js
@@ -20,6 +20,6 @@ export function eventBelongsToRun(payload, activeRunId) {
 // 带本画布 canvasId 的启动（手动/续跑/助手）→ 跟随；定时/webhook/catch-up 触发（无 canvasId）→ 不抢占视图。
 export function shouldFollowRunStart(payload, { canvasId, workflowId }) {
   if (!payload?.runId) return false;
-  if (payload.source === 'schedule' || payload.source === 'webhook' || payload.source === 'catch-up') return false;
+  if (payload.source === 'schedule' || payload.source === 'webhook' || payload.source === 'catch-up' || payload.source === 'subworkflow' || payload.source === 'workflow-list') return false;
   return eventBelongsToCanvas(payload, { canvasId, workflowId });
 }

--- a/web/src/run-event-routing.test.mjs
+++ b/web/src/run-event-routing.test.mjs
@@ -56,12 +56,14 @@ test('follow run start: 本画布手动/续跑启动跟随视图', () => {
   assert.equal(shouldFollowRunStart({ runId: 'r1', canvasId: 'cv-a', workflowId: 'wf-a', source: 'assistant' }, current), true);
 });
 
-test('follow run start: 定时/webhook 触发不抢占视图（即使属于本工作流）', () => {
+test('follow run start: 定时/webhook/子工作流触发不抢占视图（即使属于本工作流）', () => {
   const current = { canvasId: 'cv-a', workflowId: 'wf-a' };
   assert.equal(shouldFollowRunStart({ runId: 'r1', workflowId: 'wf-a', source: 'schedule' }, current), false);
   assert.equal(shouldFollowRunStart({ runId: 'r1', workflowId: 'wf-a', source: 'webhook' }, current), false);
   // catch-up 补跑同属机器触发，不抢占视图
   assert.equal(shouldFollowRunStart({ runId: 'r1', workflowId: 'wf-a', source: 'catch-up' }, current), false);
+  assert.equal(shouldFollowRunStart({ runId: 'r1', workflowId: 'wf-a', source: 'subworkflow' }, current), false);
+  assert.equal(shouldFollowRunStart({ runId: 'r1', workflowId: 'wf-a', source: 'workflow-list' }, current), false);
   // 无 canvasId 的 manual（历史遗留形状）：命名工作流对齐时可跟随
   assert.equal(shouldFollowRunStart({ runId: 'r1', workflowId: 'wf-a', source: 'manual' }, current), true);
 });

--- a/web/src/run-switcher.js
+++ b/web/src/run-switcher.js
@@ -1,8 +1,8 @@
 // RunSwitcher 胶囊模型（纯函数，可单测）：
 // 合并 /runs 列表与本地已见运行，按「LIVE 优先、开始时间倒序」排序，截断展示。
 
-export const SOURCE_ICON = { manual: '▶', schedule: '⏰', webhook: '🪝', resume: '↻', replay: '↺', assistant: '✦', 'catch-up': '⏱', revision: '✎' };
-export const SOURCE_LABEL = { manual: '手动', schedule: '定时', webhook: 'Webhook', resume: '续跑', replay: '重放', assistant: '助手', 'catch-up': '补跑', revision: '修订' };
+export const SOURCE_ICON = { manual: '▶', 'workflow-list': '▶', schedule: '⏰', webhook: '🪝', resume: '↻', replay: '↺', assistant: '✦', 'catch-up': '⏱', revision: '✎' };
+export const SOURCE_LABEL = { manual: '手动', 'workflow-list': '列表启动', schedule: '定时', webhook: 'Webhook', resume: '续跑', replay: '重放', assistant: '助手', 'catch-up': '补跑', revision: '修订' };
 
 export function switcherCapsules(runs, { max = 6 } = {}) {
   const list = [...(runs || [])];

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -889,17 +889,37 @@ body {
 .wf-search { width: 180px; }
 .wf-cards { display: flex; flex-direction: column; gap: 10px; }
 .wf-card {
-  display: flex; align-items: center; gap: 8px;
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
   background: var(--bg-panel); border: 1px solid var(--border);
   border-radius: var(--radius-lg); padding: 14px 16px;
   transition: border-color var(--dur) var(--ease), box-shadow var(--dur) var(--ease), transform var(--dur) var(--ease);
 }
 .wf-card:hover { border-color: var(--border-strong); box-shadow: var(--shadow-2); transform: translateY(-1px); }
 .wf-card-current { border-color: var(--primary); box-shadow: var(--shadow-glow); }
-.wf-card-main { flex: 1; cursor: pointer; min-width: 0; }
+.wf-card-main { flex: 1 1 220px; cursor: pointer; min-width: 0; }
 .wf-card-name { font-size: 14px; font-weight: 600; color: var(--fg); }
 .wf-card-meta { font-size: 12px; color: var(--fg-faint); margin-top: 3px; }
-.wf-card-actions { display: flex; gap: 2px; }
+.wf-card-runtime { flex: 1 1 300px; min-width: 0; font-size: 12px; }
+.wf-live-run, .wf-run-empty { display: flex; align-items: center; gap: 7px; min-width: 0; }
+.wf-live-run + .wf-live-run { margin-top: 5px; }
+.wf-run-status { font-weight: 700; white-space: nowrap; }
+.wf-run-status.running { color: var(--warn-fg); }
+.wf-run-status.success { color: var(--success); }
+.wf-run-status.error { color: var(--danger); }
+.wf-run-status.canceled { color: var(--fg-muted); }
+.wf-run-current { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--fg-muted); }
+.wf-run-time { color: var(--fg-faint); white-space: nowrap; }
+.wf-cancel-btn { color: var(--danger); }
+.wf-card-actions { display: flex; gap: 2px; align-items: center; margin-left: auto; }
+.run-workflow-form { display: flex; flex-direction: column; gap: 12px; min-width: min(420px, 76vw); }
+.run-workflow-field, .run-workflow-check { display: flex; flex-direction: column; gap: 5px; font-size: 13px; color: var(--fg-muted); }
+.run-workflow-field em, .run-workflow-check small, .run-workflow-field small { color: var(--fg-faint); font-style: normal; font-size: 11px; }
+.run-workflow-field b, .run-workflow-check b { color: var(--danger); }
+.run-workflow-field input, .run-workflow-field textarea, .run-workflow-field select { width: 100%; box-sizing: border-box; background: var(--bg-raised); color: var(--fg); border: 1px solid var(--border-strong); border-radius: 8px; padding: 8px 10px; font: inherit; }
+.run-workflow-field textarea { resize: vertical; }
+.run-workflow-check { flex-direction: row; align-items: center; flex-wrap: wrap; }
+.run-workflow-check small { flex-basis: 100%; margin-left: 21px; }
+.run-workflow-error { padding: 9px 10px; border-radius: 8px; color: var(--danger); background: rgba(239,68,68,.08); border: 1px solid rgba(239,68,68,.28); font-size: 12px; white-space: pre-wrap; }
 
 @media (max-width: 520px) {
   .wf-view { padding: 20px 16px; }

--- a/web/src/workflow-list-state.js
+++ b/web/src/workflow-list-state.js
@@ -1,0 +1,63 @@
+const TERMINAL = new Set(['success', 'error', 'canceled', 'skipped']);
+
+export function progressFromNodeStates(nodeStates = {}, total = null) {
+  const states = Object.values(nodeStates || {});
+  const done = states.filter((state) => TERMINAL.has(state?.status)).length;
+  const succeeded = states.filter((state) => state?.status === 'success').length;
+  return { done, total: total ?? states.length, succeeded };
+}
+
+export function currentNodesFromNodeStates(nodeStates = {}, labels = {}) {
+  return Object.entries(nodeStates || {})
+    .filter(([, state]) => ['running', 'waiting'].includes(state?.status))
+    .map(([id]) => ({ id, label: labels[id] || id }));
+}
+
+function byStartedAt(a, b) {
+  return String(b?.startedAt || '').localeCompare(String(a?.startedAt || '')) || String(b?.runId || '').localeCompare(String(a?.runId || ''));
+}
+
+export function mergeRunSummary(runs, next) {
+  if (!next?.runId) return runs || [];
+  const current = (runs || []).find((run) => run.runId === next.runId);
+  if (current && current.status !== 'running' && next.status === 'running') return runs;
+  const merged = { ...(current || {}), ...next };
+  const rest = (runs || []).filter((run) => run.runId !== next.runId);
+  return [merged, ...rest].sort((a, b) => Number(Boolean(b.live)) - Number(Boolean(a.live)) || byStartedAt(a, b));
+}
+
+export function applyRunEvent(runs, event, payload) {
+  if (!payload?.runId) return runs || [];
+  const existing = (runs || []).find((run) => run.runId === payload.runId) || {};
+  if (event === 'run-start' || event === 'snapshot') {
+    return mergeRunSummary(runs, {
+      ...existing, runId: payload.runId, workflowId: payload.workflowId ?? existing.workflowId ?? null,
+      workflowName: payload.workflowName ?? existing.workflowName ?? null, source: payload.source ?? existing.source ?? null,
+      startedAt: payload.startedAt ?? existing.startedAt ?? new Date().toISOString(), status: 'running', live: true,
+      nodeStates: payload.nodeStates || existing.nodeStates || {}, progress: payload.progress || progressFromNodeStates(payload.nodeStates, payload.nodeCount ?? payload.nodeIds?.length),
+      currentNodes: payload.currentNodes || currentNodesFromNodeStates(payload.nodeStates),
+    });
+  }
+  if (event === 'node-status') {
+    if (existing.live === false) return runs || [];
+    const nodeStates = { ...(existing.nodeStates || {}), [payload.nodeId]: { ...(existing.nodeStates?.[payload.nodeId] || {}), ...payload } };
+    return mergeRunSummary(runs, { ...existing, runId: payload.runId, status: existing.status || 'running', live: true, nodeStates, progress: progressFromNodeStates(nodeStates, existing.progress?.total), currentNodes: currentNodesFromNodeStates(nodeStates) });
+  }
+  if (event === 'agent-progress') {
+    if (existing.live === false) return runs || [];
+    return mergeRunSummary(runs, { ...existing, runId: payload.runId, live: true, currentNodes: [{ id: payload.nodeId, label: existing.currentNodes?.find((node) => node.id === payload.nodeId)?.label || payload.nodeId }] });
+  }
+  if (event === 'run-end' || event === 'run-error') {
+    return mergeRunSummary(runs, { ...existing, ...payload, runId: payload.runId, live: false, status: payload.status || 'error', finishedAt: payload.finishedAt || new Date().toISOString(), currentNodes: [] });
+  }
+  return runs || [];
+}
+
+export function workflowCards(workflows = [], runs = []) {
+  return workflows.map((workflow) => {
+    const liveFromRuns = runs.filter((run) => run.workflowId === workflow.id && run.live);
+    const liveRuns = liveFromRuns.length ? liveFromRuns.sort(byStartedAt) : (workflow.liveRuns || []).sort(byStartedAt);
+    const lastRun = runs.find((run) => run.workflowId === workflow.id && !run.live) || workflow.lastRun || liveRuns[0] || null;
+    return { ...workflow, liveRuns, lastRun };
+  });
+}

--- a/web/src/workflow-list-state.test.mjs
+++ b/web/src/workflow-list-state.test.mjs
@@ -1,0 +1,22 @@
+import assert from 'node:assert/strict';
+import { applyRunEvent, currentNodesFromNodeStates, progressFromNodeStates, workflowCards } from './workflow-list-state.js';
+
+assert.deepEqual(progressFromNodeStates({ a: { status: 'success' }, b: { status: 'running' }, c: { status: 'canceled' } }, 3), { done: 2, total: 3, succeeded: 1 });
+assert.deepEqual(currentNodesFromNodeStates({ a: { status: 'running' }, b: { status: 'success' } }, { a: '节点 A' }), [{ id: 'a', label: '节点 A' }]);
+
+let runs = applyRunEvent([], 'run-start', { runId: 'r1', workflowId: 'wf1', workflowName: '一', source: 'workflow-list', nodeIds: ['a', 'b'] });
+runs = applyRunEvent(runs, 'node-status', { runId: 'r1', nodeId: 'a', status: 'running' });
+assert.equal(runs[0].live, true);
+assert.equal(runs[0].progress.total, 2);
+assert.deepEqual(runs[0].currentNodes, [{ id: 'a', label: 'a' }]);
+runs = applyRunEvent(runs, 'run-end', { runId: 'r1', workflowId: 'wf1', status: 'success', durationMs: 42 });
+assert.equal(runs[0].live, false);
+assert.equal(runs[0].status, 'success');
+runs = applyRunEvent(runs, 'node-status', { runId: 'r1', nodeId: 'a', status: 'running' });
+assert.equal(runs[0].status, 'success');
+assert.equal(runs[0].live, false);
+
+const cards = workflowCards([{ id: 'wf1', name: '一', liveRuns: [{ runId: 'r2', startedAt: '2026-01-01T00:00:00Z' }] }], runs);
+assert.equal(cards[0].liveRuns[0].runId, 'r2');
+assert.equal(cards[0].lastRun.runId, 'r1');
+console.log('workflow list state tests: passed');

--- a/web/src/workflow-run-inputs.js
+++ b/web/src/workflow-run-inputs.js
@@ -1,0 +1,89 @@
+const isObject = (value) => value !== null && typeof value === 'object' && !Array.isArray(value);
+
+export function schemaFields(inputSchema) {
+  return Array.isArray(inputSchema?.fields) ? inputSchema.fields.filter((field) => field && typeof field === 'object') : [];
+}
+
+export function fieldKey(field) {
+  return String(field?.key ?? field?.name ?? '').trim();
+}
+
+export function initialRunInputValues(inputSchema) {
+  const values = {};
+  for (const field of schemaFields(inputSchema)) {
+    const key = fieldKey(field);
+    if (!key || field.defaultValue === undefined) continue;
+    values[key] = structuredClone(field.defaultValue);
+  }
+  return values;
+}
+
+function parseValue(field, value) {
+  const type = String(field?.type || 'string').toLowerCase();
+  if (type === 'string') return String(value ?? '');
+  if (type === 'number') {
+    if (value === '' || value === null || value === undefined) return undefined;
+    const number = typeof value === 'number' ? value : Number(value);
+    return Number.isFinite(number) ? number : undefined;
+  }
+  if (type === 'boolean') return value === true || value === 'true';
+  if (type === 'string[]') {
+    if (Array.isArray(value)) return value.map(String);
+    return String(value ?? '').split(/\r?\n/).map((item) => item.trim()).filter(Boolean);
+  }
+  if (type === 'object' || type === 'json' || type === 'array') {
+    if (typeof value === 'object' && value !== null) return value;
+    if (!String(value ?? '').trim()) return undefined;
+    try { return JSON.parse(String(value)); } catch { return undefined; }
+  }
+  return value;
+}
+
+export function validateRunInputValues(inputSchema, values = {}) {
+  const fields = schemaFields(inputSchema);
+  if (!fields.length) return { ok: true, value: isObject(values) ? values : {} };
+  const output = {};
+  const errors = [];
+  const known = new Set();
+  for (const field of fields) {
+    const key = fieldKey(field);
+    if (!key) continue;
+    known.add(key);
+    const has = Object.prototype.hasOwnProperty.call(values, key) && values[key] !== '' && values[key] !== undefined;
+    if (!has) {
+      if (field.required === true && field.defaultValue === undefined) errors.push(`${field.label || key}为必填项`);
+      if (field.defaultValue !== undefined) output[key] = structuredClone(field.defaultValue);
+      continue;
+    }
+    const parsed = parseValue(field, values[key]);
+    const type = String(field.type || 'string').toLowerCase();
+    const valid = parsed !== undefined
+      && (type === 'number' ? typeof parsed === 'number'
+        : type === 'boolean' ? typeof parsed === 'boolean'
+          : type === 'string[]' ? Array.isArray(parsed) && parsed.every((item) => typeof item === 'string')
+            : type === 'object' ? isObject(parsed)
+                : type === 'json' ? parsed !== undefined
+
+                : type === 'array' ? Array.isArray(parsed)
+                  : type === 'string' ? typeof parsed === 'string' : true);
+    if (!valid) {
+      errors.push(`${field.label || key}格式不正确`);
+      continue;
+    }
+    if (Array.isArray(field.enum) && !field.enum.includes(parsed)) {
+      errors.push(`${field.label || key}不在允许值范围内`);
+      continue;
+    }
+    output[key] = parsed;
+  }
+  for (const key of Object.keys(values)) {
+    if (!known.has(key) && values[key] !== '' && values[key] !== undefined) errors.push(`不支持输入字段：${key}`);
+  }
+  return errors.length ? { ok: false, errors } : { ok: true, value: output };
+}
+
+export function serializeRunInputValues(inputSchema, values = {}) {
+  const result = validateRunInputValues(inputSchema, values);
+  if (!result.ok) throw new Error(result.errors.join('；'));
+  return result.value;
+}

--- a/web/src/workflow-run-inputs.test.mjs
+++ b/web/src/workflow-run-inputs.test.mjs
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { initialRunInputValues, serializeRunInputValues, validateRunInputValues } from './workflow-run-inputs.js';
+
+const schema = { fields: [
+  { key: 'name', type: 'string', required: true },
+  { key: 'count', type: 'number', defaultValue: 2 },
+  { key: 'enabled', type: 'boolean' },
+  { key: 'tags', type: 'string[]' },
+  { key: 'config', type: 'json' },
+] };
+assert.deepEqual(initialRunInputValues(schema), { count: 2 });
+assert.equal(validateRunInputValues(schema, {}).ok, false);
+assert.deepEqual(serializeRunInputValues(schema, { name: 'x', count: '3', enabled: true, tags: 'a\nb', config: '{"x":1}' }), { name: 'x', count: 3, enabled: true, tags: ['a', 'b'], config: { x: 1 }});
+assert.equal(validateRunInputValues(schema, { name: 'x', extra: 1 }).ok, false);
+assert.equal(validateRunInputValues({ fields: [{ name: 'mode', type: 'string', enum: ['a'] }] }, { mode: 'b' }).ok, false);
+console.log('workflow run inputs tests: passed');

--- a/web/src/workflow-transfer-ui.test.mjs
+++ b/web/src/workflow-transfer-ui.test.mjs
@@ -9,5 +9,9 @@ assert.match(source, /if \(!res\.ok\)/);
 assert.match(source, /URL\.createObjectURL\(await res\.blob\(\)\)/);
 assert.match(source, /await onOpen\?\.\(out\)/);
 assert.match(styles, /@media \(max-width: 520px\)[\s\S]*\.wf-list-head \{ flex-wrap: wrap; \}[\s\S]*\.wf-list-head \.btn \{ white-space: nowrap; \}/);
+assert.match(source, /onStartRun/);
+assert.match(source, /onCancelRun/);
+assert.match(source, /wf-live-run/);
+assert.match(source, /RunWorkflowModal/);
 
 console.log('workflow transfer UI tests: passed');


### PR DESCRIPTION
## 背景

Closes #118。工作流列表页原来只有元数据管理（搜索/新建/复制/导入导出/重命名/删除），看不到运行中工作流的实时状态，也没有启动、取消等运行控制入口。

## 方案

列表页升级为运行入口，同时保持多运行并发、`inspectedRunId` 单一事实源、定时/Webhook 不抢占画布等既有约束：

### 后端（orchestrator）
- **`GET /wf1/api/workflows` 运行概览**：每个已保存工作流附 `liveRuns[]`（内存实时态，多并发 run 各自一条）与 `lastRun`（最新 live 与最近持久化终态按开始时间取新）。进度口径与 `runProgressOf` 一致（排除 notify），只暴露状态/进度/当前节点/时间，不带输出正文，workspace 隔离。
- **新增 `POST /wf1/api/workflows/run`**：列表专用启动，只按 `workflowId` 使用持久化图/变量/输入 Schema（不收前端图覆盖），`source='workflow-list'`，与画布运行/助手工具共享 `startWorkflowRun()` 的 lint、安全与 Schema 校验。
- **统一命名工作流输入校验**：新增 `lib/workflow-inputs.js`（required/defaultValue/类型/enum/未知字段，空 schema 允许任意 JSON 对象），`startWorkflowRun()` 与 `/wf1/api/run` 的 `workflowId` 分支共用；顺带修复后者 `persisted` 变量作用域缺陷。
- **`run-start` 事件附 `nodeCount`**（业务节点数）：前端列表进度总数与后端口径一致。

### 前端（web）
- **App 复用唯一 SSE 连接**：经 `workflow-list-state.js` 纯函数把 `run-start/node-status/agent-progress/run-end/run-error/snapshot` 归并进列表模型；终态后迟到的 `node-status`/`agent-progress` 不会复活已结束 run；`runList` 拉取升为 `limit=100`。
- **`WorkflowList` 改造**：卡片运行摘要区（LIVE 进度/当前节点/开始时间、最近终态）、同一工作流多个 live run 独立「查看/取消」、启动按钮打开 `RunWorkflowModal`；删除/重命名/复制等操作补齐 HTTP 错误处理（原来无视失败）。
- **`RunWorkflowModal`**：`inputSchema.fields` 渲染 schema-aware 表单（string/number/boolean/enum/string[]/JSON），无 schema 时 JSON 对象兜底；前端即时校验，失败保留输入。
- **`shouldFollowRunStart` 排除 `workflow-list`**：列表启动不抢占当前画布视图；RunSwitcher 增加「列表启动」来源图标与标签。
- **取消/查看**：取消先经 ConfirmModal 防误触（明确展示 runId），查看复用 `openWorkflow()` + `selectRunForView()` 同一条路径。

## 验证

- orchestrator 17 套单测全过（含新增 HTTP 列表概览/列表启动集成测试：404/终态对账/inputSchema 概览形状）
- web 全套 + 全量 `npm test` 通过
- `build-web.sh` 双 base 构建通过；`git diff --check` 干净
- 本 PR 基于 origin/main（65ad8a3），已与 subworkflow 等其他在途批次解耦（校验函数独立为 `workflow-inputs.js`，不依赖未合并的 `subworkflow.js`）

## 后续（不在本 PR）

- 真实 dsh + 浏览器 E2E 全流程点验（启动→LIVE→并发→取消→查看）