### PR TITLE
fix(document-preview): 预览弹窗 markdown 渲染 raw HTML 表格

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,10 @@ jobs:
           # orchestrator 自有依赖（ajv/cron-parser/quickjs）+ 单测可达的 dsh SDK。
           # 本地完整 SDK 经 bootstrap-deps.sh 从 dsh 安装软链；CI 用 registry rc 版
           # （lib/index.js import 四个 SDK 包，集成测试真实加载 apply()）。
-          # document-preview 依赖由 build-document-preview.sh 自装。
+          # document-preview 单测会真实加载 rehype 管线（test/index.test.mjs），
+          # 依赖须在 test 前装好；build-document-preview.sh 的 npm ci 幂等复用。
           npm --prefix dsh-plugins/dsh-ccpg-orchestrator install --no-audit --no-fund
+          npm --prefix dsh-plugins/dsh-ccpg-document-preview install --no-audit --no-fund
           npm install --no-save --no-audit --no-fund @deepseek-ai/schemastery @deepseek-ai/dsh-llm @deepseek-ai/dsh-tools @deepseek-ai/dsh-session
 
       - name: test

--- a/dsh-plugins/dsh-ccpg-document-preview/package-lock.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package-lock.json
@@ -1,30 +1,34 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.1.1",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-ccpg-document-preview",
-      "version": "0.1.1",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@file-viewer/pptx": "2.3.0",
         "docx-preview": "0.4.0",
         "lucide-react": "^1.32.0",
         "pdfjs-dist": "5.6.205",
-        "react-markdown": "^10.1.0",
-        "remark-gfm": "^4.0.1",
+        "react-markdown": ">=9",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
+        "remark-gfm": ">=4",
         "xlsx": "0.18.5"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "4.3.4",
