### PR TITLE
fix(web): 节点面板默认模型展示对齐引擎解析链（WF1 默认值优先）

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -3420,6 +3420,9 @@ export function apply(ctx, config) {
       defaultProvider: sel.provider,
       defaultModel: sel.model,
       defaultReasoningEffort: sel.reasoningEffort,
+      // 节点未配置时的真正第一顺位默认值（设置面板「Workflow One」）；空串 = 未设置。
+      // 前端占位文案优先展示这层，node 面板与 runAgentNode 解析链（agent-defaults.js）对齐。
+      wf1Defaults: agentDefaultsStore.read(),
       providers,
       ...(failures.length ? { failures } : {}),
     });

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults-api.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults-api.integration.test.mjs
@@ -136,6 +136,23 @@ await test('PUT 畸形 JSON 请求体 400（scoped:false 路由也要有请求�
   assert.match(body.error, /JSON/);
 });
 
+// llm-config 是节点面板默认值展示链的数据源：必须同步暴露 wf1Defaults，
+// 否则前端占位文案只能回退「跟随 dsh 默认」，与引擎实际解析（WF1 默认值优先）不一致。
+await test('llm-config 暴露 wf1Defaults（节点面板展示链与引擎解析链对齐）', async () => {
+  const llmRoute = ctx.webServer.routes.find((entry) => entry.kind === 'exact' && entry.path === '/wf1/api/llm-config')?.handler;
+  assert.ok(llmRoute, 'llm-config 路由已注册');
+  const put = await call('PUT', { provider: 'glm', model: 'glm-5', reasoningEffort: '' });
+  assert.equal(put.status, 200);
+  const res = responseCapture();
+  await llmRoute(request('GET', '/wf1/api/llm-config'), res);
+  const body = res.json();
+  assert.deepEqual(body.wf1Defaults, { provider: 'glm', model: 'glm-5', reasoningEffort: '' });
+  // dsh 全局选择字段保持原语义，不受 WF1 默认值影响
+  assert.equal(body.defaultProvider, 'deepseek');
+  assert.equal(body.defaultModel, 'deepseek-chat');
+  await call('PUT', {}); // 清理，恢复空默认值
+});
+
 if (originalEnv.DSH_HOME === undefined) delete process.env.DSH_HOME; else process.env.DSH_HOME = originalEnv.DSH_HOME;
 if (originalEnv.WF1_LEGACY_DATA_DIR === undefined) delete process.env.WF1_LEGACY_DATA_DIR;
 else process.env.WF1_LEGACY_DATA_DIR = originalEnv.WF1_LEGACY_DATA_DIR;

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "test:variables": "node src/variables.test.mjs && node src/global-variables.test.mjs && node src/json-response.test.mjs && node src/api-base.test.mjs && node src/trial-request.test.mjs && node src/variable-scope.test.mjs && node src/run-event-routing.test.mjs && node src/workflow-serialization.test.mjs && node src/doc-wall-data.test.mjs && node src/live-run-adopt.test.mjs",
     "test:results": "node src/result-adapter.test.mjs",
     "test:scripts": "node src/script-parameters.test.mjs",
-    "test:ui": "node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs && node src/notify-node.test.mjs && node src/workflow-transfer-ui.test.mjs && node src/run-switcher.test.mjs && node src/schedule-center.test.mjs && node src/node-detail-polling.test.mjs"
+    "test:ui": "node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs && node src/notify-node.test.mjs && node src/agent-default-label.test.mjs && node src/workflow-transfer-ui.test.mjs && node src/run-switcher.test.mjs && node src/schedule-center.test.mjs && node src/node-detail-polling.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/web/src/NodePanel.jsx
+++ b/web/src/NodePanel.jsx
@@ -149,18 +149,29 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
   const scriptInputs = normalizeScriptInputs(d.inputs);
   const scriptInputErrors = validateScriptInputs(scriptInputs);
   const providers = Array.isArray(llmConfig.providers) ? llmConfig.providers : [];
