### PR TITLE
fix(release): 补齐 dsh-agent 依赖引导

### DIFF
--- a/dsh-plugins/pack.sh
+++ b/dsh-plugins/pack.sh
@@ -80,7 +80,7 @@ done
 [ -n "$DSH_PROBE" ] && SDK_DIR=$(node -e "console.log(require('path').dirname(require('path').dirname(process.argv[1])))" "$DSH_PROBE")/node_modules/@deepseek-ai
 if [ -n "$SDK_DIR" ] && [ -d "$SDK_DIR/dsh-tools" ]; then
   mkdir -p node_modules/@deepseek-ai
-  for dep in schemastery cordis dsh-tools dsh-llm dsh-session; do
+  for dep in schemastery cordis dsh-tools dsh-llm dsh-session dsh-agent; do
     T="node_modules/@deepseek-ai/$dep"
     [ -d "$SDK_DIR/$dep" ] || continue
     [ -L "$T" ] || ln -s "$SDK_DIR/$dep" "$T"

--- a/dsh-plugins/setup.sh
+++ b/dsh-plugins/setup.sh
@@ -202,7 +202,7 @@ LINK_ROOTS="$PLUGINS"
 [ "$AGGREGATE" = 1 ] && LINK_ROOTS="$PLUGINS dsh-harness-one/dsh-ccpg-tools dsh-harness-one/dsh-ccpg-orchestrator dsh-harness-one/dsh-ccpg-web dsh-harness-one/dsh-ccpg-canvasui dsh-harness-one/dsh-ccpg-document-preview dsh-harness-one/dsh-ccpg-larkauth dsh-harness-one/dsh-ccpg-llm-guard"
 for pkg in $LINK_ROOTS; do
   mkdir -p "$HERE/$pkg/node_modules/@deepseek-ai"
-  for dep in schemastery cordis dsh-tools dsh-llm dsh-session; do
+  for dep in schemastery cordis dsh-tools dsh-llm dsh-session dsh-agent; do
     [ -d "$SDK_DIR/$dep" ] || continue
     T="$HERE/$pkg/node_modules/@deepseek-ai/$dep"
     [ -L "$T" ] || ln -s "$SDK_DIR/$dep" "$T"


### PR DESCRIPTION
## 背景
0.8.1 发版 boot smoke 在隔离安装后无法解析 `@deepseek-ai/dsh-agent`。

## 修复
- setup.sh 为归档内嵌插件补齐 dsh-agent SDK 软链
- pack.sh 为本地打包后的 orchestrator 依赖补齐 dsh-agent 软链

## 验证
- sh -n dsh-plugins/setup.sh dsh-plugins/pack.sh
- pack.sh 重新打包并通过 QuickJS、包结构和 vendor 校验
- CI 将执行隔离安装 boot smoke