### PR TITLE
fix(canvasui+web): 消息卡「打开画布」定位到卡片对应的工作流与运行

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -183,6 +183,36 @@ window.__ModuleLoader__.load({
       return true;
     }
 
+    // 消息卡「打开画布」带定位目标（runId）：开侧栏 tab 后向常驻画布 iframe 发
+    // wf1-open-run，画布据 run 详情打开对应工作流并选中该运行（不传则维持原
+    // 「只开 tab」行为）。iframe 未挂载（侧栏从没开过）时等 SidebarWorkflowTab
+    // mount 后由 pendingOpenRun 队列补发。
+    var pendingOpenRun = null;
+    function openCanvasWithRun(runId) {
+      pendingOpenRun = runId || null;
+      if (!openWorkflowSidebar()) {
+        // 无侧栏服务（老宿主）：退回新窗口打开画布，hash 直达该 run 的文稿视图
+        if (runId) window.open(CANVAS_URL + "#docs/" + encodeURIComponent(runId), "_blank");
+        else window.open(CANVAS_URL, "_blank");
+        pendingOpenRun = null;
+        return;
+      }
+      flushPendingOpenRun();
+    }
+    function flushPendingOpenRun() {
+      if (!pendingOpenRun) return;
+      var host = persistentHost;
+      var frame = host ? host.querySelector("iframe") : null;
+      if (!frame || !canvasReady) return; // 未挂载/未就绪：SidebarWorkflowTab 挂载后重试
+      try {
+        frame.contentWindow.postMessage(
+          { type: "wf1-open-run", runId: pendingOpenRun },
+          window.location.origin,
+        );
+        pendingOpenRun = null;
+      } catch (e) { /* 画布异常不炸消息流 */ }
+    }
+
     // ---- 消息流工作流卡片（tool.call.toolview）----
     // 数据源全部现成：canvas_run_workflow 的工具结果带 runId → 轮询 /wf1/api/runs/detail；
     // canvas_graph_patch 的 args/结果自带 ops 与 lint。卡片自绘 SVG 缩略图，画布本体零改动。
@@ -460,7 +490,11 @@ window.__ModuleLoader__.load({
       return result;
     }
 
-    function openCanvasFallback() {
+    function openCanvasFallback(target) {
+      if (target && target.runId) {
+        openCanvasWithRun(target.runId);
+        return;
+      }
       if (openWorkflowSidebar()) return;
       window.open(CANVAS_URL, "_blank");
     }
@@ -474,7 +508,7 @@ window.__ModuleLoader__.load({
           type: "button",
           className: "wf1-card",
           ref: props.hostRef || undefined,
-          onClick: function () { try { openCanvasFallback(); } catch (e) { /* 宿主状态异常不炸消息流 */ } },
+          onClick: function () { try { openCanvasFallback(props.target); } catch (e) { /* 宿主状态异常不炸消息流 */ } },
         },
         react.createElement(
           "div", { className: "wf1-card-head" },
@@ -672,6 +706,8 @@ window.__ModuleLoader__.load({
           width: thumbW, capacity: capacity,
         }),
         hostRef: attachHost,
+        // 点击定位到卡片正在跟踪的 run（续跑换 run 后也指向最新）
+        target: { runId: trackedRunId },
       });
     }
 
@@ -872,9 +908,13 @@ window.__ModuleLoader__.load({
           if (d.type === "wf1-ready") {
             canvasReady = true;
             setReady(true);
+            // 画布就绪即可投递「打开画布」定位请求（卡片点击可能先于 iframe 挂载/就绪）
+            flushPendingOpenRun();
           }
         }
         window.addEventListener("message", onMessage);
+        // mount 即补投：侧栏 tab 本就打开、iframe 已就绪的场景
+        flushPendingOpenRun();
         return function () {
           window.removeEventListener("message", onMessage);
         };

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1468,6 +1468,24 @@ export default function App() {
       if (d.type === 'wf1-theme' && (d.theme === 'light' || d.theme === 'dark')) {
         document.documentElement.dataset.theme = d.theme;
       }
+      if (d.type === 'wf1-open-run' && d.runId) {
+        // 宿主消息卡「打开画布」：定位到卡片对应的运行——先取 run 详情拿 workflowId
+        //（跨工作流则复用 openWorkflow 切图，同图直接选中），再进画布查看态。
+        (async () => {
+          try {
+            const res = await fetch(apiUrl(`/runs/detail?id=${encodeURIComponent(String(d.runId))}`));
+            if (!res.ok) { toast('打开画布：运行不存在或已清理', 'error'); return; }
+            const detail = await res.json();
+            const wfId = detail.workflowId || null;
+            if (wfId && wfId !== currentWfIdRef.current) {
+              const wfRes = await fetch(apiUrl(`/workflows/detail?id=${encodeURIComponent(wfId)}`));
+              if (wfRes.ok) await openWorkflowRef.current?.(await wfRes.json());
+            }
+            inspectRun(String(d.runId));
+            setView('canvas');
+          } catch { toast('打开画布：定位运行失败', 'error'); }
+        })();
+      }
       if (d.type === 'wf1-session' && d.sessionId) {
         hostSessionRef.current = d.sessionId;
         setApiSessionId(d.sessionId);


### PR DESCRIPTION
## 现象

对话里的工作流消息卡（workflow_run / canvas_run_workflow 等）点击「打开画布」只打开侧栏工作流 tab，画布仍停在当前打开的工作流——卡片对应的运行属于别的工作流时，看到的图对不上，也没切换。

## 方案

复用宿主↔画布既有 postMessage 通道（wf1-session / wf1-theme 同款），新增 `wf1-open-run` 定位消息：

**canvasui（宿主侧）**
- 运行卡骨架新增 `target.runId`（取 trackedRunId——失败续跑自动换 run 后仍指向最新）
- `openCanvasWithRun`：开侧栏 tab → 向常驻画布 iframe 发 `wf1-open-run`；iframe 未挂载或未就绪时进 pending 队列，`SidebarWorkflowTab` mount / 画布 `wf1-ready` 后补投
- 老宿主无侧栏服务：退回新窗口打开 `#docs/<runId>`（文稿视图直达）

**web 画布（App.jsx）**
- 收到 `wf1-open-run`：取 run 详情拿 workflowId → 跨工作流复用 `openWorkflow` 切图（同图跳过）→ `inspectRun` 选中该运行 → 切画布视图；运行不存在 / 定位失败 toast 提示

## 验证

- 真实环境实测：消息流「质量计划-知识库摄取（KB-Ingest）」运行卡点击 → 侧栏画布从另一工作流自动切到 KB-Ingest，节点状态按该 run 投影
- 全量 `npm test` 绿（web 14 套 + canvasui）；`build-canvasui.sh --check` 无漂移；`build-web.sh` 双构建通过