### PR TITLE
chore(one): 准备 0.8.1 发版

### DIFF
--- a/dsh-plugins/dsh-ccpg-brand/package.json
+++ b/dsh-plugins/dsh-ccpg-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-brand",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-llm-guard/lib/index.js
@@ -2,6 +2,12 @@ export const name = 'dsh-ccpg-llm-guard';
 
 const MALFORMED_TOOL_CALL_CODE = 'EMPTY_RESPONSE';
 
+// dsh 的 write/edit 等变更类工具把 sandbox_permissions/justification 当「沙箱升级」
+// 参数：只有从更窄模式升级时才合法，且必须成对、justification 非空。会话已跑在
+// danger-full-access（最宽）时，模型自发带上这对参数（GPT 系常见：预填权限声明）
+// 会被 dsh-sandbox 校验直接拒绝，写入永远失败。清洗层在流上把这类多余参数剔除。
+const ESCALATION_FIELDS = ['sandbox_permissions', 'justification'];
+
 function malformedToolCall(block) {
   return block?.type === 'tool-call' && (
     typeof block.id !== 'string' || block.id.trim() === '' ||
@@ -23,6 +29,27 @@ function malformedFinish() {
   };
 }
 
+// 剔除多余的沙箱升级参数。仅在解析成功、且对象里确实含这两个字段之一时重写；
+// 解析失败或无该字段一律原样返回——升级参数若真被沙箱拒过，拒错文案会引导模型
+// 正确重试，这里不能把它吞掉。justification 单独出现（无 sandbox_permissions）
+// 同样过不了 dsh-sandbox 的成对校验，一并剔除。
+function stripEscalationArgs(argumentsText) {
+  let parsed;
+  try {
+    parsed = JSON.parse(argumentsText);
+  } catch {
+    return argumentsText;
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    return argumentsText;
+  }
+  if (!ESCALATION_FIELDS.some((field) => Object.prototype.hasOwnProperty.call(parsed, field))) {
+    return argumentsText;
+  }
+  for (const field of ESCALATION_FIELDS) delete parsed[field];
+  return JSON.stringify(parsed);
+}
+
 export async function* guardToolCalls(stream) {
   let buffered;
 
@@ -40,6 +67,11 @@ export async function* guardToolCalls(stream) {
         return;
       }
 
+      for (const item of buffered) {
+        if (item.type === 'block-end' && item.block?.type === 'tool-call' && typeof item.block.arguments === 'string') {
+          item.block = { ...item.block, arguments: stripEscalationArgs(item.block.arguments) };
+        }
+      }
       yield* buffered;
       return;
     }

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/test/index.test.mjs
+++ b/dsh-plugins/dsh-ccpg-llm-guard/test/index.test.mjs
@@ -47,3 +47,41 @@ for (const block of [
 }
 
 console.log('llm guard tests passed');
+
+// —— 多余沙箱升级参数清洗（gpt-5.6-terra 在 danger-full-access 会话里自发带
+//    sandbox_permissions/justification 导致 write 被拒的回归）——
+const escalationCall = (args) => [
+  { type: 'block-start', index: 0, blockType: 'tool-call' },
+  { type: 'tool-call-delta', index: 0, id: 'call-9', name: 'write', argumentsDelta: args },
+  { type: 'block-end', index: 0, block: { type: 'tool-call', id: 'call-9', name: 'write', arguments: args } },
+  finish,
+];
+
+{
+  const out = await collect(escalationCall('{"file_path":"/tmp/a.md","content":"x","sandbox_permissions":"danger-full-access","justification":"创建交付物。"}'));
+  assert.equal(out.length, 4);
+  assert.deepEqual(JSON.parse(out[2].block.arguments), { file_path: '/tmp/a.md', content: 'x' });
+}
+
+{
+  // justification 单独出现（无 sandbox_permissions）同样过不了成对校验，剔除
+  const out = await collect(escalationCall('{"file_path":"/tmp/a.md","justification":""}'));
+  assert.deepEqual(JSON.parse(out[2].block.arguments), { file_path: '/tmp/a.md' });
+}
+
+{
+  // 无升级参数的调用原样放行（字符串引用相等，未被重写）
+  const args = '{"file_path":"/tmp/a.md","content":"x"}';
+  const out = await collect(escalationCall(args));
+  assert.equal(out[2].block.arguments, args);
+}
+
+{
+  // 非法 JSON 与非对象 JSON 原样放行
+  for (const args of ['not json', '["sandbox_permissions"]', '"str"', 'null']) {
+    const out = await collect(escalationCall(args));
+    assert.equal(out[2].block.arguments, args);
+  }
+}
+
+console.log('escalation strip tests passed');

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-harness-one",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.8.0",
-    "dsh-ccpg-document-preview": "0.8.0",
-    "dsh-ccpg-larkauth": "0.8.0",
-    "dsh-ccpg-llm-guard": "0.8.0",
-    "dsh-ccpg-orchestrator": "0.8.0",
-    "dsh-ccpg-tools": "0.8.0",
-    "dsh-ccpg-web": "0.8.0"
+    "dsh-ccpg-canvasui": "0.8.1",
+    "dsh-ccpg-document-preview": "0.8.1",
+    "dsh-ccpg-larkauth": "0.8.1",
+    "dsh-ccpg-llm-guard": "0.8.1",
+    "dsh-ccpg-orchestrator": "0.8.1",
+    "dsh-ccpg-tools": "0.8.1",
+    "dsh-ccpg-web": "0.8.1"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-ccpg-orchestrator",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 背景
发布 0.8.1，包含 llm-guard 对模型多余沙箱升级参数的兼容清洗。

## 变更
- 清洗 write/edit 工具调用中多余的 sandbox_permissions/justification 参数
- 增加 llm-guard 回归测试
- 同步 9 个插件包及聚合包版本到 0.8.1

## 验证
- 全量单元测试通过
- build-web.sh 通过
- pack.sh v0.8.1 通过
- verify-plugin-packages.mjs 通过