### PR TITLE
fix(web): 文稿成果条带横向滚动失效（flex 内容宽级联撑爆版面）

### DIFF
--- a/web/src/doc-wall.css
+++ b/web/src/doc-wall.css
@@ -1,7 +1,10 @@
 /* ===== 文稿视图（DocWallView）—— 原型 v2 定稿样式，令牌全部来自 styles.css :root ===== */
 
 .docwall-view { flex: 1; min-width: 0; min-height: 0; display: flex; background: var(--bg); }
-.docwall { display: flex; flex: 1; height: 100%; min-height: 0; }
+/* min-width:0 断开「内容宽→容器宽」级联：条带卡片是 flex:none，若本层随内容
+   放大（flex item 默认 min-width:auto），横向滚动会发生在 docwall-main 而不是
+   条带内——成果多时整版被撑出视口，窗口里只能看到开头两张卡且无处可滑 */
+.docwall { display: flex; flex: 1; height: 100%; min-height: 0; min-width: 0; }
 .docwall-center { flex: 1; flex-direction: column; gap: 12px; display: flex; align-items: center; justify-content: center; color: var(--fg-muted); font-size: 13px; }
 .docwall-empty { font-size: 14px; }
 .docwall-load-error { display: flex; align-items: center; gap: 8px; color: var(--danger-fg); }
@@ -20,8 +23,9 @@
 .docwall-dot-error, .docwall-dot-canceled { background: var(--danger); opacity: 1; }
 .docwall-dot-running { background: var(--accent); opacity: 1; }
 
-/* 右侧 */
-.docwall-main { flex: 1; min-width: 0; display: flex; flex-direction: column; overflow-y: auto; }
+/* 右侧：纵向滚动归本层；横向隐藏（横向滚动只应发生在条带 .docwall-strip-cards 内，
+   auto 会在条带被撑爆时出现整版横向滚动条，掩盖条带自身的滚动） */
+.docwall-main { flex: 1; min-width: 0; display: flex; flex-direction: column; overflow-y: auto; overflow-x: hidden; }
 .docwall-toolbar { display: flex; align-items: baseline; gap: 12px; padding: 14px 22px 10px; position: sticky; top: 0; background: var(--bg); z-index: 2; border-bottom: 1px solid var(--border); }
 .docwall-toolbar-meta { font-size: 12px; color: var(--fg-faint); }
 .docwall-toolbar-spacer { flex: 1; }


### PR DESCRIPTION
## 现象

文稿 → 成果：文稿多时横向卡片只能看到开头两张，没有滚动条，无法横滑查看更多。

## 根因

flex 布局的内容宽级联：成果卡 `flex:none` + 条带 `.docwall-strip-cards` 自带 `overflow-x:auto` 本身正确，但祖先 `.docwall` 作为 flex item 未设 `min-width`（默认 `auto` = 不小于内容宽），被 12 张 420px 卡撑到 5216px。于是：

- 条带 `clientWidth = scrollWidth = 5216`，滚动余量为零（滚动条无从出现）
- 横向滚动被挤到外层 `.docwall-main`（`overflow-x` 计算值为 auto），表现为整版可拖出去，但鼠标滚轮/触控板在条带上没有横向滚动语义，窗口里只看到前两张卡

实测数据（8.4合并 run，12 张成果卡，1800px 视口）：`.docwall` clientWidth 5512、条带 clientWidth=scrollWidth=5216。

## 修复（2 行 CSS）

- `.docwall` 补 `min-width:0`：断开级联，条带回到视口宽度内、恢复自身横向滚动
- `.docwall-main` 明确 `overflow-x:hidden`：横向滚动只应发生在条带内，防止再出现整版横向滚动条掩盖问题

## 验证

- 真实环境实测同一 run：条带 `clientWidth 1504 / scrollWidth 5216 / maxScrollLeft 3712`，`scrollLeft` 可滑到底、最后一张卡完整可见
- web 14 套测试全绿；`build-web.sh` 双构建通过