### PR TITLE
fix(orchestrator): agent 节点收尾兼容 dsh-session 新 API，修「events is not iterable」

### DIFF
--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -1481,7 +1481,7 @@ export function apply(ctx, config) {
         let turns = 0; let preview = ''; let turnEnded = false;
         let lastStepStartSeq = -1; let stepsSeen = 0;
         try {
-          for (const ev of agent.session.events) {
+          for (const ev of sessionEventsOf(agent.session)) {
             if (ev.seq < firstSeq) continue;
             if (ev.type === 'turn/start') turns += 1;
             if (ev.type === 'turn/end') turnEnded = true;
@@ -1535,7 +1535,7 @@ export function apply(ctx, config) {
         // 视为该次模型调用卡死，cancel 本节点（区别于 timeoutSec 的节点总超时）。
         // 以事件序号驱动：step/end 或任何新事件落盘都会刷新 lastActivitySeq。
         if (!turnEnded && stepsSeen > 0) {
-          const events = agent.session.events;
+          const events = sessionEventsOf(agent.session);
           const lastSeq = events.length ? events[events.length - 1].seq : firstSeq;
           if (lastStepStartSeq > 0 && lastSeq === lastStepStartSeq && !watchState.rechecking) {
             const stepAgeMs = Date.now() - (watchState.stepStartedAt || Date.now());
@@ -1596,7 +1596,7 @@ export function apply(ctx, config) {
       await agent.whenIdle().catch(() => {});
       try { await ctx.get('sessions').flush(agent.session); } catch { /* flush 失败不影响结果 */ }
 
-      let { text, reason } = summarize(agent.session.events, firstSeq);
+      let { text, reason } = summarize(sessionEventsOf(agent.session), firstSeq);
       // 模型请求看门狗触发：取消导致的「正常收尾」要改写为显式超时错误，
       // 让引擎的重试机制（非取消类失败）能接手
       if (watchState.modelTimeout) {
@@ -1613,7 +1613,7 @@ export function apply(ctx, config) {
               source: { kind: 'user' },
             }));
             await agent.whenIdle();
-            const repaired = summarize(agent.session.events, repairSeq);
+            const repaired = summarize(sessionEventsOf(agent.session), repairSeq);
             reason = repaired.reason;
             if (reason?.kind === 'error') throw reason.error || new Error('结构化输出修复请求失败');
             return repaired.text;
@@ -1630,15 +1630,15 @@ export function apply(ctx, config) {
       }
       const inputFileSet = new Set(inputFiles);
       const artifacts = safeWsList(ws).filter((file) => !inputFileSet.has(file));
-      const usage = sumUsage(agent.session.events, firstSeq);
+      const usage = sumUsage(sessionEventsOf(agent.session), firstSeq);
       const details = {
         model: `${provider}:${model}`,
         runtime: 'dsh-plugin',
-        turns: countTurns(agent.session.events, firstSeq),
+        turns: countTurns(sessionEventsOf(agent.session), firstSeq),
         artifacts,
         sessionId: String(agent.id || ''),
         // 过程轨迹（详情弹窗数据源）：渲染后的输入 + 轮次/工具调用/助手文本时间线
-        trace: buildTrace(agent.session.events, firstSeq, { input: userPrompt, model: `${provider}:${model}` }),
+        trace: buildTrace(sessionEventsOf(agent.session), firstSeq, { input: userPrompt, model: `${provider}:${model}` }),
         input: rendered.text || '(无上游输入)',
         ...(structuredMeta ? { structuredMeta } : {}),
         ...(usage ? { usage } : {}),
@@ -3602,6 +3602,18 @@ export function apply(ctx, config) {
 
 // ---------------- helpers ----------------
 
+// dsh-session 0.1.2-alpha.5 起删除了 Session.events getter（改为 snapshotEvents() 方法）。
+// 引擎消费的是运行中 agent 的 session：新 SDK 走 snapshotEvents()，旧 SDK 回退 .events；
+// 两者都不是数组（session 已释放等异常形态）时给空数组，让收尾逻辑按「无事件」降级
+// 而不是抛「events is not iterable」吞掉整个节点结果。
+export function sessionEventsOf(session) {
+  if (!session) return [];
+  if (typeof session.snapshotEvents === 'function') {
+    try { return session.snapshotEvents() || []; } catch { return []; }
+  }
+  return Array.isArray(session.events) ? session.events : [];
+}
+
 // agent 过程轨迹：把本节点产生的 session 事件折叠成 UI 可直接渲染的时间线。
 // entries: {kind:'input'|'assistant'|'tool', ...}；工具调用与结果按 callId 配对成一条。
 function buildTrace(events, firstSeq, meta = {}) {
@@ -3668,12 +3680,13 @@ export function finalizeTrace(trace, meta = {}) {
   }
 }
 
-// 旧运行记录（无 trace 快照）按 sessionId 从 dsh 会话存档现场回放轨迹
+// 旧运行记录（无 trace 快照）按 sessionId 从 dsh 会话存档现场回放轨迹。
+// persistence.load 返回 inspection（.events 数组，新旧 SDK 同形）。
 async function replayTrace(sessionId) {
   const persistence = ctxRef?.sessionPersistence;
   if (!persistence || !sessionId) return null;
   const insp = await persistence.load(sessionId);
-  return buildTrace(insp.events, 0, { input: '', model: '' });
+  return buildTrace(Array.isArray(insp?.events) ? insp.events : [], 0, { input: '', model: '' });
 }
 
 function summarize(events, firstSeq) {

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/live-trace.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/live-trace.test.mjs
@@ -1,8 +1,10 @@
 // 实时轨迹单测（issue #52）：foldTraceEvent 增量折叠与 buildTrace 全量产出同语义；
 // 折叠语义回归：input/inject/assistant/tool(call+result 配对)/turn-end。
+// sessionEventsOf 兼容层：dsh-session 0.1.2-alpha.5 删除 Session.events getter 后
+// 引擎收尾（summarize/countTurns/sumUsage）不再抛「events is not iterable」。
 import assert from 'node:assert/strict';
 
-const { foldTraceEvent, finalizeTrace } = await import('../lib/index.js');
+const { foldTraceEvent, finalizeTrace, sessionEventsOf } = await import('../lib/index.js');
 
 let passed = 0;
 const test = (name, fn) => Promise.resolve()
@@ -79,6 +81,27 @@ await test('失败结果 isError=true → ok=false；成功不带 error 字段',
   foldTraceEvent(trace, { seq: 2, type: 'tool/result', data: { message: { content: [{ type: 'tool-result', toolCallId: 'x', isError: true, content: [{ type: 'text', text: 'exit 1' }] }] } } }, pending, meta);
   assert.equal(trace.entries[1].result.ok, false);
   assert.equal(trace.entries[1].result.error, undefined);
+});
+
+await test('sessionEventsOf：新 SDK（snapshotEvents 方法）优先，旧 SDK（.events 数组）回退', () => {
+  const events = [{ seq: 0, type: 'turn/start', data: {} }];
+  const modern = { snapshotEvents: () => events };
+  const legacy = { events };
+  assert.equal(sessionEventsOf(modern), events);
+  assert.equal(sessionEventsOf(legacy), events);
+  // 两者都有时新 API 优先（snapshotEvents 是当前契约）
+  const both = { snapshotEvents: () => events, events: ['stale'] };
+  assert.equal(sessionEventsOf(both), events);
+});
+
+await test('sessionEventsOf：异常形态降级为空数组，不再抛「events is not iterable」', () => {
+  assert.deepEqual(sessionEventsOf(null), []);
+  assert.deepEqual(sessionEventsOf(undefined), []);
+  assert.deepEqual(sessionEventsOf({}), []);
+  // snapshotEvents 抛错（session 已释放等）也降级为空数组
+  assert.deepEqual(sessionEventsOf({ snapshotEvents: () => { throw new Error('released'); } }), []);
+  // 旧 SDK 形态但 .events 非数组
+  assert.deepEqual(sessionEventsOf({ events: undefined }), []);
 });
 
 console.log(process.exitCode ? 'live-trace tests: FAIL' : `live-trace tests: ALL PASS (${passed})`);


### PR DESCRIPTION
## 背景

用户报告正在运行的工作流中 agent 节点（3.1-交通停车沿革编制）跑完 112.3s 后报错 `events is not iterable`：无输出、无用量记录、纯错误串。

## 根因

dsh-session **0.1.2-alpha.5**（随今晨 01:54 全局 dsh 0.1.2-alpha.4 升级引入，已实测确认：0.1.0-rc.8 有 `get events()`，0.1.2-alpha.5 已删除，只留 `snapshotEvents()` 方法）删除了 `Session.events` getter。

引擎 agent 节点多处裸访问 `agent.session.events` → 新 SDK 下是 `undefined` → `for...of` 抛 `events is not iterable`：

- 轮询 `scanEvents`（index.js:1484）有 try/catch 静默——所以节点运行全程看似正常（进度流里轮数/预览全空但不报错）
- **收尾路径无保护**：`summarize`（1599）第一个裸迭代即抛，节点结果（输出/用量/turns/trace）整体被吞——这正是用户看到的症状

## 方案

- `sessionEventsOf(session)` 兼容读取：新 SDK 走 `snapshotEvents()`（try/catch 降级空数组，覆盖 session 已释放形态），旧 SDK 回退 `.events` 数组；`persistence.load` 回放的 `insp.events` 加 `Array.isArray` 防御
- 替换全部 8 处裸 `.events` 访问（scanEvents/看门狗/summarize×2/sumUsage/countTurns/buildTrace/replayTrace）
- 降级语义：取不到事件按「无事件」收尾（输出回退 `'(agent 无输出)'`），不再吞掉整个节点

## 验证

- live-trace 新增 2 例：新旧 session 形态取值优先级（两者都有时新 API 优先）、异常形态（null/undefined/{} /snapshotEvents 抛错/events 非数组）降级空数组不抛错
- orchestrator 30 套全绿、全量 `npm test` 通过

## 运维说明

正在跑的工作流里已报错的节点需重跑（断点续跑即可）；dsh 进程须彻底重启后插件 HMR 才会加载新代码（`pkill -f 'dsh web'` 后重启）。