### PR TITLE
feat(orchestrator): agent 节点超时默认值进设置面板「Workflow One」

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -1055,7 +1055,7 @@ window.__ModuleLoader__.load({
     function AgentDefaultsCard() {
       var a = s2(null), llmConfig = a[0], setLlmConfig = a[1];
       var b = s2(null), saved = b[0], setSaved = b[1]; // GET/PUT 回包 {defaults, effective, dsh}
-      var c = s2({ provider: "", model: "", reasoningEffort: "" }), draft = c[0], setDraft = c[1];
+      var c = s2({ provider: "", model: "", reasoningEffort: "", nodeTimeoutSec: 0, modelTimeoutSec: 0 }), draft = c[0], setDraft = c[1];
       var e = s2(false), saving = e[0], setSaving = e[1];
       var f = s2(null), message = f[0], setMessage = f[1]; // {kind:'ok'|'err', text}
 
@@ -1067,7 +1067,7 @@ window.__ModuleLoader__.load({
         systemGet(AGENT_DEFAULTS_API).then(function (d2) {
           if (dead || !d2 || !d2.ok) return;
           setSaved(d2);
-          setDraft(Object.assign({ provider: "", model: "", reasoningEffort: "" }, d2.defaults));
+          setDraft(Object.assign({ provider: "", model: "", reasoningEffort: "", nodeTimeoutSec: 0, modelTimeoutSec: 0 }, d2.defaults));
         }).catch(function () {});
         return function () { dead = true; };
       }, []);
@@ -1077,6 +1077,8 @@ window.__ModuleLoader__.load({
         draft.provider !== saved.defaults.provider
         || draft.model !== saved.defaults.model
         || draft.reasoningEffort !== saved.defaults.reasoningEffort
+        || Number(draft.nodeTimeoutSec || 0) !== Number(saved.defaults.nodeTimeoutSec || 0)
+        || Number(draft.modelTimeoutSec || 0) !== Number(saved.defaults.modelTimeoutSec || 0)
       );
 
       var patchDraft = function (patch) {
@@ -1087,16 +1089,27 @@ window.__ModuleLoader__.load({
       var save = function () {
         setSaving(true);
         setMessage(null);
+        // 超时输入框是文本：空串归 0（不设置），非法值在提交前拦下
+        var payload = Object.assign({}, draft, {
+          nodeTimeoutSec: Math.max(0, Math.floor(Number(draft.nodeTimeoutSec) || 0)),
+          modelTimeoutSec: Math.max(0, Math.floor(Number(draft.modelTimeoutSec) || 0)),
+        });
+        if (draft.nodeTimeoutSec !== "" && (!Number.isFinite(Number(draft.nodeTimeoutSec)) || Number(draft.nodeTimeoutSec) < 0)
+          || draft.modelTimeoutSec !== "" && (!Number.isFinite(Number(draft.modelTimeoutSec)) || Number(draft.modelTimeoutSec) < 0)) {
+          setSaving(false);
+          setMessage({ kind: "err", text: "超时必须是不小于 0 的整数（秒），0 表示用内置默认" });
+          return;
+        }
         fetch(AGENT_DEFAULTS_API, {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify(draft),
+          body: JSON.stringify(payload),
         })
           .then(function (r) { return r.json(); })
           .then(function (r2) {
             if (r2 && r2.ok) {
               setSaved(r2);
-              setDraft(Object.assign({ provider: "", model: "", reasoningEffort: "" }, r2.defaults));
+              setDraft(Object.assign({ provider: "", model: "", reasoningEffort: "", nodeTimeoutSec: 0, modelTimeoutSec: 0 }, r2.defaults));
               setMessage({ kind: "ok", text: "已保存，新发起的运行立即生效" });
             } else {
               setMessage({ kind: "err", text: (r2 && r2.error) || "保存失败" });
@@ -1133,6 +1146,17 @@ window.__ModuleLoader__.load({
           + " / " + (effective.model || "渠道首选模型")
           + (effective.reasoningEffort ? " / 思考级别 " + effective.reasoningEffort : "");
 
+      var mkTimeoutInput = function (key, placeholder) {
+        return react.createElement("input", {
+          type: "number", min: 0, max: 86400, step: 1,
+          style: selectStyle,
+          value: draft[key] === 0 || draft[key] === "" ? "" : draft[key],
+          placeholder: placeholder,
+          disabled: saving,
+          onChange: function (ev) { patchDraft({ [key]: ev.target.value === "" ? 0 : Number(ev.target.value) }); },
+        });
+      };
+
       var mkSelect = function (value, options, disabled, onChange) {
         return react.createElement(
           "select",
@@ -1161,7 +1185,7 @@ window.__ModuleLoader__.load({
         react.createElement(
           "div",
           { style: { fontSize: "12px", color: "var(--dsw-alias-text-secondary)", lineHeight: "18px" } },
-          "节点没有单独配置渠道/模型/思考级别时，按这里的默认值运行；都没有时跟随 dsh 全局选择。",
+          "节点没有单独配置渠道/模型/思考级别/超时时，按这里的默认值运行；模型层都没有时跟随 dsh 全局选择，超时 0 = 内置默认（节点 500s / 单次 300s）。",
         ),
         !llmConfig
           ? react.createElement("div", { style: { fontSize: "12px", color: "var(--dsw-alias-text-secondary)" } }, "正在读取渠道目录…")
@@ -1180,6 +1204,8 @@ window.__ModuleLoader__.load({
                   saving || !draft.model || !efforts.length,
                   function (v) { patchDraft({ reasoningEffort: v }); },
                 )),
+                defaultsField("节点超时(秒)", mkTimeoutInput("nodeTimeoutSec", "默认 500")),
+                defaultsField("单次超时(秒)", mkTimeoutInput("modelTimeoutSec", "默认 300")),
               ],
         react.createElement(
           "div",

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/agent-defaults.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/agent-defaults.js
@@ -13,7 +13,10 @@ import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 
 const MAX_FIELD_LENGTH = 200;
-const ALLOWED_KEYS = new Set(['provider', 'model', 'reasoningEffort']);
+const ALLOWED_KEYS = new Set(['provider', 'model', 'reasoningEffort', 'nodeTimeoutSec', 'modelTimeoutSec']);
+// 超时字段：正整数秒，0/空 = 不设置（回退内置默认 500s / 300s）。上限 86400（一天）防呆。
+const TIMEOUT_KEYS = new Set(['nodeTimeoutSec', 'modelTimeoutSec']);
+const MAX_TIMEOUT_SEC = 86400;
 
 export class AgentDefaultsError extends Error {
   constructor(message, { code = 'invalid-agent-defaults', status = 400 } = {}) {
@@ -33,9 +36,12 @@ export const agentDefaultsFile = () => join(
   'plugin-data', 'dsh-ccpg-orchestrator', 'state', 'agent-defaults.json',
 );
 
-export const EMPTY_AGENT_DEFAULTS = Object.freeze({ provider: '', model: '', reasoningEffort: '' });
+export const EMPTY_AGENT_DEFAULTS = Object.freeze({
+  provider: '', model: '', reasoningEffort: '',
+  nodeTimeoutSec: 0, modelTimeoutSec: 0,
+});
 
-/** 输入整形：只收三个字符串字段，空串 = 不设置（跟随 dsh 全局选择）。 */
+/** 输入整形：三个字符串字段 + 两个超时（秒，0 = 不设置）。 */
 export function normalizeAgentDefaults(source) {
   if (source === null || typeof source !== 'object' || Array.isArray(source)) fail('请求体必须是对象');
   for (const key of Object.keys(source)) {
@@ -45,12 +51,19 @@ export function normalizeAgentDefaults(source) {
   for (const key of ALLOWED_KEYS) {
     const value = source[key];
     if (value === undefined || value === null) continue;
+    if (TIMEOUT_KEYS.has(key)) {
+      const num = typeof value === 'number' ? value : Number(String(value).trim());
+      if (!Number.isFinite(num) || num < 0 || !Number.isInteger(num)) fail(`${key} 必须是不小于 0 的整数（秒）`);
+      if (num > MAX_TIMEOUT_SEC) fail(`${key} 不能超过 ${MAX_TIMEOUT_SEC} 秒`);
+      result[key] = num;
+      continue;
+    }
     if (typeof value !== 'string') fail(`${key} 必须是字符串`);
     const trimmed = value.trim();
-    if (trimmed.length > MAX_FIELD_LENGTH) fail(`${key} 最长 ${MAX_FIELD_LENGTH} 个字符`);
+    if (trimmed.length > MAX_FIELD_LENGTH) fail(`${key} 最长 ${MAX_FIELD_LENGTH} 个的字符`);
     result[key] = trimmed;
   }
-  // 依赖关系：model 依附 provider，思考级别依附具体模型
+  // 依赖关系：model 依附 provider，思考级别依附具体模型；超时独立无依赖
   if (result.model && !result.provider) fail('设置默认模型前必须先选默认渠道');
   if (result.reasoningEffort && !result.model) fail('设置默认思考级别前必须先选默认渠道和模型');
   return result;
@@ -141,4 +154,22 @@ export function resolveAgentModelSelection({ node = {}, defaults = EMPTY_AGENT_D
     || (provider === sel.provider && model === sel.model ? sel.reasoningEffort : undefined)
     || undefined;
   return { provider, model, reasoningEffort };
+}
+
+/**
+ * 节点未显式配置时的超时解析（秒）：节点 data > Workflow One 默认值 > 内置默认。
+ * 覆盖 agent 节点的两个旋钮——nodeTimeoutSec（节点总生命周期，内置 500s）与
+ * modelTimeoutSec（单次模型请求，内置 300s）。返回有效秒数，永不 undefined。
+ */
+export const DEFAULT_NODE_TIMEOUT_SEC = 500;
+export const DEFAULT_MODEL_TIMEOUT_SEC = 300;
+
+export function resolveAgentTimeouts({ node = {}, defaults = EMPTY_AGENT_DEFAULTS } = {}) {
+  const nodeTimeoutSec = Number(node.timeoutSec) > 0
+    ? Number(node.timeoutSec)
+    : (defaults.nodeTimeoutSec > 0 ? defaults.nodeTimeoutSec : DEFAULT_NODE_TIMEOUT_SEC);
+  const modelTimeoutSec = Number(node.modelTimeoutSec) > 0
+    ? Number(node.modelTimeoutSec)
+    : (defaults.modelTimeoutSec > 0 ? defaults.modelTimeoutSec : DEFAULT_MODEL_TIMEOUT_SEC);
+  return { nodeTimeoutSec, modelTimeoutSec };
 }

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/engine.js
@@ -93,6 +93,7 @@ export class Orchestrator {
     this.outputSink = null; // index.js 注入：async (node, output, {signal}) => ({output, ...extra}) 输出节点后处理（飞书写回等）
     this.runChildWorkflow = null; // index.js 注入：同步启动并等待子工作流
     this.onCancel = null; // index.js 注入：父运行取消时传播到子运行
+    this.resolveNodeTimeout = null; // index.js 注入：(node) => 该节点未配 timeoutSec 时的默认超时秒；空 = 内置 NODE_TIMEOUT_MS
   }
 
   emit(event, payload) {
@@ -304,7 +305,12 @@ export class Orchestrator {
     const startedAt = new Date(t0).toISOString();
     run.nodeStates[nodeId] = { status: 'running', startedAt };
     this.emit('node-status', { runId: run.runId, nodeId, status: 'running', startedAt });
-    const timeoutMs = Number(node.data?.timeoutSec) > 0 ? Number(node.data.timeoutSec) * 1000 : NODE_TIMEOUT_MS;
+    // 节点总超时：节点显式 timeoutSec 优先；未配时 agent 节点可注入设置面板默认值（resolveNodeTimeout），其余用内置
+    let fallbackSec = 0;
+    try { fallbackSec = Number(this.resolveNodeTimeout?.(node)) || 0; } catch { fallbackSec = 0; }
+    const timeoutMs = Number(node.data?.timeoutSec) > 0
+      ? Number(node.data.timeoutSec) * 1000
+      : (fallbackSec > 0 ? fallbackSec * 1000 : NODE_TIMEOUT_MS);
     let timedOut = false;
     const timer = setTimeout(() => { timedOut = true; ac.abort(); }, timeoutMs);
     try {

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -75,8 +75,8 @@ import {
 } from './assistant.js';
 import { ensureWorkflowSkill } from './skill-seed.js';
 import {
-  AgentDefaultsError, AgentDefaultsStore, normalizeAgentDefaults, resolveAgentModelSelection,
-  validateAgentDefaults,
+  AgentDefaultsError, AgentDefaultsStore, DEFAULT_NODE_TIMEOUT_SEC, normalizeAgentDefaults,
+  resolveAgentModelSelection, resolveAgentTimeouts, validateAgentDefaults,
 } from './agent-defaults.js';
 import {
   assertNonSensitiveVariableDefinitions, assertSafeContextObject, GlobalVariableStore, VariableStoreError,
@@ -1123,6 +1123,12 @@ export function apply(ctx, config) {
   orch = new Orchestrator(ctx, { onEvent: onOrchestratorEvent, renderTemplate });
   orch.onCancel = (runId, reason) => cancelDescendants(runId, reason);
   orch.nodeRunner = async (node, run, s, ctl) => runAgentNode(ctx, node, run, s, ctl);
+  // agent 节点未配 timeoutSec 时的总超时回退：设置面板「Workflow One」默认值（>0 才生效）
+  orch.resolveNodeTimeout = (node) => (
+    node?.type === 'agent' || node?.data?.nodeType === 'agent'
+      ? agentDefaultsStore.read().nodeTimeoutSec
+      : 0
+  );
   orch.scriptRunner = async ({ node, input, signal, timeoutMs, workflowId, runId }) => {
     const ws = workspaceFor(node, { workflowId: workflowId || 'draft', runId });
     const result = await runScript({
@@ -1380,9 +1386,10 @@ export function apply(ctx, config) {
 
     // 节点级模型解析链：节点显式配置 > 设置面板「Workflow One」默认值 > dsh 全局选择；
     // channel 仅透传给支持的 provider。默认值与全局模型都只在渠道匹配时继承（跨渠道不错配）。
+    const agentDefaults = agentDefaultsStore.read();
     const defaultModel = ctx.get('agentDefaultModel');
     const sel = defaultModel?.currentSelection?.() || {};
-    const resolved = resolveAgentModelSelection({ node: d, defaults: agentDefaultsStore.read(), dshSelection: sel });
+    const resolved = resolveAgentModelSelection({ node: d, defaults: agentDefaults, dshSelection: sel });
     const provider = resolved.provider;
     let model = resolved.model;
     if (!model && provider) {
@@ -1395,10 +1402,11 @@ export function apply(ctx, config) {
     // 节点级思考级别：节点显式配置 > Workflow One 默认档位 > 全局档位（均需同渠道同模型）。
     // 档位经 installModelSelection 注入 agent/request waterfall（AgentOptions 本身不收 effort）。
     const reasoningEffort = resolved.reasoningEffort;
+    // 超时解析链同源：节点 data > Workflow One 默认值 > 内置默认（500s / 300s）。
     // 模型单请求超时（step 粒度）：一次模型调用（含其工具执行前的新型请求）超过即视为卡死，
     // 与节点总超时（timeoutSec，整个节点生命周期）是两个独立旋钮。step/end 重置计时。
-    const MODEL_TIMEOUT_MS = 300 * 1000;
-    const modelTimeoutMs = Number(d.modelTimeoutSec) > 0 ? Number(d.modelTimeoutSec) * 1000 : MODEL_TIMEOUT_MS;
+    const { modelTimeoutSec } = resolveAgentTimeouts({ node: d, defaults: agentDefaults });
+    const modelTimeoutMs = modelTimeoutSec * 1000;
 
     // 工具过滤：与进程内已注册工具求交集（restrict 不接受未知名）
     const wanted = Array.isArray(d.tools) ? d.tools.filter((t) => t && t !== '*') : [];
@@ -2122,7 +2130,13 @@ export function apply(ctx, config) {
     };
 
     const testAbort = new AbortController();
-    const testTimeoutMs = Number(node.data?.timeoutSec) > 0 ? Number(node.data.timeoutSec) * 1000 : 5 * 60 * 1000;
+    // 测试入口超时与正式运行同链：节点 data > Workflow One 默认值（agent 节点）> 内置默认
+    let testFallbackSec = 0;
+    try { testFallbackSec = Number(orch.resolveNodeTimeout?.(node)) || 0; } catch { testFallbackSec = 0; }
+    const testTimeoutSec = Number(node.data?.timeoutSec) > 0
+      ? Number(node.data.timeoutSec)
+      : (testFallbackSec > 0 ? testFallbackSec : DEFAULT_NODE_TIMEOUT_SEC);
+    const testTimeoutMs = testTimeoutSec * 1000;
     let testTimedOut = false;
     const testTimer = setTimeout(() => { testTimedOut = true; testAbort.abort(); }, testTimeoutMs);
     req.once('aborted', () => testAbort.abort());
@@ -3435,11 +3449,12 @@ export function apply(ctx, config) {
 
   // ---- agent 节点默认值（设置面板「Workflow One」）：渠道/模型/思考级别 ----
   // dsh 用户级偏好，不依赖会话工作区（设置面板无 session 上下文），故 scoped: false。
-  // PUT 整体替换三字段；空串 = 该层不设置，回退到 dsh 全局模型选择。
+  // PUT 整体替换五字段；空串/0 = 该层不设置，超时回退内置默认（500s / 300s）。
   const agentDefaultsPayload = async () => {
     const sel = ctx.get('agentDefaultModel')?.currentSelection?.() || {};
     const defaults = agentDefaultsStore.read();
     const effective = resolveAgentModelSelection({ node: {}, defaults, dshSelection: sel });
+    const timeouts = resolveAgentTimeouts({ node: {}, defaults });
     return {
       ok: true,
       defaults,
@@ -3448,6 +3463,8 @@ export function apply(ctx, config) {
         provider: effective.provider || null,
         model: effective.model || null,
         reasoningEffort: effective.reasoningEffort || null,
+        nodeTimeoutSec: timeouts.nodeTimeoutSec,
+        modelTimeoutSec: timeouts.modelTimeoutSec,
       },
       dsh: { provider: sel.provider || null, model: sel.model || null, reasoningEffort: sel.reasoningEffort || null },
     };

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults-api.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults-api.integration.test.mjs
@@ -87,8 +87,8 @@ const test = async (name, fn) => {
 await test('GET 初始为空默认值，effective 跟随 dsh 全局选择', async () => {
   const { status, body } = await call('GET');
   assert.equal(status, 200);
-  assert.deepEqual(body.defaults, { provider: '', model: '', reasoningEffort: '' });
-  assert.deepEqual(body.effective, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium' });
+  assert.deepEqual(body.defaults, { provider: '', model: '', reasoningEffort: '', nodeTimeoutSec: 0, modelTimeoutSec: 0 });
+  assert.deepEqual(body.effective, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium', nodeTimeoutSec: 500, modelTimeoutSec: 300 });
   assert.deepEqual(body.dsh, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium' });
 });
 
@@ -99,12 +99,20 @@ await test('PUT 未知渠道 400 且不落盘', async () => {
   assert.equal(existsSync(join(dshHome, 'plugin-data', 'dsh-ccpg-orchestrator', 'state', 'agent-defaults.json')), false);
 });
 
-await test('PUT 合法三件套 200，effective 生效且 GET 可读回', async () => {
-  const put = await call('PUT', { provider: 'glm', model: 'glm-5', reasoningEffort: '' });
+await test('PUT 合法五件套 200，effective 生效且 GET 可读回', async () => {
+  const put = await call('PUT', { provider: 'glm', model: 'glm-5', reasoningEffort: '', nodeTimeoutSec: 900, modelTimeoutSec: 120 });
   assert.equal(put.status, 200);
-  assert.deepEqual(put.body.effective, { provider: 'glm', model: 'glm-5', reasoningEffort: null });
+  assert.deepEqual(put.body.effective, { provider: 'glm', model: 'glm-5', reasoningEffort: null, nodeTimeoutSec: 900, modelTimeoutSec: 120 });
   const get = await call('GET');
-  assert.deepEqual(get.body.defaults, { provider: 'glm', model: 'glm-5', reasoningEffort: '' });
+  assert.deepEqual(get.body.defaults, { provider: 'glm', model: 'glm-5', reasoningEffort: '', nodeTimeoutSec: 900, modelTimeoutSec: 120 });
+});
+
+await test('PUT 非法超时 400 且不落盘', async () => {
+  const bad = await call('PUT', { provider: 'glm', model: 'glm-5', nodeTimeoutSec: -5 });
+  assert.equal(bad.status, 400);
+  assert.match(bad.body.error, /不小于 0 的整数/);
+  const frac = await call('PUT', { provider: 'glm', model: 'glm-5', modelTimeoutSec: 1.5 });
+  assert.equal(frac.status, 400);
 });
 
 await test('PUT 思考级别校验：支持的放行、不支持的 400', async () => {
@@ -113,7 +121,7 @@ await test('PUT 思考级别校验：支持的放行、不支持的 400', async 
   assert.match(bad.body.error, /不支持思考级别/);
   const good = await call('PUT', { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' });
   assert.equal(good.status, 200);
-  assert.deepEqual(good.body.effective, { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' });
+  assert.deepEqual(good.body.effective, { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high', nodeTimeoutSec: 500, modelTimeoutSec: 300 });
 });
 
 await test('PUT 缺依赖字段 400；清空回退 dsh 全局', async () => {
@@ -122,7 +130,7 @@ await test('PUT 缺依赖字段 400；清空回退 dsh 全局', async () => {
   assert.match(bad.body.error, /先选默认渠道/);
   const cleared = await call('PUT', {});
   assert.equal(cleared.status, 200);
-  assert.deepEqual(cleared.body.effective, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium' });
+  assert.deepEqual(cleared.body.effective, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium', nodeTimeoutSec: 500, modelTimeoutSec: 300 });
 });
 
 await test('POST 方法 405', async () => {
@@ -141,12 +149,12 @@ await test('PUT 畸形 JSON 请求体 400（scoped:false 路由也要有请求�
 await test('llm-config 暴露 wf1Defaults（节点面板展示链与引擎解析链对齐）', async () => {
   const llmRoute = ctx.webServer.routes.find((entry) => entry.kind === 'exact' && entry.path === '/wf1/api/llm-config')?.handler;
   assert.ok(llmRoute, 'llm-config 路由已注册');
-  const put = await call('PUT', { provider: 'glm', model: 'glm-5', reasoningEffort: '' });
+  const put = await call('PUT', { provider: 'glm', model: 'glm-5', reasoningEffort: '', nodeTimeoutSec: 800, modelTimeoutSec: 200 });
   assert.equal(put.status, 200);
   const res = responseCapture();
   await llmRoute(request('GET', '/wf1/api/llm-config'), res);
   const body = res.json();
-  assert.deepEqual(body.wf1Defaults, { provider: 'glm', model: 'glm-5', reasoningEffort: '' });
+  assert.deepEqual(body.wf1Defaults, { provider: 'glm', model: 'glm-5', reasoningEffort: '', nodeTimeoutSec: 800, modelTimeoutSec: 200 });
   // dsh 全局选择字段保持原语义，不受 WF1 默认值影响
   assert.equal(body.defaultProvider, 'deepseek');
   assert.equal(body.defaultModel, 'deepseek-chat');

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults.test.mjs
@@ -8,6 +8,7 @@ import {
   EMPTY_AGENT_DEFAULTS,
   normalizeAgentDefaults,
   resolveAgentModelSelection,
+  resolveAgentTimeouts,
   validateAgentDefaults,
 } from '../lib/agent-defaults.js';
 
@@ -21,18 +22,25 @@ test('normalize: 空对象与缺省字段都落成空默认值', () => {
   assert.deepEqual(normalizeAgentDefaults({ provider: undefined, model: null }), EMPTY_AGENT_DEFAULTS);
 });
 
-test('normalize: 正常字段保留并 trim', () => {
+test('normalize: 正常字段保留并 trim；超时收整数', () => {
   assert.deepEqual(
     normalizeAgentDefaults({ provider: ' deepseek ', model: 'deepseek-chat', reasoningEffort: 'high' }),
-    { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'high' },
+    { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'high', nodeTimeoutSec: 0, modelTimeoutSec: 0 },
+  );
+  assert.deepEqual(
+    normalizeAgentDefaults({ provider: 'deepseek', model: 'deepseek-chat', nodeTimeoutSec: '600', modelTimeoutSec: 240 }),
+    { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: '', nodeTimeoutSec: 600, modelTimeoutSec: 240 },
   );
 });
 
-test('normalize: 拒绝未知字段 / 非字符串 / 非对象', () => {
+test('normalize: 拒绝未知字段 / 非字符串 / 非对象 / 非法超时', () => {
   assert.throws(() => normalizeAgentDefaults({ provider: 'a', extra: 1 }), AgentDefaultsError);
   assert.throws(() => normalizeAgentDefaults({ provider: 42 }), AgentDefaultsError);
   assert.throws(() => normalizeAgentDefaults(null), AgentDefaultsError);
   assert.throws(() => normalizeAgentDefaults('x'), AgentDefaultsError);
+  assert.throws(() => normalizeAgentDefaults({ nodeTimeoutSec: -1 }), /不小于 0 的整数/);
+  assert.throws(() => normalizeAgentDefaults({ modelTimeoutSec: 1.5 }), /不小于 0 的整数/);
+  assert.throws(() => normalizeAgentDefaults({ nodeTimeoutSec: 86401 }), /不能超过/);
 });
 
 test('normalize: model 依赖 provider、思考级别依赖 model', () => {
@@ -101,11 +109,12 @@ test('store: 写入后可读回，落盘 0600', () => {
   const dir = mkdtempSync(join(tmpdir(), 'wf1-agent-defaults-'));
   const file = join(dir, 'sub', 'agent-defaults.json');
   const store = new AgentDefaultsStore(file);
-  store.write({ provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' });
-  assert.deepEqual(store.read(), { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high' });
+  store.write({ provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high', nodeTimeoutSec: 600, modelTimeoutSec: 240 });
+  assert.deepEqual(store.read(), { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high', nodeTimeoutSec: 600, modelTimeoutSec: 240 });
   const doc = JSON.parse(readFileSync(file, 'utf8'));
   assert.equal(doc.version, 1);
   assert.equal(doc.provider, 'deepseek');
+  assert.equal(doc.nodeTimeoutSec, 600);
 });
 
 // ---- resolveAgentModelSelection（与 runAgentNode 同一解析链）----
@@ -173,6 +182,30 @@ test('resolve: 默认档位的下一顺位是 dsh 全局档位', () => {
     dshSelection: SEL,
   });
   assert.equal(r.reasoningEffort, 'medium');
+});
+
+// ---- resolveAgentTimeouts（节点 data > WF1 默认值 > 内置 500/300）----
+
+test('resolveTimeouts: 全空 → 内置默认 500/300', () => {
+  assert.deepEqual(resolveAgentTimeouts({ node: {}, defaults: EMPTY_AGENT_DEFAULTS }), { nodeTimeoutSec: 500, modelTimeoutSec: 300 });
+});
+
+test('resolveTimeouts: WF1 默认值生效（节点未配置时）', () => {
+  assert.deepEqual(
+    resolveAgentTimeouts({ node: {}, defaults: { ...EMPTY_AGENT_DEFAULTS, nodeTimeoutSec: 900, modelTimeoutSec: 120 } }),
+    { nodeTimeoutSec: 900, modelTimeoutSec: 120 },
+  );
+});
+
+test('resolveTimeouts: 节点显式配置永远优先（只覆盖配了的那项）', () => {
+  assert.deepEqual(
+    resolveAgentTimeouts({ node: { timeoutSec: 60 }, defaults: { ...EMPTY_AGENT_DEFAULTS, nodeTimeoutSec: 900, modelTimeoutSec: 120 } }),
+    { nodeTimeoutSec: 60, modelTimeoutSec: 120 },
+  );
+  assert.deepEqual(
+    resolveAgentTimeouts({ node: { modelTimeoutSec: 30 }, defaults: { ...EMPTY_AGENT_DEFAULTS, nodeTimeoutSec: 900 } }),
+    { nodeTimeoutSec: 900, modelTimeoutSec: 30 },
+  );
 });
 
 let failed = 0;

--- a/web/src/NodePanel.jsx
+++ b/web/src/NodePanel.jsx
@@ -152,6 +152,11 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
   // 默认值展示链与引擎解析链（agent-defaults.js）对齐：节点未配置时第一顺位是
   // 设置面板「Workflow One」默认值（wf1Defaults），未设置才回退 dsh 全局选择。
   const wf1Defaults = llmConfig.wf1Defaults || {};
+  // 超时展示（与 resolveAgentTimeouts 同链）：节点未配时实际生效的秒数，placeholder 如实展示
+  const wf1Timeouts = {
+    nodeTimeoutSec: wf1Defaults.nodeTimeoutSec > 0 ? String(wf1Defaults.nodeTimeoutSec) : '500',
+    modelTimeoutSec: wf1Defaults.modelTimeoutSec > 0 ? String(wf1Defaults.modelTimeoutSec) : '300',
+  };
   const wf1Provider = wf1Defaults.provider || '';
   const wf1Model = wf1Provider ? (wf1Defaults.model || null) : null; // 设了渠道没设模型 → 运行时取渠道首选
   const defaultProvider = wf1Provider || llmConfig.defaultProvider || '';
@@ -678,15 +683,15 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
                   placeholder="3" />
               </Field>
               <Field label="节点超时（秒）" hint="整个节点生命周期">
-                <input type="number" min="10" max="3600" value={d.timeoutSec ?? ''}
+                <input type="number" min="10" max="86400" value={d.timeoutSec ?? ''}
                   onChange={(e) => set({ timeoutSec: e.target.value === '' ? undefined : Number(e.target.value) })}
-                  placeholder="500" />
+                  placeholder={wf1Timeouts.nodeTimeoutSec} />
               </Field>
             </div>
             <Field label="单次请求超时（秒）" hint="一次模型调用无响应即判卡死，触发重试">
-              <input type="number" min="10" max="3600" value={d.modelTimeoutSec ?? ''}
+              <input type="number" min="10" max="86400" value={d.modelTimeoutSec ?? ''}
                 onChange={(e) => set({ modelTimeoutSec: e.target.value === '' ? undefined : Number(e.target.value) })}
-                placeholder="300" />
+                placeholder={wf1Timeouts.modelTimeoutSec} />
             </Field>
           </Section>
         </>
@@ -826,9 +831,9 @@ export function NodePanel({ node, onChange, onDelete, onTest, onClose, available
             </Field>
             {nodeType !== 'script' && (
               <Field label="超时（秒）">
-                <input type="number" min="5" max="3600" value={d.timeoutSec ?? ''}
+                <input type="number" min="5" max="86400" value={d.timeoutSec ?? ''}
                   onChange={(e) => set({ timeoutSec: e.target.value === '' ? undefined : Number(e.target.value) })}
-                  placeholder="500" />
+                  placeholder={nodeType === 'agent' ? wf1Timeouts.nodeTimeoutSec : '300'} />
               </Field>
             )}
           </div>

--- a/web/src/agent-default-label.test.mjs
+++ b/web/src/agent-default-label.test.mjs
@@ -25,4 +25,11 @@ assert.match(panel, /const defaultProvider = wf1Provider \|\| llmConfig\.default
 // 思考级别继承链：WF1 档位优先，且要求同渠道同模型（与引擎 resolve 同语义）
 assert.match(panel, /wf1Defaults\.reasoningEffort && wf1Model && effectiveProvider === wf1Provider/, '思考级别继承应先看 WF1 档位');
 
+// 超时占位与引擎 resolveAgentTimeouts 同链：WF1 默认值 > 内置 500/300
+assert.match(panel, /wf1Defaults\.nodeTimeoutSec > 0 \? String\(wf1Defaults\.nodeTimeoutSec\) : '500'/, '节点超时占位应先取 WF1 默认值');
+assert.match(panel, /wf1Defaults\.modelTimeoutSec > 0 \? String\(wf1Defaults\.modelTimeoutSec\) : '300'/, '单次超时占位应先取 WF1 默认值');
+assert.match(panel, /placeholder=\{wf1Timeouts\.nodeTimeoutSec\}/, 'agent 面板节点超时应使用 wf1Timeouts 占位');
+assert.match(panel, /placeholder=\{wf1Timeouts\.modelTimeoutSec\}/, 'agent 面板单次超时应使用 wf1Timeouts 占位');
+assert.match(panel, /nodeType === 'agent' \? wf1Timeouts\.nodeTimeoutSec : '300'/, '容错区超时占位应按节点类型区分（非 agent 内置 300）');
+
 console.log('agent default label tests: passed');


### PR DESCRIPTION
## 背景

设置面板「Workflow One」的 agent 默认值层（#117 渠道/模型/思考级别，#125 展示链对齐）已就绪，但两个超时旋钮（节点总超时 500s / 模型单请求超时 300s）仍只能逐节点配置。本 PR 把它们纳入同一设置面板。

调查中还发现一个隐藏回归：**#122（子工作流）把 engine 的 NODE_TIMEOUT_MS 从 500s 意外改回 300s**，与 #114 定下的 agent 默认 500s 及 UI placeholder 不符——本 PR 一并修复。

## 方案

解析链与模型层同构：**节点 data > Workflow One 默认值 > 内置默认（500/300）**

- **agent-defaults.js**：新增 `nodeTimeoutSec` / `modelTimeoutSec`（正整数秒，0=不设置，上限 86400 防呆）；`resolveAgentTimeouts` 统一解析
- **engine.js**：新增 `resolveNodeTimeout` 注入位——仅 agent 节点吃 WF1 默认值，其余节点类型维持内置 300s 不受影响
- **index.js**：runAgentNode 的单请求超时看门狗、单节点测试入口同步走解析链；agent-defaults API 回包 defaults/effective 带超时；llm-config 的 wf1Defaults 同源下发
- **canvasui 设置面板**：「节点超时(秒) / 单次超时(秒)」两个输入框 + 前端预校验；bundle 已重建防漂移
- **NodePanel**：agent 面板超时 placeholder 如实展示实际生效秒数（WF1 默认值或内置）；容错区占位按节点类型区分（agent 500 / 其他 300）；上限 3600→86400

## 验证

- orchestrator 全部套件（含新增 resolveTimeouts 4 例、PUT 非法超时 2 例）+ web 15 套 + 全仓 `npm test` 绿
- `build-web.sh` 双构建 + canvasui `--check` 通过
- 实机 dsh：PUT 900/180 落盘 ✓、llm-config wf1Defaults 下发 ✓、非法值 400 ✓、旧三字段配置文件读回自动补 0 ✓（已恢复原配置）