### PR TITLE
fix(document-preview+web): 修复缺分隔行表格与 CJK 粗体的渲染原样漏出

### DIFF
--- a/dsh-plugins/dsh-ccpg-document-preview/package-lock.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package-lock.json
@@ -16,6 +16,7 @@
         "react-markdown": ">=9",
         "rehype-raw": "^7.0.0",
         "rehype-sanitize": "^6.0.0",
+        "remark-cjk-friendly": "2.3.1",
         "remark-gfm": ">=4",
         "xlsx": "0.18.5"
       },
@@ -2301,6 +2302,18 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/hast-util-from-parse5": {
       "version": "8.0.3",
       "resolved": "https://registry.npmmirror.com/hast-util-from-parse5/-/hast-util-from-parse5-8.0.3.tgz",
@@ -2956,6 +2969,28 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-to-markdown-cjk-friendly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmmirror.com/mdast-util-to-markdown-cjk-friendly/-/mdast-util-to-markdown-cjk-friendly-1.0.0.tgz",
+      "integrity": "sha512-BoaAm8mlJ+LAYz0Qs532Y3ciTuQYgBUPZcSFbvC/ZKmEMAKgulw84YvQK1gI34t/vL2euSfuaWlqczkTBgamkw==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown": "^2.1.2",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/mdast-util-to-string": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
@@ -3036,6 +3071,50 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-cjk-friendly/-/micromark-extension-cjk-friendly-2.0.1.tgz",
+      "integrity": "sha512-OkzoYVTL1ChbvQ8Cc1ayTIz7paFQz8iS9oIYmewncweUSwmWR+hkJF9spJ1lxB90XldJl26A1F4IkPOKS3bDXw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.1.0",
+        "micromark-extension-cjk-friendly-util": "3.0.1",
+        "micromark-util-chunked": "^2.0.1",
+        "micromark-util-resolve-all": "^2.0.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "micromark": "^4.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/micromark-extension-cjk-friendly-util": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/micromark-extension-cjk-friendly-util/-/micromark-extension-cjk-friendly-util-3.0.1.tgz",
+      "integrity": "sha512-GcbXqTTHOsiZHyF753oIddP/J2eH8j9zpyQPhkof6B2JNxfEJabnQqxbCgzJNuNes0Y2jTNJ3LiYPSXr6eJA8w==",
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.4.0",
+        "micromark-util-character": "^2.1.1",
+        "micromark-util-symbol": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "micromark-util-types": {
+          "optional": true
+        }
       }
     },
     "node_modules/micromark-extension-gfm": {
@@ -3803,6 +3882,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-cjk-friendly": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmmirror.com/remark-cjk-friendly/-/remark-cjk-friendly-2.3.1.tgz",
+      "integrity": "sha512-f+pKZRxCRwNEGFBKNRAZAqU91GIK1SAo3ZyFHWRUgC9zcxRR0BXKd6YwqgSsxtW0rNpUDtONj7H5nje2WL3fcA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-to-markdown-cjk-friendly": "1.0.0",
+        "micromark-extension-cjk-friendly": "2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/mdast": "^4.0.0",
+        "unified": "^11.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/mdast": {
+          "optional": true
+        }
       }
     },
     "node_modules/remark-gfm": {

--- a/dsh-plugins/dsh-ccpg-document-preview/package.json
+++ b/dsh-plugins/dsh-ccpg-document-preview/package.json
@@ -20,7 +20,9 @@
     "./react": "./dist/react.js",
     "./client": "./dist/client.js",
     "./styles.css": "./dist/document-preview.css",
-    "./package.json": "./package.json"
+    "./package.json": "./package.json",
+    "./markdown": "./src/markdown-compat.mjs",
+    "./markdown-sanitize": "./src/markdown-sanitize.mjs"
   },
   "files": [
     "src",
@@ -40,6 +42,7 @@
     "react-markdown": ">=9",
     "rehype-raw": "^7.0.0",
     "rehype-sanitize": "^6.0.0",
+    "remark-cjk-friendly": "2.3.1",
     "remark-gfm": ">=4",
     "xlsx": "0.18.5"
   },