-  const effectiveProvider = d.channel || llmConfig.defaultProvider || '';
+  // 默认值展示链与引擎解析链（agent-defaults.js）对齐：节点未配置时第一顺位是
+  // 设置面板「Workflow One」默认值（wf1Defaults），未设置才回退 dsh 全局选择。
+  const wf1Defaults = llmConfig.wf1Defaults || {};
+  const wf1Provider = wf1Defaults.provider || '';
+  const wf1Model = wf1Provider ? (wf1Defaults.model || null) : null; // 设了渠道没设模型 → 运行时取渠道首选
+  const defaultProvider = wf1Provider || llmConfig.defaultProvider || '';
+  const effectiveProvider = d.channel || defaultProvider || '';
   const providerModels = providers.find((provider) => provider.id === effectiveProvider)?.models || [];
-  const modelDefaultLabel = d.channel
+  const defaultModelLabel = d.channel
     ? `渠道默认（${providerModels[0]?.name || providerModels[0]?.id || '未配置'}）`
-    : `跟随 dsh 默认（${llmConfig.defaultModel || '未配置'}）`;
+    : wf1Provider
+      ? `跟随 Workflow One 默认（${wf1Model || providerModels[0]?.name || providerModels[0]?.id || '渠道首选'}）`
+      : `跟随 dsh 默认（${llmConfig.defaultModel || '未配置'}）`;
   // 所选模型的能力元数据：思考级别档位 + 视觉输入。跨渠道选模型后目录无该模型时为 null
   const currentModel = providerModels.find((item) => item.id === d.model) || null;
   const modelReasoning = currentModel?.reasoning || null;
