### PR TITLE
feat(orchestrator): 设置面板支持 agent 节点通用提示词（#129）

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -1055,7 +1055,7 @@ window.__ModuleLoader__.load({
     function AgentDefaultsCard() {
       var a = s2(null), llmConfig = a[0], setLlmConfig = a[1];
       var b = s2(null), saved = b[0], setSaved = b[1]; // GET/PUT 回包 {defaults, effective, dsh}
-      var c = s2({ provider: "", model: "", reasoningEffort: "", nodeTimeoutSec: 0, modelTimeoutSec: 0 }), draft = c[0], setDraft = c[1];
+      var c = s2({ provider: "", model: "", reasoningEffort: "", nodeTimeoutSec: 0, modelTimeoutSec: 0, systemPrompt: "" }), draft = c[0], setDraft = c[1];
       var e = s2(false), saving = e[0], setSaving = e[1];
       var f = s2(null), message = f[0], setMessage = f[1]; // {kind:'ok'|'err', text}
 
@@ -1067,7 +1067,7 @@ window.__ModuleLoader__.load({
         systemGet(AGENT_DEFAULTS_API).then(function (d2) {
           if (dead || !d2 || !d2.ok) return;
           setSaved(d2);
-          setDraft(Object.assign({ provider: "", model: "", reasoningEffort: "", nodeTimeoutSec: 0, modelTimeoutSec: 0 }, d2.defaults));
+          setDraft(Object.assign({ provider: "", model: "", reasoningEffort: "", nodeTimeoutSec: 0, modelTimeoutSec: 0, systemPrompt: "" }, d2.defaults));
         }).catch(function () {});
         return function () { dead = true; };
       }, []);
@@ -1079,6 +1079,7 @@ window.__ModuleLoader__.load({
         || draft.reasoningEffort !== saved.defaults.reasoningEffort
         || Number(draft.nodeTimeoutSec || 0) !== Number(saved.defaults.nodeTimeoutSec || 0)
         || Number(draft.modelTimeoutSec || 0) !== Number(saved.defaults.modelTimeoutSec || 0)
+        || String(draft.systemPrompt || "") !== String(saved.defaults.systemPrompt || "")
       );
 
       var patchDraft = function (patch) {
@@ -1093,6 +1094,7 @@ window.__ModuleLoader__.load({
         var payload = Object.assign({}, draft, {
           nodeTimeoutSec: Math.max(0, Math.floor(Number(draft.nodeTimeoutSec) || 0)),
           modelTimeoutSec: Math.max(0, Math.floor(Number(draft.modelTimeoutSec) || 0)),
+          systemPrompt: String(draft.systemPrompt || ""),
         });
         if (draft.nodeTimeoutSec !== "" && (!Number.isFinite(Number(draft.nodeTimeoutSec)) || Number(draft.nodeTimeoutSec) < 0)
           || draft.modelTimeoutSec !== "" && (!Number.isFinite(Number(draft.modelTimeoutSec)) || Number(draft.modelTimeoutSec) < 0)) {
@@ -1109,7 +1111,7 @@ window.__ModuleLoader__.load({
           .then(function (r2) {
             if (r2 && r2.ok) {
               setSaved(r2);
-              setDraft(Object.assign({ provider: "", model: "", reasoningEffort: "", nodeTimeoutSec: 0, modelTimeoutSec: 0 }, r2.defaults));
+              setDraft(Object.assign({ provider: "", model: "", reasoningEffort: "", nodeTimeoutSec: 0, modelTimeoutSec: 0, systemPrompt: "" }, r2.defaults));
               setMessage({ kind: "ok", text: "已保存，新发起的运行立即生效" });
             } else {
               setMessage({ kind: "err", text: (r2 && r2.error) || "保存失败" });
@@ -1206,6 +1208,36 @@ window.__ModuleLoader__.load({
                 )),
                 defaultsField("节点超时(秒)", mkTimeoutInput("nodeTimeoutSec", "默认 500")),
                 defaultsField("单次超时(秒)", mkTimeoutInput("modelTimeoutSec", "默认 300")),
+                // 通用提示词：跨节点行为约束，注入所有 agent 节点系统提示词的末尾。
+                // 独立成块放在字段行之后（多行文本不适合 72px 标签行的紧凑布局）
+                react.createElement(
+                  "div",
+                  { key: "systemPrompt", style: { display: "flex", flexDirection: "column", gap: "4px" } },
+                  react.createElement(
+                    "div",
+                    { style: { fontSize: "13px", color: "var(--dsw-alias-text-secondary)" } },
+                    "通用提示词",
+                    react.createElement(
+                      "span",
+                      { style: { marginLeft: "6px", fontSize: "11px", opacity: 0.75 } },
+                      "注入所有 agent 节点提示词末尾的行为约束；留空不注入",
+                    ),
+                  ),
+                  react.createElement("textarea", {
+                    value: draft.systemPrompt || "",
+                    disabled: saving,
+                    placeholder: "例：\n- 输出统一使用中文\n- 交付物直接给结论，不要寒暄\n- 物业术语遵循公司规范手册",
+                    style: {
+                      width: "100%", minHeight: "72px", padding: "6px 8px", borderRadius: "8px",
+                      fontSize: "13px", lineHeight: "20px", resize: "vertical", boxSizing: "border-box",
+                      fontFamily: "inherit",
+                      border: "1px solid var(--dsw-alias-border-secondary, rgba(128,128,128,.3))",
+                      background: "var(--dsw-alias-bg-primary, transparent)",
+                      color: "var(--dsw-alias-label-primary)",
+                    },
+                    onChange: function (ev) { patchDraft({ systemPrompt: ev.target.value }); },
+                  }),
+                ),
               ],
         react.createElement(
           "div",

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/agent-defaults.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/agent-defaults.js
@@ -13,7 +13,9 @@ import { homedir } from 'node:os';
 import { randomUUID } from 'node:crypto';
 
 const MAX_FIELD_LENGTH = 200;
-const ALLOWED_KEYS = new Set(['provider', 'model', 'reasoningEffort', 'nodeTimeoutSec', 'modelTimeoutSec']);
+// 通用提示词是段落级文本：允许换行、给足长度，但设防呆上限。
+const MAX_SYSTEM_PROMPT_LENGTH = 8000;
+const ALLOWED_KEYS = new Set(['provider', 'model', 'reasoningEffort', 'nodeTimeoutSec', 'modelTimeoutSec', 'systemPrompt']);
 // 超时字段：正整数秒，0/空 = 不设置（回退内置默认 500s / 300s）。上限 86400（一天）防呆。
 const TIMEOUT_KEYS = new Set(['nodeTimeoutSec', 'modelTimeoutSec']);
 const MAX_TIMEOUT_SEC = 86400;
@@ -39,9 +41,10 @@ export const agentDefaultsFile = () => join(
 export const EMPTY_AGENT_DEFAULTS = Object.freeze({
   provider: '', model: '', reasoningEffort: '',
   nodeTimeoutSec: 0, modelTimeoutSec: 0,
+  systemPrompt: '',
 });
 
-/** 输入整形：三个字符串字段 + 两个超时（秒，0 = 不设置）。 */
+/** 输入整形：三个字符串字段 + 两个超时（秒，0 = 不设置）+ 通用提示词（段落文本）。 */
 export function normalizeAgentDefaults(source) {
   if (source === null || typeof source !== 'object' || Array.isArray(source)) fail('请求体必须是对象');
   for (const key of Object.keys(source)) {
@@ -56,6 +59,13 @@ export function normalizeAgentDefaults(source) {
       if (!Number.isFinite(num) || num < 0 || !Number.isInteger(num)) fail(`${key} 必须是不小于 0 的整数（秒）`);
       if (num > MAX_TIMEOUT_SEC) fail(`${key} 不能超过 ${MAX_TIMEOUT_SEC} 秒`);
       result[key] = num;
+      continue;
+    }
+    if (key === 'systemPrompt') {
+      if (typeof value !== 'string') fail('systemPrompt 必须是字符串');
+      if (value.length > MAX_SYSTEM_PROMPT_LENGTH) fail(`systemPrompt 最长 ${MAX_SYSTEM_PROMPT_LENGTH} 个字符`);
+      // 保留换行与内部空白（约束文本常是多行列表），只去掉首尾空白
+      result.systemPrompt = value.trim();
       continue;
     }
     if (typeof value !== 'string') fail(`${key} 必须是字符串`);
@@ -172,4 +182,14 @@ export function resolveAgentTimeouts({ node = {}, defaults = EMPTY_AGENT_DEFAULT
     ? Number(node.modelTimeoutSec)
     : (defaults.modelTimeoutSec > 0 ? defaults.modelTimeoutSec : DEFAULT_MODEL_TIMEOUT_SEC);
   return { nodeTimeoutSec, modelTimeoutSec };
+}
+
+/**
+ * 通用提示词段（设置面板「Workflow One」配置的部署级行为约束，issue #129）。
+ * 注入系统提示词尾部：节点提示词定义「做什么」，通用约束修正「怎么做」，
+ * 尾部位置保证它覆盖前面的行为指令。空串返回空串（调用方直接跳过拼接）。
+ */
+export function agentCommonPromptSection(defaults = EMPTY_AGENT_DEFAULTS) {
+  const text = typeof defaults?.systemPrompt === 'string' ? defaults.systemPrompt.trim() : '';
+  return text ? `## 通用约束\n\n${text}` : '';
 }

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -75,8 +75,8 @@ import {
 } from './assistant.js';
 import { ensureWorkflowSkill } from './skill-seed.js';
 import {
-  AgentDefaultsError, AgentDefaultsStore, DEFAULT_NODE_TIMEOUT_SEC, normalizeAgentDefaults,
-  resolveAgentModelSelection, resolveAgentTimeouts, validateAgentDefaults,
+  AgentDefaultsError, AgentDefaultsStore, DEFAULT_NODE_TIMEOUT_SEC, agentCommonPromptSection,
+  normalizeAgentDefaults, resolveAgentModelSelection, resolveAgentTimeouts, validateAgentDefaults,
 } from './agent-defaults.js';
 import {
   assertNonSensitiveVariableDefinitions, assertSafeContextObject, GlobalVariableStore, VariableStoreError,
@@ -1354,6 +1354,10 @@ export function apply(ctx, config) {
     if (skillIds.some((x) => x === 'feishu-cli') && larkCliAvailable()) {
       systemPrompt += `\n\n飞书操作：本机装有 lark-cli（飞书官方 CLI，在 dsh 设置「飞书账号」扫码授权一次即可）。默认身份已固定为 user，执行 lark-cli 命令默认加 --as user；user token 由宿主后台自动续约，无需关心过期。user 身份报错/授权失效时降级 --as bot 并在结果注明"需用户重新扫码"。详见技能 feishu-cli。输出 JSON 信封，成功看 ok==true。`;
     }
+    // 通用提示词（设置面板「Workflow One」，issue #129）：部署级行为约束，
+    // 尾部注入——节点提示词定义「做什么」，通用约束修正「怎么做」并覆盖前面指令
+    const commonPromptSection = agentCommonPromptSection(agentDefaults);
+    if (commonPromptSection) systemPrompt += `\n\n${commonPromptSection}`;
 
     // 用户输入 = 模板渲染 + 附件复制进工作区
     const tctx = {

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -1481,7 +1481,7 @@ export function apply(ctx, config) {
         let turns = 0; let preview = ''; let turnEnded = false;
         let lastStepStartSeq = -1; let stepsSeen = 0;
         try {
-          for (const ev of agent.session.events) {
+          for (const ev of sessionEventsOf(agent.session)) {
             if (ev.seq < firstSeq) continue;
             if (ev.type === 'turn/start') turns += 1;
             if (ev.type === 'turn/end') turnEnded = true;
@@ -1535,7 +1535,7 @@ export function apply(ctx, config) {
         // 视为该次模型调用卡死，cancel 本节点（区别于 timeoutSec 的节点总超时）。
         // 以事件序号驱动：step/end 或任何新事件落盘都会刷新 lastActivitySeq。
         if (!turnEnded && stepsSeen > 0) {
-          const events = agent.session.events;
+          const events = sessionEventsOf(agent.session);
           const lastSeq = events.length ? events[events.length - 1].seq : firstSeq;
           if (lastStepStartSeq > 0 && lastSeq === lastStepStartSeq && !watchState.rechecking) {
             const stepAgeMs = Date.now() - (watchState.stepStartedAt || Date.now());
@@ -1596,7 +1596,7 @@ export function apply(ctx, config) {
       await agent.whenIdle().catch(() => {});
       try { await ctx.get('sessions').flush(agent.session); } catch { /* flush 失败不影响结果 */ }
 
-      let { text, reason } = summarize(agent.session.events, firstSeq);
+      let { text, reason } = summarize(sessionEventsOf(agent.session), firstSeq);
       // 模型请求看门狗触发：取消导致的「正常收尾」要改写为显式超时错误，
       // 让引擎的重试机制（非取消类失败）能接手
       if (watchState.modelTimeout) {
@@ -1613,7 +1613,7 @@ export function apply(ctx, config) {
               source: { kind: 'user' },
             }));
             await agent.whenIdle();
-            const repaired = summarize(agent.session.events, repairSeq);
+            const repaired = summarize(sessionEventsOf(agent.session), repairSeq);
             reason = repaired.reason;
             if (reason?.kind === 'error') throw reason.error || new Error('结构化输出修复请求失败');
             return repaired.text;
@@ -1630,15 +1630,15 @@ export function apply(ctx, config) {
       }
       const inputFileSet = new Set(inputFiles);
       const artifacts = safeWsList(ws).filter((file) => !inputFileSet.has(file));
-      const usage = sumUsage(agent.session.events, firstSeq);
+      const usage = sumUsage(sessionEventsOf(agent.session), firstSeq);
       const details = {
         model: `${provider}:${model}`,
         runtime: 'dsh-plugin',
-        turns: countTurns(agent.session.events, firstSeq),
+        turns: countTurns(sessionEventsOf(agent.session), firstSeq),
         artifacts,
         sessionId: String(agent.id || ''),
         // 过程轨迹（详情弹窗数据源）：渲染后的输入 + 轮次/工具调用/助手文本时间线
-        trace: buildTrace(agent.session.events, firstSeq, { input: userPrompt, model: `${provider}:${model}` }),
+        trace: buildTrace(sessionEventsOf(agent.session), firstSeq, { input: userPrompt, model: `${provider}:${model}` }),
         input: rendered.text || '(无上游输入)',
         ...(structuredMeta ? { structuredMeta } : {}),
         ...(usage ? { usage } : {}),
@@ -3602,6 +3602,18 @@ export function apply(ctx, config) {
 
 // ---------------- helpers ----------------
 
+// dsh-session 0.1.2-alpha.5 起删除了 Session.events getter（改为 snapshotEvents() 方法）。
+// 引擎消费的是运行中 agent 的 session：新 SDK 走 snapshotEvents()，旧 SDK 回退 .events；
+// 两者都不是数组（session 已释放等异常形态）时给空数组，让收尾逻辑按「无事件」降级
+// 而不是抛「events is not iterable」吞掉整个节点结果。
+export function sessionEventsOf(session) {
+  if (!session) return [];
+  if (typeof session.snapshotEvents === 'function') {
+    try { return session.snapshotEvents() || []; } catch { return []; }
+  }
+  return Array.isArray(session.events) ? session.events : [];
+}
+
 // agent 过程轨迹：把本节点产生的 session 事件折叠成 UI 可直接渲染的时间线。
 // entries: {kind:'input'|'assistant'|'tool', ...}；工具调用与结果按 callId 配对成一条。
 function buildTrace(events, firstSeq, meta = {}) {
@@ -3668,12 +3680,13 @@ export function finalizeTrace(trace, meta = {}) {
   }
 }
 
-// 旧运行记录（无 trace 快照）按 sessionId 从 dsh 会话存档现场回放轨迹
+// 旧运行记录（无 trace 快照）按 sessionId 从 dsh 会话存档现场回放轨迹。
+// persistence.load 返回 inspection（.events 数组，新旧 SDK 同形）。
 async function replayTrace(sessionId) {
   const persistence = ctxRef?.sessionPersistence;
   if (!persistence || !sessionId) return null;
   const insp = await persistence.load(sessionId);
-  return buildTrace(insp.events, 0, { input: '', model: '' });
+  return buildTrace(Array.isArray(insp?.events) ? insp.events : [], 0, { input: '', model: '' });
 }
 
 function summarize(events, firstSeq) {

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -1355,8 +1355,10 @@ export function apply(ctx, config) {
       systemPrompt += `\n\n飞书操作：本机装有 lark-cli（飞书官方 CLI，在 dsh 设置「飞书账号」扫码授权一次即可）。默认身份已固定为 user，执行 lark-cli 命令默认加 --as user；user token 由宿主后台自动续约，无需关心过期。user 身份报错/授权失效时降级 --as bot 并在结果注明"需用户重新扫码"。详见技能 feishu-cli。输出 JSON 信封，成功看 ok==true。`;
     }
     // 通用提示词（设置面板「Workflow One」，issue #129）：部署级行为约束，
-    // 尾部注入——节点提示词定义「做什么」，通用约束修正「怎么做」并覆盖前面指令
-    const commonPromptSection = agentCommonPromptSection(agentDefaults);
+    // 尾部注入——节点提示词定义「做什么」，通用约束修正「怎么做」并覆盖前面指令。
+    // 注意：此处 agentDefaults 尚未初始化（下方 const 声明），TDZ 直接引用会炸，
+    // 从 store 现读一份。
+    const commonPromptSection = agentCommonPromptSection(agentDefaultsStore.read());
     if (commonPromptSection) systemPrompt += `\n\n${commonPromptSection}`;
 
     // 用户输入 = 模板渲染 + 附件复制进工作区

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults-api.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults-api.integration.test.mjs
@@ -87,7 +87,7 @@ const test = async (name, fn) => {
 await test('GET 初始为空默认值，effective 跟随 dsh 全局选择', async () => {
   const { status, body } = await call('GET');
   assert.equal(status, 200);
-  assert.deepEqual(body.defaults, { provider: '', model: '', reasoningEffort: '', nodeTimeoutSec: 0, modelTimeoutSec: 0 });
+  assert.deepEqual(body.defaults, { provider: '', model: '', reasoningEffort: '', nodeTimeoutSec: 0, modelTimeoutSec: 0, systemPrompt: '' });
   assert.deepEqual(body.effective, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium', nodeTimeoutSec: 500, modelTimeoutSec: 300 });
   assert.deepEqual(body.dsh, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium' });
 });
@@ -104,7 +104,7 @@ await test('PUT 合法五件套 200，effective 生效且 GET 可读回', async 
   assert.equal(put.status, 200);
   assert.deepEqual(put.body.effective, { provider: 'glm', model: 'glm-5', reasoningEffort: null, nodeTimeoutSec: 900, modelTimeoutSec: 120 });
   const get = await call('GET');
-  assert.deepEqual(get.body.defaults, { provider: 'glm', model: 'glm-5', reasoningEffort: '', nodeTimeoutSec: 900, modelTimeoutSec: 120 });
+  assert.deepEqual(get.body.defaults, { provider: 'glm', model: 'glm-5', reasoningEffort: '', nodeTimeoutSec: 900, modelTimeoutSec: 120, systemPrompt: '' });
 });
 
 await test('PUT 非法超时 400 且不落盘', async () => {
@@ -133,6 +133,24 @@ await test('PUT 缺依赖字段 400；清空回退 dsh 全局', async () => {
   assert.deepEqual(cleared.body.effective, { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'medium', nodeTimeoutSec: 500, modelTimeoutSec: 300 });
 });
 
+// 通用提示词（issue #129）：与渠道/模型/超时同存储同端点，多行文本原样保留
+await test('PUT systemPrompt 保存并回读；超长 400；空串清空', async () => {
+  const text = '- 输出统一使用中文\n- 交付物直接给结论';
+  const put = await call('PUT', { systemPrompt: text });
+  assert.equal(put.status, 200);
+  assert.equal(put.body.defaults.systemPrompt, text);
+  const get = await call('GET');
+  assert.equal(get.body.defaults.systemPrompt, text);
+  const tooLong = await call('PUT', { systemPrompt: 'x'.repeat(8001) });
+  assert.equal(tooLong.status, 400);
+  assert.match(tooLong.body.error, /systemPrompt 最长/);
+  const badType = await call('PUT', { systemPrompt: 42 });
+  assert.equal(badType.status, 400);
+  const cleared = await call('PUT', { systemPrompt: '' });
+  assert.equal(cleared.status, 200);
+  assert.equal(cleared.body.defaults.systemPrompt, '');
+});
+
 await test('POST 方法 405', async () => {
   const { status } = await call('POST', {});
   assert.equal(status, 405);
@@ -154,7 +172,7 @@ await test('llm-config 暴露 wf1Defaults（节点面板展示链与引擎解析
   const res = responseCapture();
   await llmRoute(request('GET', '/wf1/api/llm-config'), res);
   const body = res.json();
-  assert.deepEqual(body.wf1Defaults, { provider: 'glm', model: 'glm-5', reasoningEffort: '', nodeTimeoutSec: 800, modelTimeoutSec: 200 });
+  assert.deepEqual(body.wf1Defaults, { provider: 'glm', model: 'glm-5', reasoningEffort: '', nodeTimeoutSec: 800, modelTimeoutSec: 200, systemPrompt: '' });
   // dsh 全局选择字段保持原语义，不受 WF1 默认值影响
   assert.equal(body.defaultProvider, 'deepseek');
   assert.equal(body.defaultModel, 'deepseek-chat');

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/agent-defaults.test.mjs
@@ -6,6 +6,7 @@ import {
   AgentDefaultsError,
   AgentDefaultsStore,
   EMPTY_AGENT_DEFAULTS,
+  agentCommonPromptSection,
   normalizeAgentDefaults,
   resolveAgentModelSelection,
   resolveAgentTimeouts,
@@ -25,11 +26,43 @@ test('normalize: 空对象与缺省字段都落成空默认值', () => {
 test('normalize: 正常字段保留并 trim；超时收整数', () => {
   assert.deepEqual(
     normalizeAgentDefaults({ provider: ' deepseek ', model: 'deepseek-chat', reasoningEffort: 'high' }),
-    { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'high', nodeTimeoutSec: 0, modelTimeoutSec: 0 },
+    { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: 'high', nodeTimeoutSec: 0, modelTimeoutSec: 0, systemPrompt: '' },
   );
   assert.deepEqual(
     normalizeAgentDefaults({ provider: 'deepseek', model: 'deepseek-chat', nodeTimeoutSec: '600', modelTimeoutSec: 240 }),
-    { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: '', nodeTimeoutSec: 600, modelTimeoutSec: 240 },
+    { provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: '', nodeTimeoutSec: 600, modelTimeoutSec: 240, systemPrompt: '' },
+  );
+});
+
+// ---- systemPrompt（通用提示词，issue #129）----
+
+test('normalize: systemPrompt 保留换行、去首尾空白；空/缺省回退空串', () => {
+  const text = '- 输出统一使用中文\n- 交付物直接给结论\n\n- 物业术语遵循规范';
+  assert.equal(normalizeAgentDefaults({ systemPrompt: `\n${text}\n` }).systemPrompt, text);
+  assert.equal(normalizeAgentDefaults({}).systemPrompt, '');
+  assert.equal(normalizeAgentDefaults({ systemPrompt: undefined }).systemPrompt, '');
+  assert.equal(normalizeAgentDefaults({ systemPrompt: null }).systemPrompt, '');
+});
+
+test('normalize: systemPrompt 非字符串 / 超长都拒绝', () => {
+  assert.throws(() => normalizeAgentDefaults({ systemPrompt: 42 }), AgentDefaultsError);
+  assert.throws(() => normalizeAgentDefaults({ systemPrompt: 'x'.repeat(8001) }), /systemPrompt 最长 8000/);
+  assert.doesNotThrow(() => normalizeAgentDefaults({ systemPrompt: 'x'.repeat(8000) }));
+});
+
+test('commonPromptSection: 空串不注入（返回空），非空包成通用约束段', () => {
+  assert.equal(agentCommonPromptSection(EMPTY_AGENT_DEFAULTS), '');
+  assert.equal(agentCommonPromptSection({}), '');
+  assert.equal(agentCommonPromptSection(null), '');
+  assert.equal(agentCommonPromptSection({ systemPrompt: '   ' }), '');
+  assert.equal(
+    agentCommonPromptSection({ ...EMPTY_AGENT_DEFAULTS, systemPrompt: '输出用中文' }),
+    '## 通用约束\n\n输出用中文',
+  );
+  // 多行约束整体保留
+  assert.equal(
+    agentCommonPromptSection({ ...EMPTY_AGENT_DEFAULTS, systemPrompt: '第一条\n第二条' }),
+    '## 通用约束\n\n第一条\n第二条',
   );
 });
 
@@ -110,7 +143,7 @@ test('store: 写入后可读回，落盘 0600', () => {
   const file = join(dir, 'sub', 'agent-defaults.json');
   const store = new AgentDefaultsStore(file);
   store.write({ provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high', nodeTimeoutSec: 600, modelTimeoutSec: 240 });
-  assert.deepEqual(store.read(), { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high', nodeTimeoutSec: 600, modelTimeoutSec: 240 });
+  assert.deepEqual(store.read(), { provider: 'deepseek', model: 'deepseek-reasoner', reasoningEffort: 'high', nodeTimeoutSec: 600, modelTimeoutSec: 240, systemPrompt: '' });
   const doc = JSON.parse(readFileSync(file, 'utf8'));
   assert.equal(doc.version, 1);
   assert.equal(doc.provider, 'deepseek');
@@ -206,6 +239,22 @@ test('resolveTimeouts: 节点显式配置永远优先（只覆盖配了的那项
     resolveAgentTimeouts({ node: { modelTimeoutSec: 30 }, defaults: { ...EMPTY_AGENT_DEFAULTS, nodeTimeoutSec: 900 } }),
     { nodeTimeoutSec: 900, modelTimeoutSec: 30 },
   );
+});
+
+test('store: 旧版存量文件（无 systemPrompt 字段）读取回退空串、写回补齐字段', () => {
+  const dir = mkdtempSync(join(tmpdir(), 'wf1-agent-defaults-'));
+  const file = join(dir, 'agent-defaults.json');
+  const store = new AgentDefaultsStore(file);
+  // 旧版五字段文件（v0.8.1 及之前落盘形态）
+  writeFileSync(file, JSON.stringify({ version: 1, provider: 'deepseek', model: 'deepseek-chat', reasoningEffort: '', nodeTimeoutSec: 600, modelTimeoutSec: 0 }), 'utf8');
+  const read = store.read();
+  assert.equal(read.systemPrompt, '');
+  assert.equal(read.provider, 'deepseek');
+  assert.equal(read.nodeTimeoutSec, 600);
+  // 写回后含新字段
+  const written = store.write({ ...read, systemPrompt: '输出用中文' });
+  assert.equal(written.systemPrompt, '输出用中文');
+  assert.equal(JSON.parse(readFileSync(file, 'utf8')).systemPrompt, '输出用中文');
 });
 
 let failed = 0;

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/live-trace.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/live-trace.test.mjs
@@ -1,8 +1,10 @@
 // 实时轨迹单测（issue #52）：foldTraceEvent 增量折叠与 buildTrace 全量产出同语义；
 // 折叠语义回归：input/inject/assistant/tool(call+result 配对)/turn-end。
+// sessionEventsOf 兼容层：dsh-session 0.1.2-alpha.5 删除 Session.events getter 后
+// 引擎收尾（summarize/countTurns/sumUsage）不再抛「events is not iterable」。
 import assert from 'node:assert/strict';
 
-const { foldTraceEvent, finalizeTrace } = await import('../lib/index.js');
+const { foldTraceEvent, finalizeTrace, sessionEventsOf } = await import('../lib/index.js');
 
 let passed = 0;
 const test = (name, fn) => Promise.resolve()
@@ -79,6 +81,27 @@ await test('失败结果 isError=true → ok=false；成功不带 error 字段',
   foldTraceEvent(trace, { seq: 2, type: 'tool/result', data: { message: { content: [{ type: 'tool-result', toolCallId: 'x', isError: true, content: [{ type: 'text', text: 'exit 1' }] }] } } }, pending, meta);
   assert.equal(trace.entries[1].result.ok, false);
   assert.equal(trace.entries[1].result.error, undefined);
+});
+
+await test('sessionEventsOf：新 SDK（snapshotEvents 方法）优先，旧 SDK（.events 数组）回退', () => {
+  const events = [{ seq: 0, type: 'turn/start', data: {} }];
+  const modern = { snapshotEvents: () => events };
+  const legacy = { events };
+  assert.equal(sessionEventsOf(modern), events);
+  assert.equal(sessionEventsOf(legacy), events);
+  // 两者都有时新 API 优先（snapshotEvents 是当前契约）
+  const both = { snapshotEvents: () => events, events: ['stale'] };
+  assert.equal(sessionEventsOf(both), events);
+});
+
+await test('sessionEventsOf：异常形态降级为空数组，不再抛「events is not iterable」', () => {
+  assert.deepEqual(sessionEventsOf(null), []);
+  assert.deepEqual(sessionEventsOf(undefined), []);
+  assert.deepEqual(sessionEventsOf({}), []);
+  // snapshotEvents 抛错（session 已释放等）也降级为空数组
+  assert.deepEqual(sessionEventsOf({ snapshotEvents: () => { throw new Error('released'); } }), []);
+  // 旧 SDK 形态但 .events 非数组
+  assert.deepEqual(sessionEventsOf({ events: undefined }), []);
 });
 
 console.log(process.exitCode ? 'live-trace tests: FAIL' : `live-trace tests: ALL PASS (${passed})`);


### PR DESCRIPTION
Closes #129

## 背景

agent 节点的系统提示词此前完全由节点自身「提示词」字段决定。跨节点反复出现的行为约束（统一中文输出、交付物直给结论、物业术语规范）只能在每个节点里复制粘贴，改了还要挨个同步。本 PR 在设置面板「Workflow One」加「通用提示词」：一次配置对所有 agent 节点生效。

## 方案

**语义**：部署级行为约束，注入 agent 系统提示词**尾部**（节点提示词 + 引擎固定指令 + 技能索引 + 结构化输出/飞书指令之后）——节点提示词定义「做什么」，通用约束修正「怎么做」，尾部位置保证覆盖前面的行为指令。空串 = 不注入，零行为变化。

- **agent-defaults.js**：`systemPrompt` 进默认值存储（与渠道/模型/超时同文件同端点，dsh 用户级 `~/.dsh/plugin-data/.../state/agent-defaults.json`）；normalize 校验字符串类型与 8000 字符防呆上限，保留换行只去首尾空白；`agentCommonPromptSection()` 把非空文本包成 `## 通用约束` 段
- **index.js**：`runAgentNode` 提示词链尾部拼接（`agentDefaults` 已在作用域内，无额外读盘）
- **canvasui**：`AgentDefaultsCard` 超时字段后加多行 textarea（纵向可调高度），dirty/保存/draft 重置链路全部纳入新字段；bundle 已重建，`--check` 逐字比对通过
- **API**：`/wf1/api/agent-defaults` GET/PUT 现有形状直接带新字段，无新路由

## 兼容性

- 旧版 `agent-defaults.json`（五字段）读取时 `systemPrompt` 回退空串，写回补齐
- 旧客户端 PUT 不带 `systemPrompt` = 清空（PUT 整体替换语义，与渠道/模型一致）

## 验证

- 单测 23+10 例：normalize 边界（多行保留/超长 400/非串 400）、注入段语义（空不注入/多行整体保留）、旧存量文件读写回退、API 集成（PUT 回读、空串清空、400 路径）
- orchestrator 30 套、canvasui client 测试、全量 `npm test`、`build-web.sh` 双构建、`build-canvasui.sh --check` 全部通过

## 关联

- 分支基于 `fix/agent-session-events-compat`（PR #128）切出，包含其提交——请先合 #128，本 PR 的 diff 会自动收敛