--- a/dsh-plugins/dsh-ccpg-document-preview/scripts/build.mjs
+++ b/dsh-plugins/dsh-ccpg-document-preview/scripts/build.mjs
@@ -17,7 +17,7 @@ await build({
     cssCodeSplit: false,
     lib: { entry: resolve(root, 'src/react.jsx'), formats: ['es'], fileName: () => 'react.js' },
     rollupOptions: {
-      external: ['react', 'react-dom', 'react-dom/client', 'react-markdown', 'remark-gfm', 'rehype-raw', 'rehype-sanitize'],
+      external: ['react', 'react-dom', 'react-dom/client', 'react-markdown', 'remark-gfm', 'remark-cjk-friendly', 'rehype-raw', 'rehype-sanitize'],
       output: {
         assetFileNames: (asset) => asset.name?.endsWith('.css') ? 'document-preview.css' : 'assets/[name]-[hash][extname]',
         chunkFileNames: 'renderers/[name]-[hash].js',

--- a/dsh-plugins/dsh-ccpg-document-preview/src/markdown-compat.mjs
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/markdown-compat.mjs
@@ -1,0 +1,62 @@
+// LLM 产出的中文文稿常见两类非规范 markdown，规范渲染器按原文漏出：
+// 1. GFM 表格缺 | --- | --- | 分隔行（分隔行是 GFM 规范强制的表头定界）
+// 2. **粗体**紧贴中文（闭定界符前后是汉字/全角标点）——CommonMark 侧翼规则
+//    按西文空白判定，CJK 文本里定界符无法闭合，星号原样漏出
+// 这里提供统一插件清单与纯字符串预处理，供预览弹窗（src/react.jsx）与画布
+// 卡片（web/src/MarkdownDocument.jsx）两条渲染管线共用；独立纯 .mjs 是为了
+// node --test 在无 JSX 加载器环境下直接单测。
+import remarkGfm from 'remark-gfm';
+import remarkCjkFriendly from 'remark-cjk-friendly';
+
+// remark-cjk-friendly 须在 gfm 之前注册（改写 emphasis 侧翼分类）
+export const markdownRemarkPlugins = [remarkCjkFriendly, remarkGfm];
+
+// 分隔行识别：GFM 允许 |:---| 与 |---:| 等对齐变体，单元格只含 -、=、:
+// （宽松匹配），不匹配则该行组按普通段落处理。
+const DELIMITER_CELL = /^:?[-=]+:?$/;
+const FENCE_RE = /^(\s{0,3})(`{3,}|~{3,})/;
+
+// 竖线行：非空、含 |、非分隔行自身；行内代码片段与 \| 转义不参与分列
+// （与 GFM 的表格分列规则一致，列数才不会算错）。
+function pipeRowCells(line) {
+  if (!line.includes('|')) return null;
+  const bare = line.replace(/`[^`]*`/g, '').replace(/\\\|/g, '·');
+  if (!bare.trim() || !bare.includes('|')) return null;
+  const cells = bare.replace(/^\s*\|/, '').replace(/\|\s*$/, '').split('|');
+  return cells.length >= 2 ? cells : null;
+}
+
+function isDelimiterRow(line) {
+  const cells = pipeRowCells(line);
+  return Boolean(cells) && cells.every((cell) => DELIMITER_CELL.test(cell.trim()));
+}
+
+// 连续竖线行构成隔离段落且不含分隔行时，在首行后补一行等宽分隔行。
+// 已带分隔行的合法表格、散落在正文段落中的竖线行原样返回。
+export function repairMissingTableDelimiter(text) {
+  if (!text || !text.includes('|')) return text;
+  const lines = text.split('\n');
+  const out = [];
+  let index = 0;
+  while (index < lines.length) {
+    const line = lines[index];
+    const fence = line.match(FENCE_RE);
+    if (fence) {
+      const marker = fence[2][0].repeat(3);
+      out.push(line);
+      index += 1;
+      while (index < lines.length && !lines[index].includes(marker)) { out.push(lines[index]); index += 1; }
+      if (index < lines.length) { out.push(lines[index]); index += 1; }
+      continue;
+    }
+    if (!pipeRowCells(line)) { out.push(line); index += 1; continue; }
+    const block = [];
+    while (index < lines.length && pipeRowCells(lines[index])) { block.push(lines[index]); index += 1; }
+    if (block.length >= 2 && !block.some(isDelimiterRow)) {
+      const width = pipeRowCells(block[0]).length;
+      out.push(block[0], `|${' --- |'.repeat(width)}`);
+      out.push(...block.slice(1));
+    } else out.push(...block);
+  }
+  return out.join('\n');
+}

--- a/dsh-plugins/dsh-ccpg-document-preview/src/react.jsx
+++ b/dsh-plugins/dsh-ccpg-document-preview/src/react.jsx
@@ -2,9 +2,9 @@ import { Component, lazy, Suspense, useCallback, useEffect, useId, useMemo, useR
 import { createPortal } from 'react-dom';
 import { Download, Expand, Eye, Minimize, X } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize from 'rehype-sanitize';
+import { markdownRemarkPlugins, repairMissingTableDelimiter } from './markdown-compat.mjs';
 import { markdownSanitizeSchema } from './markdown-sanitize.mjs';
 import { documentPreviewKind, loadPreviewText, normalizePreviewDocument, previewErrorMessage } from './index.js';
 import './styles.css';
@@ -68,17 +68,18 @@ function TextRenderer({ document, kind, maxTextBytes }) {
 // 标题/代码块/列表/段落，表格、粗体、行内代码、链接、引用全部原样漏出。
 // rehype-raw + sanitize 管线与画布卡片侧（web/src/MarkdownDocument.jsx）对齐：
 // 正文里嵌的 <table>/<br/> 等 raw HTML 原地渲染，白名单在 markdown-sanitize.mjs。
+// markdown-compat.mjs 补两类中文文稿高频缺陷：缺分隔行的表格、紧贴 CJK 的粗体。
 function Markdown({ text }) {
   return (
     <article className="dsh-doc-preview-scroll dsh-doc-preview-markdown">
       <ReactMarkdown
-        remarkPlugins={[remarkGfm]}
+        remarkPlugins={markdownRemarkPlugins}
         rehypePlugins={[rehypeRaw, [rehypeSanitize, markdownSanitizeSchema]]}
         components={{
           a: ({ children, ...props }) => <a {...props} target="_blank" rel="noreferrer">{children}</a>,
           table: ({ node, ...props }) => <div className="md-table-wrap"><table {...props} /></div>,
         }}
-      >{text}</ReactMarkdown>
+      >{repairMissingTableDelimiter(text)}</ReactMarkdown>
     </article>
   );
 }

--- a/dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs
+++ b/dsh-plugins/dsh-ccpg-document-preview/test/index.test.mjs
@@ -15,6 +15,7 @@ import {
   normalizePreviewDocument,
 } from '../src/index.js';
 import { markdownSanitizeSchema } from '../src/markdown-sanitize.mjs';
+import { markdownRemarkPlugins, repairMissingTableDelimiter } from '../src/markdown-compat.mjs';
 
 test('detects supported preview formats by extension', () => {
   const cases = {
@@ -150,6 +151,72 @@ test('markdown: unified pipeline renders raw HTML table and strips script vector
   assert.ok(!hostile.includes('iframe'), hostile);
   // style 整串透传（与卡片侧同取舍，td 的 vertical-align 需要它）：合法值保留
   assert.ok((await run('<table><tr><td style="vertical-align:top">x</td></tr></table>')).includes('vertical-align:top'));
+});
+
+// ---- markdown 兼容层：LLM 中文文稿的两类高频缺陷 ----
+
+test('markdown: repairMissingTableDelimiter 给隔离竖线段落补分隔行', () => {
+  // 缺分隔行：首行后补等宽分隔行，原文一字不动
+  const repaired = repairMissingTableDelimiter('| a | b |\n| 1 | 2 |\n| 3 | 4 |');
+  assert.equal(repaired, '| a | b |\n| --- | --- |\n| 1 | 2 |\n| 3 | 4 |');
+  // 已带分隔行（含对齐变体）的合法表格不动
+  const legal = '| a | b |\n|:--|--:|\n| 1 | 2 |';
+  assert.equal(repairMissingTableDelimiter(legal), legal);
+  // 正文段落里的孤立竖线行不动（可能是普通文本）
+  assert.equal(repairMissingTableDelimiter('前文\n单行 | 竖线\n后文'), '前文\n单行 | 竖线\n后文');
+  // 围栏代码块内的竖线行不动
+  const fenced = '```\n| a | b |\n| 1 | 2 |\n```';
+  assert.equal(repairMissingTableDelimiter(fenced), fenced);
+  // 行内代码里的竖线不算表格语法
+  const inlineCode = '运行 `cmd | filter` 命令';
+  assert.equal(repairMissingTableDelimiter(inlineCode), inlineCode);
+  // \| 转义竖线是单元格内容、不参与分列：分隔行列数须与表头一致
+  assert.equal(
+    repairMissingTableDelimiter('| a \\| b | c |\n| 1 \\| 2 | 3 |'),
+    '| a \\| b | c |\n| --- | --- |\n| 1 \\| 2 | 3 |',
+  );
+  // 单列竖线行（|| 内无内容拆不出多列）不动
+  assert.equal(repairMissingTableDelimiter('| 单列 |'), '| 单列 |');
+  // 无竖线文本原样返回
+  assert.equal(repairMissingTableDelimiter('普通段落'), '普通段落');
+  assert.equal(repairMissingTableDelimiter(''), '');
+});
+
+test('markdown: 完整管线修复缺分隔行表格与 CJK 粗体', async () => {
+  const { unified } = await import('unified');
+  const remarkParse = (await import('remark-parse')).default;
+  const remarkRehype = (await import('remark-rehype')).default;
+  const rehypeRaw = (await import('rehype-raw')).default;
+  const rehypeSanitize = (await import('rehype-sanitize')).default;
+  const rehypeStringify = (await import('rehype-stringify')).default;
+  assert.deepEqual(markdownRemarkPlugins.map((plugin) => plugin.name), ['remarkCjkFriendly', 'remarkGfm']);
+
+  const run = async (text) => String(await unified()
+    .use(remarkParse)
+    .use(markdownRemarkPlugins)
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypeSanitize, markdownSanitizeSchema)
+    .use(rehypeStringify)
+    .process(repairMissingTableDelimiter(text)));
+
+  // 缺分隔行的中文表格：渲染成 thead/tbody，不再整段漏竖线
+  const table = await run('| 配套用房 | 1栋一层老人活动中心。 |\n| 管理用房 | 物业服务中心共计3间。 |');
+  assert.match(table, /<th>配套用房<\/th>/);
+  assert.match(table, /<th>1栋一层老人活动中心。<\/th>/);
+  assert.match(table, /<td>管理用房<\/td>/);
+  assert.ok(!table.includes('| 管理用房'), table);
+
+  // 紧贴 CJK 的粗体：闭定界符前是全角冒号、后是汉字，正常闭合为 <strong>
+  const bold = await run('**周边环境概述：**项目位于深圳市南山区海德一道200号。');
+  assert.match(bold, /<strong>周边环境概述：<\/strong>项目位于深圳市南山区/);
+
+  // 常规 markdown 不回归：空格粗体、合法表格、行内代码、链接
+  assert.match(await run('正常 **粗体** 正常'), /<strong>粗体<\/strong>/);
+  const legal = await run('| a | b |\n| --- | --- |\n| 1 | 2 |');
+  assert.match(legal, /<td>1<\/td>/);
+  assert.match(await run('`code|x`'), /<code>code\|x<\/code>/);
+  assert.match(await run('[链接](https://example.com)'), /href="https:\/\/example.com"/);
 });
 
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -40,25 +40,32 @@
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.1",
+        "rehype-stringify": "10.0.1",
+        "remark-parse": "11.0.0",
         "vite": "^5.4.0"
       }
     },
     "../dsh-plugins/dsh-ccpg-document-preview": {
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@file-viewer/pptx": "2.3.0",
         "docx-preview": "0.4.0",
         "lucide-react": "^1.32.0",
         "pdfjs-dist": "5.6.205",
-        "react-markdown": "^10.1.0",
-        "remark-gfm": "^4.0.1",
+        "react-markdown": ">=9",
+        "rehype-raw": "^7.0.0",
+        "rehype-sanitize": "^6.0.0",
+        "remark-cjk-friendly": "2.3.1",
+        "remark-gfm": ">=4",
         "xlsx": "0.18.5"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "4.3.4",
+        "hast-util-to-html": "^9.0.5",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "rehype-stringify": "^10.0.1",
         "vite": "5.4.19"
       },
       "engines": {
@@ -5117,6 +5124,30 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmmirror.com/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "license": "MIT",
@@ -6542,6 +6573,22 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmmirror.com/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-gfm": {
       "version": "4.0.1",
       "license": "MIT",
@@ -6560,6 +6607,8 @@
     },
     "node_modules/remark-parse": {
       "version": "11.0.0",
+      "resolved": "https://registry.npmmirror.com/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
       "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",

--- a/web/package.json
+++ b/web/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "test": "npm run test:variables && npm run test:results && npm run test:scripts && npm run test:ui",
     "test:variables": "node src/variables.test.mjs && node src/global-variables.test.mjs && node src/json-response.test.mjs && node src/api-base.test.mjs && node src/trial-request.test.mjs && node src/variable-scope.test.mjs && node src/run-event-routing.test.mjs && node src/workflow-serialization.test.mjs && node src/doc-wall-data.test.mjs && node src/live-run-adopt.test.mjs",
-    "test:results": "node src/result-adapter.test.mjs",
+    "test:results": "node src/result-adapter.test.mjs && node src/markdown-compat.test.mjs",
     "test:scripts": "node src/script-parameters.test.mjs",
     "test:ui": "node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs && node src/notify-node.test.mjs && node src/agent-default-label.test.mjs && node src/workflow-transfer-ui.test.mjs && node src/run-switcher.test.mjs && node src/schedule-center.test.mjs && node src/node-detail-polling.test.mjs"
   },
@@ -45,6 +45,8 @@
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",
+    "rehype-stringify": "10.0.1",
+    "remark-parse": "11.0.0",
     "vite": "^5.4.0"
   }
 }

--- a/web/src/MarkdownDocument.jsx
+++ b/web/src/MarkdownDocument.jsx
@@ -1,7 +1,7 @@
 import ReactMarkdown from 'react-markdown';
-import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import { markdownRemarkPlugins, repairMissingTableDelimiter } from 'dsh-ccpg-document-preview/markdown';
 import { DocumentPreviewButton } from 'dsh-ccpg-document-preview/react';
 import { findArtifactByName } from './ArtifactPreview.jsx';
 
@@ -25,7 +25,7 @@ const sanitizeSchema = {
 export default function MarkdownDocument({ content, files = [] }) {
   return (
     <ReactMarkdown
-      remarkPlugins={[remarkGfm]}
+      remarkPlugins={markdownRemarkPlugins}
       rehypePlugins={[rehypeRaw, [rehypeSanitize, sanitizeSchema]]}
       components={{
         a: ({ children, ...props }) => <a {...props} target="_blank" rel="noreferrer">{children}</a>,
@@ -46,7 +46,7 @@ export default function MarkdownDocument({ content, files = [] }) {
         },
       }}
     >
-      {content}
+      {repairMissingTableDelimiter(content)}
     </ReactMarkdown>
   );
 }

--- a/web/src/markdown-compat.test.mjs
+++ b/web/src/markdown-compat.test.mjs
@@ -1,0 +1,53 @@
+// 卡片侧 markdown 兼容层回归：共享模块经 dsh-ccpg-document-preview/markdown
+// 导入（file: 软链），管线用 web 自己的依赖组装，插件清单与
+// MarkdownDocument.jsx 同款（cjk-friendly 在 gfm 前）+ 预处理。
+import assert from 'node:assert/strict';
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkRehype from 'remark-rehype';
+import rehypeRaw from 'rehype-raw';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
+import rehypeStringify from 'rehype-stringify';
+import { markdownRemarkPlugins, repairMissingTableDelimiter } from 'dsh-ccpg-document-preview/markdown';
+
+const sanitizeSchema = {
+  ...defaultSchema,
+  tagNames: [
+    ...(defaultSchema.tagNames || []),
+    'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'col', 'colgroup', 'caption', 'br',
+  ],
+  attributes: {
+    ...defaultSchema.attributes,
+    '*': [...(defaultSchema.attributes?.['*'] || []), 'style', 'align', 'colspan', 'rowspan'],
+  },
+};
+
+const render = async (content) => String(await unified()
+  .use(remarkParse)
+  .use(markdownRemarkPlugins)
+  .use(remarkRehype, { allowDangerousHtml: true })
+  .use(rehypeRaw)
+  .use(rehypeSanitize, sanitizeSchema)
+  .use(rehypeStringify)
+  .process(repairMissingTableDelimiter(content)));
+
+// 实况样例一：缺分隔行的多列中文表格（原样漏出整段竖线）
+const table = await render(
+  '| 配套用房/场地 | 配套场地：1栋一层老人活动中心；活动场地：中心广场。 | 配套场地分散于多栋架空层。 |\n'
+  + '| 管理用房 | 物业服务中心共计3间，管理用房不足。 | 沟通增加物业用房。 |',
+);
+assert.match(table, /<th>配套用房\/场地<\/th>/);
+assert.match(table, /<td>管理用房<\/td>/);
+assert.ok(!table.includes('| 管理用房'), table);
+
+// 实况样例二：闭定界符前是全角冒号、后紧贴汉字的粗体（星号原样漏出）
+const bold = await render('**周边环境概述：**项目位于深圳市南山区海德一道200号，地处南山商业文化中心区。');
+assert.match(bold, /<strong>周边环境概述：<\/strong>项目位于深圳市南山区/);
+assert.ok(!bold.includes('**'), bold);
+
+// 已带分隔行的合法表格与常规语法不回归
+assert.match(await render('| a | b |\n| --- | --- |\n| 1 | 2 |'), /<td>1<\/td>/);
+assert.match(await render('正常 **粗体** 正常'), /<strong>粗体<\/strong>/);
+assert.match(await render('[链接](https://example.com)'), /href="https:\/\/example.com"/);
+
+console.log('✓ markdown-compat（卡片侧管线）：缺分隔行表格 + CJK 粗体修复与常规回归全部通过');


### PR DESCRIPTION
## 背景

用户实报两例文稿预览渲染异常：

1. 多列中文表格整段竖线原样漏出（配套用房/管理用房等行）
2. `**周边环境概述：**项目…` 粗体星号原样漏出

排查确认是两个独立的解析层根因：

- **表格缺分隔行**：GFM 规范强制 `| --- | --- |` 分隔行作为表头定界，缺失时 remark-gfm 不认为是表格，整段按段落处理
- **CJK 粗体侧翼规则**：CommonMark 按西文空白判定定界符开合；闭 `**` 前是全角标点、后紧贴汉字时无法闭合（探针实证：`**加粗：**汉字` 失败、`**加粗**汉字` 正常）

## 方案

新增共享兼容层 `document-preview/src/markdown-compat.mjs`：

- `repairMissingTableDelimiter`：隔离竖线行组缺分隔行时自动补等宽分隔行；跳过围栏代码块、行内代码、`\|` 转义，合法表格与散落正文不动
- `markdownRemarkPlugins`：`remark-cjk-friendly`（remarkjs 官方生态插件，改写 CJK 上下文 emphasis 侧翼分类）+ remark-gfm 统一清单，经 package exports `./markdown` 导出

两侧管线接入同源模块：预览弹窗 `document-preview/src/react.jsx` + 画布卡片 `web/src/MarkdownDocument.jsx`（原先各写一份插件清单）。

## 验证

- 单测：document-preview 13 套全绿（新增预处理边界 + 端到端断言）；web 新增 `markdown-compat.test.mjs`（挂入 test:results）断言实况样例修复与常规回归；全仓 `npm test` 通过
- 双构建：`build-web.sh` 通过；画布 bundle 与 runtime 自包含产物均确认含修复逻辑
- 真浏览器：起真实 dsh web profile，官方 UI 内以两段实况内容调 `dshDocumentPreview.open()`——表格渲染出 4 列 thead/tbody（无竖线漏出），粗体渲染出 `<strong>周边环境概述：</strong>`（无星号漏出）

## 已知无关问题（不在本 PR 范围）

web profile 官方 UI 聚合 URL（`/plugins/??…`）加载插件 client 时，document-preview 的 client.js 用 `document.currentScript.src` 推导基址会解析到 `/plugins/client-assets/` → 404，弹窗入口注册不上（Desktop 逐插件加载无此问题）。后续单独修。