-  // 继承全局默认档位：同渠道同模型时 dsh 默认档位生效（与引擎继承语义一致）
-  const inheritedEffort = effectiveProvider === llmConfig.defaultProvider && (!d.model || d.model === llmConfig.defaultModel)
-    ? llmConfig.defaultReasoningEffort
-    : undefined;
+  // 继承默认档位（与引擎同语义）：同渠道同模型时先看 WF1 默认档位，未设再看 dsh 全局档位
+  let inheritedEffort;
+  if (wf1Defaults.reasoningEffort && wf1Model && effectiveProvider === wf1Provider && (!d.model || d.model === wf1Model)) {
+    inheritedEffort = wf1Defaults.reasoningEffort;
+  } else if (llmConfig.defaultReasoningEffort && effectiveProvider === llmConfig.defaultProvider && (!d.model || d.model === llmConfig.defaultModel)) {
+    inheritedEffort = llmConfig.defaultReasoningEffort;
+  }
 
   const selectProvider = (providerId) => {
     if (!providerId) {
@@ -610,7 +621,11 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
             <div className="field-grid">
               <Field label="渠道">
                 <select value={d.channel || ''} onChange={(e) => selectProvider(e.target.value)}>
-                  <option value="">跟随 dsh 默认（{llmConfig.defaultProvider || '未配置'}）</option>
+                  <option value="">
+                    {wf1Provider
+                      ? `跟随 Workflow One 默认（${providers.find((p) => p.id === wf1Provider)?.name || wf1Provider}${wf1Model ? '' : '，渠道首选模型'}）`
+                      : `跟随 dsh 默认（${llmConfig.defaultProvider || '未配置'}）`}
+                  </option>
                   {providers.map((provider) => (
                     <option key={provider.id} value={provider.id}>{provider.name || provider.id}</option>
                   ))}

--- a/web/src/NodePanel.jsx
+++ b/web/src/NodePanel.jsx
@@ -633,7 +633,7 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
               </Field>
               <Field label="模型">
                 <select value={d.model || ''} onChange={(e) => set({ model: e.target.value || undefined, reasoningEffort: undefined })} disabled={!effectiveProvider}>
-                  <option value="">{modelDefaultLabel}</option>
+                  <option value="">{defaultModelLabel}</option>
                   {d.model && !providerModels.some((model) => model.id === d.model) && (
                     <option value={d.model}>{d.model}（目录中不可用）</option>
                   )}

--- a/web/src/agent-default-label.test.mjs
+++ b/web/src/agent-default-label.test.mjs
@@ -1,0 +1,28 @@
+// 节点面板「模型与轮次」默认值展示链（issue：WF1 默认模型被展示成 dsh 默认）。
+// 前端展示必须与引擎解析链（orchestrator/lib/agent-defaults.js）对齐：
+// 节点未配置时第一顺位是设置面板「Workflow One」默认值（llmConfig.wf1Defaults），
+// 未设置才回退 dsh 全局选择（llmConfig.default*）。用源码断言（与 notify-node.test.mjs 同模式）。
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(fileURLToPath(import.meta.url));
+const panel = readFileSync(join(root, 'NodePanel.jsx'), 'utf8');
+
+// llmConfig.wf1Defaults 是展示链的第一顺位数据源
+assert.match(panel, /llmConfig\.wf1Defaults/, 'NodePanel 应从 llmConfig.wf1Defaults 读取 WF1 默认值');
+
+// 占位文案：WF1 设置了渠道时显示「跟随 Workflow One 默认」，而不是「跟随 dsh 默认」
+assert.match(panel, /跟随 Workflow One 默认/, '占位文案应包含「跟随 Workflow One 默认」分支');
+
+// 渠道下拉占位：wf1Provider 存在时优先展示 WF1 层
+assert.match(panel, /wf1Provider\s*\?\s*`跟随 Workflow One 默认/, '渠道下拉占位应优先 wf1Provider');
+
+// effectiveProvider 链：wf1Provider 优先于 llmConfig.defaultProvider
+assert.match(panel, /const defaultProvider = wf1Provider \|\| llmConfig\.defaultProvider \|\| ''/, 'defaultProvider 应先取 wf1Provider');
+
+// 思考级别继承链：WF1 档位优先，且要求同渠道同模型（与引擎 resolve 同语义）
+assert.match(panel, /wf1Defaults\.reasoningEffort && wf1Model && effectiveProvider === wf1Provider/, '思考级别继承应先看 WF1 档位');
+
+console.log('agent default label tests: passed');


### PR DESCRIPTION
## 背景

用户反馈：工作流智能体默认模型应该跟随 Workflow One 设置里配置的模型，而不是 dsh 默认模型。

## 调查结论（引擎没坏，缺口在展示层）

v0.8.1（#117）的引擎解析链 `节点配置 > Workflow One 设置默认值 > dsh 全局` 真实生效，运行记录可证：
- 9-2 18:14 的运行（保存 WF1 默认值 1 分钟后）实跑 `codex:gpt-5.6-terra`，与设置一致
- 18:03 的失败运行发生在默认值保存之前（agent-defaults.json 落盘于 18:13），当时回退 dsh 全局是设计行为

真正的缺口：`/wf1/api/llm-config` 不暴露 WF1 默认值，节点面板占位文案只会写「跟随 dsh 默认（X）」。用户在 UI 上看不到「未配置节点会跑 Workflow One 默认模型」，误以为功能没生效，只能把渠道/模型手动逐个烤进节点 data（显式配置永远优先，进一步固化了误解）。

## 方案

- **引擎**：llm-config 路由回包新增 `wf1Defaults`（与 agent-defaults 存储同源）；`default*` 字段保持 dsh 全局语义不变
- **前端**：NodePanel 展示链对齐引擎解析链——
  - 渠道/模型占位文案优先展示「跟随 Workflow One 默认（…）」，WF1 未设置才回退「跟随 dsh 默认（…）」
  - `effectiveProvider` 先取 wf1Provider（决定模型下拉的候选目录）
  - 思考级别继承档位先看 WF1 层，且要求同渠道同模型（跨层不错配，与 `resolveAgentModelSelection` 同语义）

## 验证

- orchestrator 17 套 + web 15 套（新增 `agent-default-label.test.mjs`、llm-config 集成用例）全绿
- `build-web.sh` 双构建通过
- 兼容性：旧版引擎无 `wf1Defaults` 字段时前端自动回退 dsh 默认文案，行为不变