+        "hast-util-to-html": "^9.0.5",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "rehype-stringify": "^10.0.1",
         "vite": "5.4.19"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.15.0"
       },
       "peerDependencies": {
         "@deepseek-ai/schemastery": "*",
@@ -2174,6 +2178,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.21.5",
       "resolved": "https://registry.npmmirror.com/esbuild/-/esbuild-0.21.5.tgz",
@@ -2285,6 +2301,103 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/hast-util-from-parse5": {
+      "version": "8.0.3",
+      "resolved": "https://registry.npmmirror.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
+      "integrity": "sha512-3kxEVkEKt0zvcZ3hCRYI8rqrgwtlIOFMWkbclACvjlDw8Li9S2hk/d51OI0nr/gIpdMHNepwgOKqZ/sy0Clpyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "devlop": "^1.0.0",
+        "hastscript": "^9.0.0",
+        "property-information": "^7.0.0",
+        "vfile": "^6.0.0",
+        "vfile-location": "^5.0.0",
+        "web-namespaces": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-parse-selector": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-parse-selector/-/hast-util-parse-selector-4.0.0.tgz",
+      "integrity": "sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-raw": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmmirror.com/hast-util-raw/-/hast-util-raw-9.1.0.tgz",
+      "integrity": "sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-from-parse5": "^8.0.0",
+        "hast-util-to-parse5": "^8.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "parse5": "^7.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-sanitize": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmmirror.com/hast-util-sanitize/-/hast-util-sanitize-5.0.2.tgz",
+      "integrity": "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "unist-util-position": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmmirror.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -2312,6 +2425,25 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-parse5/-/hast-util-to-parse5-8.0.1.tgz",
+      "integrity": "sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "web-namespaces": "^2.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-whitespace": {
       "version": "3.0.0",
       "resolved": "https://registry.npmmirror.com/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
@@ -2319,6 +2451,23 @@
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hastscript": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmmirror.com/hastscript/-/hastscript-9.0.1.tgz",
+      "integrity": "sha512-g7df9rMFX/SPi34tyGCyUBREQoKkapwdY/T04Qn9TDWfHhAYt4/I0gMVirzK5wEzeUqIjEB+LXC/ypb7Aqno5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-parse-selector": "^4.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -2333,6 +2482,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/iconv-lite": {
@@ -3446,6 +3605,18 @@
       "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
       "license": "MIT"
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/pdfjs-dist": {
       "version": "5.6.205",
       "resolved": "https://registry.npmmirror.com/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
@@ -3587,6 +3758,51 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/rehype-raw": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/rehype-raw/-/rehype-raw-7.0.0.tgz",
+      "integrity": "sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-raw": "^9.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-sanitize": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmmirror.com/rehype-sanitize/-/rehype-sanitize-6.0.0.tgz",
+      "integrity": "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-sanitize": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmmirror.com/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {
@@ -3991,6 +4207,20 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/vfile-location": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmmirror.com/vfile-location/-/vfile-location-5.0.3.tgz",
+      "integrity": "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/vfile-message": {
       "version": "4.0.3",
       "resolved": "https://registry.npmmirror.com/vfile-message/-/vfile-message-4.0.3.tgz",
@@ -4063,6 +4293,16 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/web-namespaces": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/web-namespaces/-/web-namespaces-2.0.1.tgz",
+      "integrity": "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/wmf": {

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -37,8 +37,10 @@
     "docx-preview": "0.4.0",
     "lucide-react": "^1.32.0",
     "pdfjs-dist": "5.6.205",
-    "react-markdown": "^10.1.0",
-    "remark-gfm": "^4.0.1",
+    "react-markdown": ">=9",
+    "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
+    "remark-gfm": ">=4",
     "xlsx": "0.18.5"
   },
   "peerDependencies": {
@@ -55,8 +57,10 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "4.3.4",
+    "hast-util-to-html": "^9.0.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "rehype-stringify": "^10.0.1",
     "vite": "5.4.19"
   },
   "dsh": {

--- a/dsh-plugins/dsh-ccpg-document-preview/scripts/build.mjs
+++ b/dsh-plugins/dsh-ccpg-document-preview/scripts/build.mjs
@@ -17,7 +17,7 @@ await build({
     cssCodeSplit: false,
     lib: { entry: resolve(root, 'src/react.jsx'), formats: ['es'], fileName: () => 'react.js' },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react-dom/client', 'react-markdown', 'remark-gfm'],
+      external: ['react', 'react-dom', 'react-dom/client', 'react-markdown', 'remark-gfm', 'rehype-raw', 'rehype-sanitize'],
       output: {
         assetFileNames: (asset) => asset.name?.endsWith('.css') ? 'document-preview.css' : 'assets/[name]-[hash][extname]',
         chunkFileNames: 'renderers/[name]-[hash].js',

--- a/dsh-plugins/dsh-ccpg-document-preview/src/markdown-sanitize.mjs
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/markdown-sanitize.mjs
@@ -1,0 +1,18 @@
+// react-markdown 的 sanitize 白名单：与画布卡片侧（web/src/MarkdownDocument.jsx）
+// 同款配置。独立成纯 .mjs 是为了 node --test 能在无 JSX 加载器环境下直接单测；
+// src/react.jsx 具名导入使用。
+import { defaultSchema } from 'rehype-sanitize';
+
+// agent 产出的文稿常见「markdown 套 HTML 表格」混合格式：rehype-raw 放行原始
+// HTML 后，这里以白名单收口防脚本注入；td/th 的 colspan/rowspan/内联样式放行。
+export const markdownSanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [
+    ...(defaultSchema.tagNames || []),
+    'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'col', 'colgroup', 'caption', 'br',
+  ],
+  attributes: {
+    ...defaultSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] || []), 'style', 'align', 'colspan', 'rowspan'],
+  },
+};

--- a/dsh-plugins/dsh-ccpg-document-preview/src/react.jsx
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/react.jsx
@@ -3,6 +3,9 @@ import { createPortal } from 'react-dom';
 import { Download, Expand, Eye, Minimize, X } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize from 'rehype-sanitize';
+import { markdownSanitizeSchema } from './markdown-sanitize.mjs';
 import { documentPreviewKind, loadPreviewText, normalizePreviewDocument, previewErrorMessage } from './index.js';
 import './styles.css';
 
@@ -63,11 +66,14 @@ function TextRenderer({ document, kind, maxTextBytes }) {
 
 // react-markdown + GFM：完整表格/任务列表/删除线/脚注等；此前手写解析器只会
 // 标题/代码块/列表/段落，表格、粗体、行内代码、链接、引用全部原样漏出。
+// rehype-raw + sanitize 管线与画布卡片侧（web/src/MarkdownDocument.jsx）对齐：
+// 正文里嵌的 <table>/<br/> 等 raw HTML 原地渲染，白名单在 markdown-sanitize.mjs。
 function Markdown({ text }) {
   return (
     <article className="dsh-doc-preview-scroll dsh-doc-preview-markdown">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
+        rehypePlugins={[rehypeRaw, [rehypeSanitize, markdownSanitizeSchema]]}
         components={{
           a: ({ children, ...props }) => <a {...props} target="_blank" rel="noreferrer">{children}</a>,
           table: ({ node, ...props }) => <div className="md-table-wrap"><table {...props} /></div>,

--- a/dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs
+++ b/dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs
@@ -14,6 +14,7 @@ import {
   documentPreviewKind,
   normalizePreviewDocument,
 } from '../src/index.js';
+import { markdownSanitizeSchema } from '../src/markdown-sanitize.mjs';
 
 test('detects supported preview formats by extension', () => {
   const cases = {
@@ -110,6 +111,45 @@ test('host entry declares the plugin shape and serves client-assets static files
 
 test('apply tolerates a missing webServer', () => {
   assert.doesNotThrow(() => apply({ logger: { info() {} } }));
+});
+
+// ---- markdown 渲染管线 ----
+
+// 与画布卡片侧（web/src/MarkdownDocument.jsx）同款管线：raw HTML 表格（agent 产出
+// 文稿的常见混合格式）要放行，脚本注入向量要在 sanitize 白名单处拦下。
+test('markdown: unified pipeline renders raw HTML table and strips script vectors', async () => {
+  const { unified } = await import('unified');
+  const remarkParse = (await import('remark-parse')).default;
+  const remarkRehype = (await import('remark-rehype')).default;
+  const rehypeRaw = (await import('rehype-raw')).default;
+  const rehypeSanitize = (await import('rehype-sanitize')).default;
+  const rehypeStringify = (await import('rehype-stringify')).default;
+
+  const run = async (text) => String(await unified()
+    .use(remarkParse)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypeSanitize, markdownSanitizeSchema)
+    .use(rehypeStringify)
+    .process(text));
+
+  // 「markdown 套 HTML 表格」：标题走 markdown、表格走 raw HTML（colspan/rowspan/<b> 原样保留）
+  const table = await run('# 保洁服务岗位工作流程表\n\n<table><tr><td colspan="5"><b>楼栋岗工作流程表</b></td></tr>'
+    + '<tr><th>类别</th><th>时间</th></tr>'
+    + '<tr><td rowspan="2">日常工作</td><td>07:00-12:00</td></tr></table>\n');
+  assert.match(table, /<h1>保洁服务岗位工作流程表<\/h1>/);
+  assert.match(table, /<td colspan="5"><b>楼栋岗工作流程表<\/b><\/td>/);
+  assert.match(table, /<th>类别<\/th>/);
+  assert.match(table, /<td rowspan="2">日常工作<\/td>/);
+
+  // sanitize 白名单收口：脚本与事件处理器不得漏出
+  const hostile = await run('<table><tr><td onclick="steal()">x</td></tr></table>'
+    + '<img src=x onerror="steal()"><script>alert(1)<\/script><iframe src="https://evil"></iframe>');
+  assert.ok(!hostile.includes('steal'), hostile);
+  assert.ok(!hostile.includes('script'), hostile);
+  assert.ok(!hostile.includes('iframe'), hostile);
+  // style 整串透传（与卡片侧同取舍，td 的 vertical-align 需要它）：合法值保留
+  assert.ok((await run('<table><tr><td style="vertical-align:top">x</td></tr></table>')).includes('vertical-align:top'));
 });
 
 


### PR DESCRIPTION
## 背景

用户报告文稿预览弹窗里 markdown 内嵌 HTML 表格渲染成源码墙（同一份内容在画布流卡里渲染正常）。根因：预览弹窗的 `Markdown` 组件只挂了 `remark-gfm`，没有 raw HTML 管线；画布卡片侧（web/src/MarkdownDocument.jsx）在 PR #111 已用 `rehype-raw + rehype-sanitize` 修复，预览侧没跟上。

## 方案

- `src/markdown-sanitize.mjs`（新）：sanitize 白名单独立成纯 `.mjs`，供 `node --test` 在无 JSX 加载器环境下直接单测；`src/react.jsx` 具名导入使用。白名单与卡片侧同款：放行 `table/thead/tbody/tr/td/th/col/colgroup/caption/br` 与 `colspan/rowspan/style/align`
- `src/react.jsx`：`ReactMarkdown` 挂 `rehype-raw + rehype-sanitize`，`<table>/<br/>` 等 raw HTML 原地渲染，脚本注入在白名单处拦下
- `scripts/build.mjs`：`dist/react.js` 的 external 清单补 `rehype-raw`/`rehype-sanitize`（web 画布消费）；官方 UI runtime.js 仍自包含内联（已在产物中确认 parse5 等全部打进 client chunk）
- `package.json`：dependencies 补 `rehype-raw ^7.0.0`、`rehype-sanitize ^6.0.0`（与 web 侧同版本）；devDependencies 补 `hast-util-to-html`、`rehype-stringify`（测试序列化用）
- `test/index.test.mjs`：新增管线用例——「markdown 标题 + raw HTML 表格」混合内容原样渲染（colspan/rowspan/`<b>` 保留），`script`/`iframe`/`onclick`/`onerror` 注入向量剔除，合法内联样式（vertical-align）保留

## 验证

- 插件单测 11 例全绿（原 10 + 新增管线用例）
- 全量 `npm test`、`build-web.sh` 双构建通过
- 真实浏览器加载 `dist/react.js`，以用户报告的「8.1.4 保洁服务岗位工作流程表」原始样本实测：24 行全部渲染（标题行 colspan=5、责任人行、5 列表头、rowspan=13/7 两个分组、临时工作行），3 处 `<b>` 加粗、午餐 colspan=2、末行台风内容在位，无源码墙残留，表格自然宽度 850px 无挤压