### PR TITLE
chore(one): 准备 0.9.0 发版

### DIFF
--- a/dsh-plugins/dsh-ccpg-brand/package.json
+++ b/dsh-plugins/dsh-ccpg-brand/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-brand",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-canvasui/package.json
+++ b/dsh-plugins/dsh-ccpg-canvasui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-canvasui",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-document-preview/package-lock.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-ccpg-document-preview",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@file-viewer/pptx": "2.3.0",

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-document-preview",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": false,
   "description": "Shared full-screen document preview for dsh and React applications",
   "license": "MIT",

--- a/dsh-plugins/dsh-ccpg-larkauth/package.json
+++ b/dsh-plugins/dsh-ccpg-larkauth/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-larkauth",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-llm-guard/package.json
+++ b/dsh-plugins/dsh-ccpg-llm-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-llm-guard",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-one/package.json
+++ b/dsh-plugins/dsh-ccpg-one/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-harness-one",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "Workflow One - Visual AI workflow orchestrator for DeepSeek Harness (dsh), with multi-agent DAGs, live execution, recovery, and Feishu integration",
   "license": "MIT",
   "repository": {
@@ -47,13 +47,13 @@
   ],
   "dependencies": {
     "dsh-better-sidebar": "0.16.1",
-    "dsh-ccpg-canvasui": "0.8.1",
-    "dsh-ccpg-document-preview": "0.8.1",
-    "dsh-ccpg-larkauth": "0.8.1",
-    "dsh-ccpg-llm-guard": "0.8.1",
-    "dsh-ccpg-orchestrator": "0.8.1",
-    "dsh-ccpg-tools": "0.8.1",
-    "dsh-ccpg-web": "0.8.1"
+    "dsh-ccpg-canvasui": "0.9.0",
+    "dsh-ccpg-document-preview": "0.9.0",
+    "dsh-ccpg-larkauth": "0.9.0",
+    "dsh-ccpg-llm-guard": "0.9.0",
+    "dsh-ccpg-orchestrator": "0.9.0",
+    "dsh-ccpg-tools": "0.9.0",
+    "dsh-ccpg-web": "0.9.0"
   },
   "publishConfig": {
     "access": "public",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dsh-ccpg-orchestrator",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.20.0",

--- a/dsh-plugins/dsh-ccpg-orchestrator/package.json
+++ b/dsh-plugins/dsh-ccpg-orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-orchestrator",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-tools/package.json
+++ b/dsh-plugins/dsh-ccpg-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-tools",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",

--- a/dsh-plugins/dsh-ccpg-web/package.json
+++ b/dsh-plugins/dsh-ccpg-web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-ccpg-web",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": false,
   "type": "module",
   "main": "lib/index.js",


### PR DESCRIPTION
## 版本：0.8.1 → 0.9.0

自 0.8.1（v0.8.1 tag，26c2ace）以来合入 7 个 PR，其中 2 个面向用户的功能新增，按 semver 进 minor：

| PR | 类型 | 内容 |
|---|---|---|
| #130 | feat | agent 节点通用提示词（设置面板部署级行为约束，尾部注入；合并前修 TDZ 崩溃） |
| #131 | feat | workflow_run/_status 接入消息流运行卡 + 缩略图随卡片宽度自适应（ResizeObserver） |
| #128 | fix | agent 节点收尾兼容 dsh-session 新 API，修「events is not iterable」 |
| #127 | fix | 文稿预览 markdown 渲染 raw HTML 表格（rehype 管线对齐卡片侧） |
| #126 | feat | agent 节点超时默认值进设置面板 |
| #125 | fix | 节点面板默认模型展示对齐引擎解析链 |

## 变更面

- 10 个包版本号 0.8.1 → 0.9.0（含 dsh-harness-one 聚合壳与装配目录）
- 聚合包依赖 7 个子插件版本同步 0.9.0
- orchestrator / document-preview 两个 package-lock.json 顶层版本对齐

## 验证

- `npm test` 全量绿（document-preview 本地缺 node_modules 补装后通过）
- `build-web.sh` 双构建通过；`build-canvasui.sh --check` 无漂移
- 合并后打 `v0.9.0` tag 触发 release.yml（pack → boot-smoke → npm 8 包）