### PR TITLE
feat(orchestrator): webhook 对接加固——HMAC 签名、幂等键、完成回调 (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,11 +197,21 @@ Workflow One 嵌在 dsh 官方界面中，推荐从 AI 对话开始创建复杂�
 | 运行 | `POST /run`、`POST /run/cancel`、`GET /runs`、`GET /runs/detail`、`GET /runs/export`、`POST /runs/replay`、`GET /run-results`、`GET /run-artifact` |
 | 节点 | `POST /node/test`（试运行）、`GET /node-detail` |
 | 产物 | `GET /artifact`（节点工作区文件，支持 preview/Range）、`GET/POST /attachments` |
-| 触发 | `GET/POST/DELETE /hooks`（webhook，token 鉴权）、`GET/POST/PATCH/DELETE /schedule`（cron，含 overlap/misfirePolicy/启停）、`POST /schedule/preview`（下 3 次触发）、`POST /schedule/run`（立即运行） |
+| 触发 | `GET/POST/PATCH/DELETE /hooks`（webhook，token 鉴权 + 可选 HMAC 签名/幂等键/完成回调）、`GET/POST/PATCH/DELETE /schedule`（cron，含 overlap/misfirePolicy/启停）、`POST /schedule/preview`（下 3 次触发）、`POST /schedule/run`（立即运行） |
 | 变量/模板 | `GET /variables/describe`、`GET/POST /global-variables`、`POST /template/render`、`POST /template/validate` |
 | 配置 | `GET /tools`、`GET /skills`、`GET /llm-config`、`GET/POST /runtime-config`、`GET/POST/DELETE /feishu-credentials`、`GET/POST /lark-auth` |
 | AI 助手 | `POST /assistant/bind` / `unbind`、`GET /assistant/canvas-state` |
 | 实时 | `GET /events`（SSE）、`GET /state` |
+
+### webhook 对接协议（可选加固，全部向后兼容）
+
+`POST /wf1/api/hooks/<id>` 触发（GET 也可，经 `?input=`）。基础鉴权用 token（`?token=` / `Authorization: Bearer` / `X-Hook-Token` 三选一，常数时间比较）。三项可选能力按 hook 配置启用，未配置的存量 hook 行为零变化：
+
+- **HMAC 签名**（`PATCH /hooks { id, signingSecret }` 配置，≥16 字符）：请求必须带 `X-WF1-Timestamp`（unix 秒，±5 分钟窗口）与 `X-WF1-Signature: sha256=<hex>`；签名为 HMAC-SHA256(secret, rawBodyBytes + timestamp) 的 hex——覆盖**原始 body 字节**（GET 无 body 时对空字节签名），不要先 JSON 序列化再签
+- **幂等键**：请求头 `Idempotency-Key`（或 body.inputs.idempotencyKey）；24h 窗口内同 key 直接返回首次 runId（`{ ok, runId, idempotent: true }`）不起新 run
+- **完成回调**（`PATCH /hooks { id, callbackUrl }` 配置）：run 终态（success/error/canceled）POST 回调负载 `X-WF1-Event: workflow_run.finished`：`{ event, hookId, runId, status, workflowId, workflowName, startedAt, finishedAt, durationMs, summary }`（summary 脱敏+截断）；发送失败只记日志与内存元数据，不重试、不影响运行状态
+
+触发与手动/助手路径走同一条校验链（图 lint + 输入 schema）：坏图/坏输入返回 422 `{ ok: false, error, code }`。
 
 ## 环境变量
 

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -13,7 +13,7 @@
 //
 // HTTP 全部挂 ctx.webServer（/wf1 前缀，避开 dsh 自己的 /api）。
 
-import { randomUUID } from 'node:crypto';
+import { createHmac, randomUUID, timingSafeEqual } from 'node:crypto';
 import { AsyncLocalStorage } from 'node:async_hooks';
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync, copyFileSync, cpSync, unlinkSync, renameSync, realpathSync, rmSync, openSync, readSync, closeSync, constants as fsConstants } from 'node:fs';
 import { join, dirname, extname, isAbsolute, relative, resolve, sep, basename } from 'node:path';
@@ -53,7 +53,7 @@ import {
 import { FeishuClient } from './feishu.js';
 import { createFeishuNotificationChannel } from './notification-feishu.js';
 import { collectInstallReport, compareSemver, executePlan, planUpgrade, PACKAGE as UPGRADE_PACKAGE } from './system-upgrade.js';
-import { NotificationChannelRegistry, WorkflowNotificationManager } from './notifications.js';
+import { NotificationChannelRegistry, WorkflowNotificationManager, summarizeNotificationText } from './notifications.js';
 import { listFeishuCreds, addFeishuCred, removeFeishuCred, setDefaultFeishuCred, getFeishuCredOrEnv } from './credentials.js';
 import { Orchestrator, lintGraph, getKind } from './engine.js';
 import { validateWorkflowInputs } from './workflow-inputs.js';
@@ -98,6 +98,8 @@ const RUNS_KEEP = 100; // 运行历史保留条数（按开始时间新→旧）
 const REQUEST_BODY_LIMIT = 8_000_000;
 const MAX_MANUAL_REVISION_CONTENT = 400 * 1024; // 手工编辑正文上限（字符），防超大写入库表
 const TERMINAL_NODE_STATUSES = new Set(['success', 'error', 'canceled', 'skipped']);
+const HOOK_SIGNATURE_TOLERANCE_SEC = 5 * 60; // HMAC 时间窗，窗外拒绝（防重放）
+const HOOK_IDEMPOTENCY_WINDOW_MS = 24 * 60 * 60 * 1000; // 幂等键窗口，窗口内同 key 复用首次 runId
 let runIdSeq = 0;
 let ctxRef = null;
 
@@ -108,6 +110,61 @@ class RequestBodyError extends Error {
     this.code = code;
   }
 }
+
+// ---- webhook 加固纯函数（导出供测试直接断言）----
+
+// 常数时间字符串比较：长度不等先短路（timingSafeEqual 要求等长 Buffer）。
+export const secureTokenMatch = (presented, expected) => {
+  if (typeof presented !== 'string' || typeof expected !== 'string' || !presented || !expected) return false;
+  const a = Buffer.from(presented);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+};
+
+// HMAC 验签：X-WF1-Signature: sha256=<hex>，覆盖 raw body 字节 + 时间戳。
+// 返回 null 表示通过；否则返回拒绝原因（路由层转 401 文案）。
+export const verifyHookSignature = ({ signingSecret, raw, signatureHeader, timestampHeader, now = Date.now() }) => {
+  if (!signingSecret) return null; // 未配置签名密钥的存量 hook 只走 token
+  const m = /^sha256=([0-9a-f]{64})$/i.exec(String(signatureHeader || '').trim());
+  if (!m) return '缺少或格式错误的 X-WF1-Signature（应为 sha256=<hex>）';
+  const ts = Number(String(timestampHeader || '').trim());
+  if (!Number.isFinite(ts)) return '缺少或非法的 X-WF1-Timestamp（unix 秒）';
+  if (Math.abs(now / 1000 - ts) > HOOK_SIGNATURE_TOLERANCE_SEC) return 'X-WF1-Timestamp 超出时间窗（±5 分钟）';
+  const expected = createHmac('sha256', signingSecret).update(Buffer.from(raw || Buffer.alloc(0))).update(String(timestampHeader).trim()).digest('hex');
+  const presented = m[1].toLowerCase();
+  return presented === expected.toLowerCase() ? null : '签名不匹配';
+};
+
+// 幂等命中判定：同 key 且窗口内 → 复用 runId；窗口外/异 key → 不命中。
+export const matchHookIdempotency = (hook, key, now = Date.now()) => {
+  if (!key || !hook?.lastIdempotency) return null;
+  const { key: lastKey, runId, at } = hook.lastIdempotency;
+  if (lastKey !== key) return null;
+  const age = now - Date.parse(at || '');
+  if (!Number.isFinite(age) || age < 0 || age > HOOK_IDEMPOTENCY_WINDOW_MS) return null;
+  return runId || null;
+};
+
+// 完成回调负载：与通知事件同款脱敏（summarizeNotificationText）+ 截断。
+export const buildHookCallbackPayload = ({ hookId, run }) => ({
+  event: 'workflow_run.finished',
+  hookId,
+  runId: run?.runId ?? null,
+  status: run?.status ?? null,
+  workflowId: run?.workflowId ?? null,
+  workflowName: run?.workflowName ?? null,
+  startedAt: run?.startedAt ?? null,
+  finishedAt: run?.finishedAt ?? null,
+  durationMs: typeof run?.durationMs === 'number' ? run.durationMs : null,
+  summary: summarizeNotificationText(run?.summary || summarizeOutputsForCallback(run)),
+});
+
+const summarizeOutputsForCallback = (run) => {
+  try {
+    const first = Object.values(run?.outputs || {})[0];
+    return typeof first === 'string' ? first : JSON.stringify(first ?? '');
+  } catch { return ''; }
+};
 
 // 原子写入：临时文件 + rename，进程中途挂掉不会留截断 JSON
 const atomicWrite = (file, data) => {
@@ -262,7 +319,10 @@ export function apply(ctx, config) {
     res.writeHead(code, { 'Content-Type': 'application/json; charset=utf-8' });
     res.end(JSON.stringify(body));
   };
-  const readBody = (req) => new Promise((resolve, reject) => {
+  // raw:true 供 webhook HMAC 验签：resolve { raw, body }——签名必须覆盖原始
+  // body 字节，JSON.parse 后的代理对象无法还原（键序/空白不同即签名漂移）。
+  // 不传选项的行为与历史完全一致（只回解析后的对象）。
+  const readBody = (req, options = {}) => new Promise((resolve, reject) => {
     const chunks = [];
     let bytes = 0;
     let failed = false;
@@ -285,8 +345,10 @@ export function apply(ctx, config) {
     req.on('end', () => {
       if (failed) return;
       try {
-        const text = new TextDecoder('utf-8', { fatal: true }).decode(Buffer.concat(chunks, bytes));
-        resolve(JSON.parse(text || '{}'));
+        const raw = Buffer.concat(chunks, bytes);
+        const text = new TextDecoder('utf-8', { fatal: true }).decode(raw);
+        const body = JSON.parse(text || '{}');
+        resolve(options.raw ? { raw, body } : body);
       } catch {
         reject(new RequestBodyError('请求体不是有效的 UTF-8 JSON', 400, 'invalid-request-body'));
       }
@@ -1142,6 +1204,32 @@ export function apply(ctx, config) {
     return { ...result, artifacts: safeWsList(ws) };
   };
 
+  // ---- webhook 完成回调（失败隔离：只记日志/内存元数据，绝不影响运行状态）----
+  const pendingHookCallbacks = new Map(); // runId → hook
+  const fireHookCallback = (hook, runId) => {
+    pendingHookCallbacks.set(runId, hook);
+  };
+  const firePendingHookCallbacks = (runId, run) => {
+    const hook = pendingHookCallbacks.get(runId);
+    pendingHookCallbacks.delete(runId);
+    if (!hook?.callbackUrl || !run) return;
+    const payload = buildHookCallbackPayload({ hookId: hook.id, run });
+    fetch(hook.callbackUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'X-WF1-Event': payload.event, 'X-WF1-Hook': hook.id },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(10_000),
+    }).then((r) => {
+      if (!r.ok) throw new Error(`callback HTTP ${r.status}`);
+      hook.lastCallbackAt = new Date().toISOString();
+      delete hook.lastCallbackError;
+    }).catch((error) => {
+      // 失败只记内存元数据 + 日志（与通知失败隔离同款约定），不重试、不改 run 状态
+      hook.lastCallbackError = String(error?.message || error);
+      ctx.logger?.warn?.(`[webhook] 完成回调失败（${hook.id} → ${hook.callbackUrl}）：${hook.lastCallbackError}`);
+    });
+  };
+
   const startRun = (graph, {
     triggerInput, workflowName, workflowId, canvasId, source,
     globalVariables = {}, workflowVariables = {}, runInputs = {}, runId: providedRunId, replayOf, resume, revises,
@@ -1184,6 +1272,7 @@ export function apply(ctx, config) {
         ctx.logger?.warn?.(`[notify] 运行通知收尾失败（${runId}）：${error.message}`);
       }
       persistRun(run, graph, workflowName, workflowId);
+      firePendingHookCallbacks(runId, run);
       return run;
     })).catch((error) => {
       notifications.discard(runId);
@@ -2553,7 +2642,7 @@ export function apply(ctx, config) {
   } });
 
   // ---- webhook + 定时触发（落盘 state/triggers.json，重启自动恢复）----
-  // hooks: [{ id, token, workflowId, workflowName, createdAt }]
+  // hooks: [{ id, token, workflowId, workflowName, createdAt, signingSecret?, callbackUrl?, lastIdempotency? }]
   // schedules meta 字段见 lib/schedule.js normalizeScheduleMeta
   const loadTriggers = () => {
     const store = currentStore();
@@ -2577,7 +2666,12 @@ export function apply(ctx, config) {
     try {
       const store = currentStore();
       atomicJson(store.triggersFile, {
-        hooks: [...currentHooks().values()].map(({ id, token, workflowId, workflowName, createdAt }) => ({ id, token, workflowId, workflowName, createdAt })),
+        hooks: [...currentHooks().values()].map(({ id, token, workflowId, workflowName, createdAt, signingSecret, callbackUrl, lastIdempotency }) => ({
+          id, token, workflowId, workflowName, createdAt,
+          ...(signingSecret ? { signingSecret } : {}),
+          ...(callbackUrl ? { callbackUrl } : {}),
+          ...(lastIdempotency ? { lastIdempotency } : {}),
+        })),
         schedules: [...currentSchedulerMeta().entries()].map(([key, m]) => persistableScheduleMeta({ ...m, key })),
       });
     } catch { /* 落盘失败不影响运行 */ }
@@ -2585,7 +2679,13 @@ export function apply(ctx, config) {
 
   register({ kind: 'exact', path: '/wf1/api/hooks', async handler(req, res) {
     if (req.method === 'GET') {
-      return json(res, 200, { hooks: [...currentHooks().values()].map((h) => ({ ...h, url: `/wf1/api/hooks/${h.id}` })) });
+      // signingSecret 不回传（只暴露是否配置）；token 维持历史行为原样返回
+      const hooks = [...currentHooks().values()].map(({ signingSecret, ...h }) => ({
+        ...h,
+        hasSigningSecret: Boolean(signingSecret),
+        url: `/wf1/api/hooks/${h.id}`,
+      }));
+      return json(res, 200, { hooks });
     }
     if (req.method === 'POST') {
       const body = await readBody(req);
@@ -2598,6 +2698,33 @@ export function apply(ctx, config) {
       publicHooks.set(id, { store: currentStore(), hook });
       persistTriggers();
       return json(res, 200, { ok: true, id, token, url: `/wf1/api/hooks/${id}` });
+    }
+    if (req.method === 'PATCH') {
+      const body = await readBody(req);
+      const hook = currentHooks().get(String(body?.id || ''));
+      if (!hook) return json(res, 404, { error: 'hook 不存在' });
+      if ('signingSecret' in (body || {})) {
+        const secret = String(body.signingSecret || '').trim();
+        if (secret) {
+          if (secret.length < 16) return json(res, 400, { error: 'signingSecret 至少 16 个字符' });
+          hook.signingSecret = secret;
+        } else delete hook.signingSecret;
+      }
+      if ('callbackUrl' in (body || {})) {
+        const url = String(body.callbackUrl || '').trim();
+        if (url) {
+          try { if (!['http:', 'https:'].includes(new URL(url).protocol)) throw new Error('protocol'); }
+          catch { return json(res, 400, { error: 'callbackUrl 必须是合法的 http(s) URL' }); }
+          hook.callbackUrl = url;
+        } else delete hook.callbackUrl;
+      }
+      if (body?.token) {
+        hook.token = randomUUID().replace(/-/g, ''); // 轮换由服务端生成，不接受外部指定值
+      }
+      currentHooks().set(hook.id, hook);
+      publicHooks.set(hook.id, { store: currentStore(), hook });
+      persistTriggers();
+      return json(res, 200, { ok: true, id: hook.id, token: hook.token, hasSigningSecret: Boolean(hook.signingSecret), callbackUrl: hook.callbackUrl || '' });
     }
     if (req.method === 'DELETE') {
       const url = new URL(req.url, 'http://x');
@@ -2627,32 +2754,57 @@ export function apply(ctx, config) {
       const hook = owner.hook;
       const u = new URL(req.url, 'http://x');
       const presented = u.searchParams.get('token')
-        || String(req.headers.authorization || '').replace(/^Bearer\s+/i, '')
+        || (/^Bearer\s+/i.test(String(req.headers.authorization || '')) ? String(req.headers.authorization).replace(/^Bearer\s+/i, '') : '')
         || String(req.headers['x-hook-token'] || '');
-      if (!presented || presented !== hook.token) {
+      if (!presented || !secureTokenMatch(presented, hook.token)) {
         return json(res, 401, { error: '缺少或错误的 hook token（?token= 或 Authorization: Bearer 或 X-Hook-Token）' });
       }
       const wf = readWf(hook.workflowId);
       if (!wf) return json(res, 404, { error: 'hook 指向的工作流已删除' });
       let triggerInput = '';
       let runInputs = {};
+      let rawBody = Buffer.alloc(0);
       try {
         triggerInput = u.searchParams.get('input') || '';
         if (req.method === 'POST') {
-          const body = await readBody(req);
+          const { raw, body } = await readBody(req, { raw: true });
+          rawBody = raw;
           if (!triggerInput) triggerInput = String(body?.input || body?.text || (typeof body === 'string' ? body : ''));
           runInputs = assertSafeContextObject(body?.inputs, 'inputs');
         }
       } catch (error) { return routeError(res, error); }
-      let globals; try { globals = globalContext(); } catch (error) { return routeError(res, error); }
-      const { runId } = startRun(wf.graph, {
-        triggerInput, workflowName: wf.name, workflowId: wf.id,
-        globalVariables: globals.globalVariables,
-        workflowVariables: variableDefinitionsToValues(wf.variables),
-        runInputs,
-        source: 'webhook',
-      });
-      return json(res, 200, { ok: true, triggered: wf.name, runId });
+      // 配置了 signingSecret 的 hook 强制验签（覆盖 raw body 字节 + 时间戳）
+      if (hook.signingSecret) {
+        const rejected = verifyHookSignature({
+          signingSecret: hook.signingSecret,
+          raw: rawBody,
+          signatureHeader: req.headers['x-wf1-signature'],
+          timestampHeader: req.headers['x-wf1-timestamp'],
+        });
+        if (rejected) return json(res, 401, { error: `验签失败：${rejected}` });
+      }
+      // 幂等键：窗口内同 key 复用首次 runId，不起新 run
+      const idempotencyKey = String(req.headers['idempotency-key'] || '').trim()
+        || (typeof runInputs?.idempotencyKey === 'string' ? runInputs.idempotencyKey.trim() : '');
+      if (idempotencyKey) {
+        const hit = matchHookIdempotency(hook, idempotencyKey);
+        if (hit) return json(res, 200, { ok: true, triggered: wf.name, runId: hit, idempotent: true });
+      }
+      // 与 manual/assistant 同一条校验链（lint + inputSchema）；失败映射 422
+      const started = startWorkflowRun(wf, { triggerInput, runInputs, source: 'webhook' });
+      if (!started.ok) {
+        const status = ['workflow-invalid-graph', 'workflow-input-invalid'].includes(started.code) ? 422 : 400;
+        return json(res, status, { ok: false, error: started.error, code: started.code });
+      }
+      if (idempotencyKey) {
+        hook.lastIdempotency = { key: idempotencyKey, runId: started.runId, at: new Date().toISOString() };
+        persistTriggers();
+      }
+      // 完成回调：fire-and-forget，失败只记日志与内存元数据，不碰运行状态
+      if (hook.callbackUrl) {
+        fireHookCallback(hook, started.runId);
+      }
+      return json(res, 200, { ok: true, triggered: wf.name, runId: started.runId });
     });
   } }, { scoped: false });
 

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/webhook-hooks.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/webhook-hooks.integration.test.mjs
@@ -1,0 +1,315 @@
+// webhook 对接加固集成测试（假 webServer 直调路由，与 schedule-api 同模式）：
+// HMAC 签名 / timing-safe token / 幂等键 / 完成回调 / PATCH 配置 / 统一起跑校验。
+import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
+import { createHmac } from 'node:crypto';
+import { mkdtempSync, readFileSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { apply, verifyHookSignature, matchHookIdempotency, buildHookCallbackPayload, secureTokenMatch } from '../lib/index.js';
+
+function responseCapture() {
+  const listeners = new Map();
+  return {
+    status: 0,
+    headers: {},
+    chunks: [],
+    writableEnded: false,
+    writeHead(status, headers = {}) { this.status = status; this.headers = headers; },
+    write(chunk) { this.chunks.push(Buffer.from(chunk)); },
+    end(chunk) { if (chunk) this.chunks.push(Buffer.from(chunk)); this.writableEnded = true; },
+    on(event, callback) { listeners.set(event, callback); return this; },
+    once(event, callback) { const inner = listeners.get(event); listeners.set(event, () => { inner?.(); callback(); }); return this; },
+    emit(event) { listeners.get(event)?.(); return true; },
+    destroy(error) { if (error) throw error; },
+    json() { return JSON.parse(Buffer.concat(this.chunks).toString('utf8') || '{}'); },
+  };
+}
+
+// rawRequest：支持任意 Buffer body + 自定义 headers（HMAC 必须对原始字节签名）
+function rawRequest(method, url, { raw, headers = {} } = {}) {
+  const req = new EventEmitter();
+  req.method = method;
+  req.url = url;
+  req.headers = headers;
+  queueMicrotask(() => {
+    if (raw !== undefined) req.emit('data', Buffer.isBuffer(raw) ? raw : Buffer.from(raw));
+    req.emit('end');
+  });
+  return req;
+}
+
+const withSession = (url, sessionId) => `${url}${url.includes('?') ? '&' : '?'}sessionId=${sessionId}`;
+const dshHome = mkdtempSync(join(tmpdir(), 'wf1-hook-home-'));
+const workspacesRoot = mkdtempSync(join(tmpdir(), 'wf1-hook-ws-'));
+const workspace = join(workspacesRoot, 'ws');
+mkdirSync(workspace, { recursive: true });
+const originalEnv = { DSH_HOME: process.env.DSH_HOME, WF1_LEGACY_DATA_DIR: process.env.WF1_LEGACY_DATA_DIR };
+process.env.DSH_HOME = dshHome;
+const packageLegacyDir = join(dshHome, 'package-legacy');
+mkdirSync(join(packageLegacyDir, 'state'), { recursive: true });
+process.env.WF1_LEGACY_DATA_DIR = packageLegacyDir;
+writeFileSync(join(packageLegacyDir, 'state', 'graph.json'), JSON.stringify({ nodes: [], edges: [] }));
+
+const triggersFile = () => join(workspace, '.workflow-one', 'state', 'triggers.json');
+const readTriggers = () => JSON.parse(readFileSync(triggersFile(), 'utf8'));
+const disposers = [];
+const results = [];
+const test = async (name, fn) => {
+  try { await fn(); results.push(['✓', name]); }
+  catch (error) { results.push(['✗', name, error]); }
+};
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const ctx = {
+  webServer: { register(route) { this.routes.push(route); }, routes: [] },
+  tools: { register() {}, schemas() { return []; } },
+  get(name) {
+    if (name === 'sessions') return { get: (id) => (String(id) === 'session-1' ? { header: { cwd: workspace } } : undefined), flush: async () => {} };
+    if (name === 'workspaceRegistry') return { list: () => [{ path: workspace }] };
+    return null;
+  },
+  skills: { async list() { return []; } },
+  llm: { listProviders() { return []; }, async listModels() { return []; } },
+  agentPresets: { async mount() {} },
+  logger: { info() {}, warn() {}, error() {} },
+  effect(setup) { const dispose = setup(); if (dispose) disposers.push(dispose); },
+};
+apply(ctx, {});
+const exactRoute = (path) => ctx.webServer.routes.find((entry) => entry.kind === 'exact' && entry.path === path)?.handler;
+const prefixRoute = (path) => ctx.webServer.routes.find((entry) => entry.kind === 'prefix' && entry.path === path)?.handler;
+const call = async (method, url, body) => {
+  const res = responseCapture();
+  await exactRoute(url.split('?')[0])(rawRequest(method, withSession(url, 'session-1'), { raw: JSON.stringify(body ?? {}) }), res);
+  return { status: res.status, body: res.json() };
+};
+// webhook 触发路由（scoped:false，不需要 sessionId）
+const fire = async ({ method = 'POST', hookId, token, body, headers = {} }) => {
+  const res = responseCapture();
+  const url = `/wf1/api/hooks/${hookId}${token ? `?token=${token}` : ''}`;
+  const req = rawRequest(method, url, {
+    raw: body === undefined ? undefined : JSON.stringify(body),
+    headers,
+  });
+  await prefixRoute('/wf1/api/hooks')(req, res);
+  return { status: res.status, body: res.json() };
+};
+const hmacHeaders = (secret, rawBody, { ts = Math.floor(Date.now() / 1000) } = {}) => ({
+  'x-wf1-signature': `sha256=${createHmac('sha256', secret).update(rawBody).update(String(ts)).digest('hex')}`,
+  'x-wf1-timestamp': String(ts),
+});
+
+const wfGraph = {
+  nodes: [{ id: 'hk_input', type: 'input', position: { x: 0, y: 0 }, data: { label: '输入', text: 'ok' } }],
+  edges: [],
+};
+const created = await call('POST', '/wf1/api/workflows', { id: 'wf_hook', name: 'webhook测试工作流', graph: wfGraph });
+assert.equal(created.status, 200);
+const hookCreated = await call('POST', '/wf1/api/hooks', { workflowId: 'wf_hook' });
+assert.equal(hookCreated.status, 200);
+const hookId = hookCreated.body.id;
+const hookToken = hookCreated.body.token;
+
+// ---- 纯函数 ----
+
+await test('纯函数：secureTokenMatch 常数时间比较', () => {
+  assert.equal(secureTokenMatch(hookToken, hookToken), true);
+  assert.equal(secureTokenMatch(hookToken + 'x', hookToken), false);
+  assert.equal(secureTokenMatch('', hookToken), false);
+  assert.equal(secureTokenMatch(hookToken, ''), false);
+});
+
+await test('纯函数：verifyHookSignature 签名/时间窗判定', () => {
+  const secret = 's'.repeat(16);
+  const raw = Buffer.from('{"input":"x"}');
+  const ok = hmacHeaders(secret, raw);
+  assert.equal(verifyHookSignature({ signingSecret: secret, raw, signatureHeader: ok['x-wf1-signature'], timestampHeader: ok['x-wf1-timestamp'] }), null);
+  assert.match(verifyHookSignature({ signingSecret: secret, raw, signatureHeader: '', timestampHeader: '' }), /X-WF1-Signature/);
+  assert.match(verifyHookSignature({ signingSecret: secret, raw, signatureHeader: 'sha256=' + '0'.repeat(64), timestampHeader: ok['x-wf1-timestamp'] }), /签名不匹配/);
+  assert.match(verifyHookSignature({ signingSecret: secret, raw, signatureHeader: ok['x-wf1-signature'], timestampHeader: String(Math.floor(Date.now() / 1000) - 3600) }), /时间窗/);
+  assert.equal(verifyHookSignature({ signingSecret: '', raw }), null, '未配 secret 直接通过');
+});
+
+await test('纯函数：matchHookIdempotency 窗口与 key 判定', () => {
+  const now = Date.now();
+  const hook = { lastIdempotency: { key: 'k1', runId: 'run_a', at: new Date(now - 1000).toISOString() } };
+  assert.equal(matchHookIdempotency(hook, 'k1', now), 'run_a');
+  assert.equal(matchHookIdempotency(hook, 'k2', now), null);
+  const stale = { lastIdempotency: { key: 'k1', runId: 'run_a', at: new Date(now - 25 * 3600 * 1000).toISOString() } };
+  assert.equal(matchHookIdempotency(stale, 'k1', now), null, '窗口外不命中');
+  assert.equal(matchHookIdempotency({ lastIdempotency: undefined }, 'k1', now), null);
+  assert.equal(matchHookIdempotency(hook, '', now), null);
+});
+
+await test('纯函数：buildHookCallbackPayload 脱敏与截断', () => {
+  const payload = buildHookCallbackPayload({ hookId: 'hk_x', run: { runId: 'r1', status: 'success', summary: 'password=abc123 完成' } });
+  assert.equal(payload.event, 'workflow_run.finished');
+  assert.equal(payload.hookId, 'hk_x');
+  assert.equal(payload.status, 'success');
+  assert.ok(!payload.summary.includes('abc123'), 'secret 必须脱敏');
+});
+
+// ---- 路由行为 ----
+
+await test('token 错误 401；正确触发 200 且 source=webhook（走过 lint 校验链）', async () => {
+  const denied = await fire({ hookId, token: 'wrong', body: { input: 'x' } });
+  assert.equal(denied.status, 401);
+  const ok = await fire({ hookId, token: hookToken, body: { input: '巡检' } });
+  assert.equal(ok.status, 200);
+  assert.ok(ok.body.runId);
+  globalThis.__hookRunId = ok.body.runId;
+  let detail;
+  for (let i = 0; i < 30; i += 1) {
+    const res = await call('GET', `/wf1/api/runs/detail?id=${ok.body.runId}`);
+    detail = res.body;
+    if (detail.status && detail.status !== 'running') break;
+    await sleep(20);
+  }
+  assert.equal(detail.source, 'webhook');
+});
+
+await test('PATCH：配置 signingSecret/callbackUrl 落盘可重载；GET 脱敏不回传 secret', async () => {
+  const patched = await call('PATCH', '/wf1/api/hooks', { id: hookId, signingSecret: 'topsecret-16-chars-min', callbackUrl: 'http://127.0.0.1:19999/done' });
+  assert.equal(patched.status, 200);
+  assert.equal(patched.body.hasSigningSecret, true);
+  const disk = readTriggers().hooks.find((h) => h.id === hookId);
+  assert.equal(disk.signingSecret, 'topsecret-16-chars-min');
+  assert.equal(disk.callbackUrl, 'http://127.0.0.1:19999/done');
+  const list = await call('GET', '/wf1/api/hooks');
+  const row = list.body.hooks.find((h) => h.id === hookId);
+  assert.equal(row.signingSecret, undefined, 'GET 不得回传 secret');
+  assert.equal(row.hasSigningSecret, true);
+  const short = await call('PATCH', '/wf1/api/hooks', { id: hookId, signingSecret: 'too-short' });
+  assert.equal(short.status, 400);
+  const badUrl = await call('PATCH', '/wf1/api/hooks', { id: hookId, callbackUrl: 'javascript:alert(1)' });
+  assert.equal(badUrl.status, 400);
+  const missing = await call('PATCH', '/wf1/api/hooks', { id: 'hk_none', signingSecret: 'x'.repeat(20) });
+  assert.equal(missing.status, 404);
+});
+
+await test('HMAC：签名缺失/错误 401；正确签名 200；GET 空体也可签名', async () => {
+  const body = { input: 'signed' };
+  const raw = Buffer.from(JSON.stringify(body));
+  const noSig = await fire({ hookId, token: hookToken, body });
+  assert.equal(noSig.status, 401);
+  assert.match(noSig.body.error, /验签失败/);
+  const badSig = await fire({ hookId, token: hookToken, body, headers: hmacHeaders('wrong-secret-16chars!', raw) });
+  assert.equal(badSig.status, 401);
+  const ok = await fire({ hookId, token: hookToken, body, headers: hmacHeaders('topsecret-16-chars-min', raw) });
+  assert.equal(ok.status, 200);
+  const getOk = await fire({ method: 'GET', hookId, token: hookToken, headers: hmacHeaders('topsecret-16-chars-min', Buffer.alloc(0)) });
+  assert.equal(getOk.status, 200);
+});
+
+await test('幂等：同 key 复用首次 runId 不起新 run；异 key 正常起跑', async () => {
+  const first = await fire({
+    hookId, token: hookToken, body: { input: 'job1' },
+    headers: { 'idempotency-key': 'op-42', ...hmacHeaders('topsecret-16-chars-min', Buffer.from(JSON.stringify({ input: 'job1' }))) },
+  });
+  assert.equal(first.status, 200);
+  assert.equal(first.body.idempotent, undefined);
+  const firstRunId = first.body.runId;
+  const replayBody = Buffer.from(JSON.stringify({ input: 'job1' }));
+  const replay = await fire({
+    hookId, token: hookToken, body: { input: 'job1' },
+    headers: { 'idempotency-key': 'op-42', ...hmacHeaders('topsecret-16-chars-min', replayBody) },
+  });
+  assert.equal(replay.status, 200);
+  assert.equal(replay.body.runId, firstRunId, '同 key 复用首次 runId');
+  assert.equal(replay.body.idempotent, true);
+  const disk = readTriggers().hooks.find((h) => h.id === hookId);
+  assert.equal(disk.lastIdempotency.key, 'op-42');
+  assert.equal(disk.lastIdempotency.runId, firstRunId);
+  const otherBody = Buffer.from(JSON.stringify({ input: 'job2' }));
+  const other = await fire({
+    hookId, token: hookToken, body: { input: 'job2' },
+    headers: { 'idempotency-key': 'op-43', ...hmacHeaders('topsecret-16-chars-min', otherBody) },
+  });
+  assert.equal(other.status, 200);
+  assert.notEqual(other.body.runId, firstRunId);
+});
+
+await test('完成回调：终态 POST callbackUrl；失败只记元数据不影响运行', async () => {
+  // 前序测试起的 run 可能仍有迟到回调：先排空（等所有活跃 run 到终态）
+  for (let i = 0; i < 50; i += 1) {
+    const res = await call('GET', '/wf1/api/runs');
+    if (!(res.body.runs || []).some((r) => r.status === 'running')) break;
+    await sleep(20);
+  }
+  const calls = [];
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url: String(url), body: JSON.parse(init.body) });
+    return { ok: true, status: 200 };
+  };
+  try {
+    const body = JSON.stringify({ input: 'cb' });
+    const fired = await fire({
+      hookId, token: hookToken, body: { input: 'cb' },
+      headers: { ...hmacHeaders('topsecret-16-chars-min', Buffer.from(body)) },
+    });
+    assert.equal(fired.status, 200);
+    for (let i = 0; i < 50 && !calls.some((c) => c.body.runId === fired.body.runId); i += 1) await sleep(20);
+    const mine = calls.find((c) => c.body.runId === fired.body.runId);
+    assert.ok(mine, '本次触发的回调已发送');
+    assert.equal(mine.url, 'http://127.0.0.1:19999/done');
+    assert.equal(mine.body.event, 'workflow_run.finished');
+    assert.equal(mine.body.hookId, hookId);
+    assert.ok(['success', 'error', 'canceled'].includes(mine.body.status), '回调带终态');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+  // 回调目标不可达：触发仍 200，运行状态不受影响
+  const failBody = JSON.stringify({ input: 'cb-fail' });
+  const unreachable = await fire({
+    hookId, token: hookToken, body: { input: 'cb-fail' },
+    headers: { ...hmacHeaders('topsecret-16-chars-min', Buffer.from(failBody)) },
+  });
+  assert.equal(unreachable.status, 200);
+});
+
+await test('统一校验：坏图工作流的 hook 触发返回 422', async () => {
+  const badGraph = { nodes: [{ id: 'n1', type: 'http', position: { x: 0, y: 0 }, data: { label: '坏节点', url: '' } }], edges: [] };
+  const wfBad = await call('POST', '/wf1/api/workflows', { id: 'wf_hook_bad', name: '坏图工作流', graph: badGraph });
+  assert.equal(wfBad.status, 200);
+  const badHook = await call('POST', '/wf1/api/hooks', { workflowId: 'wf_hook_bad' });
+  assert.equal(badHook.status, 200);
+  const res = await fire({ hookId: badHook.body.id, token: badHook.body.token, body: { input: 'x' } });
+  assert.equal(res.status, 422);
+  assert.equal(res.body.ok, false);
+  await call('DELETE', `/wf1/api/hooks?id=${badHook.body.id}`);
+});
+
+await test('存量 hook 零变化：清掉 secret/callback 后无新字段请求全链路 200', async () => {
+  await call('PATCH', '/wf1/api/hooks', { id: hookId, signingSecret: '', callbackUrl: '' });
+  const disk = readTriggers().hooks.find((h) => h.id === hookId);
+  assert.equal(disk.signingSecret, undefined);
+  assert.equal(disk.callbackUrl, undefined);
+  const fired = await fire({ hookId, token: hookToken, body: { input: 'legacy' } });
+  assert.equal(fired.status, 200);
+  assert.ok(fired.body.runId);
+});
+
+await test('DELETE hook 后触发 404', async () => {
+  const tmp = await call('POST', '/wf1/api/hooks', { workflowId: 'wf_hook' });
+  await call('DELETE', `/wf1/api/hooks?id=${tmp.body.id}`);
+  const res = await fire({ hookId: tmp.body.id, token: tmp.body.token, body: {} });
+  assert.equal(res.status, 404);
+});
+
+for (const d of disposers) await d?.();
+rmSync(workspacesRoot, { recursive: true, force: true });
+rmSync(dshHome, { recursive: true, force: true });
+process.env.DSH_HOME = originalEnv.DSH_HOME;
+process.env.WF1_LEGACY_DATA_DIR = originalEnv.WF1_LEGACY_DATA_DIR;
+
+for (const [mark, name, error] of results) {
+  console.log(`  ${mark} ${name}`);
+  if (error) console.log(error);
+}
+const failed = results.filter(([mark]) => mark === '✗').length;
+if (failed) {
+  console.error(`${failed} FAILED / ${results.length}`);
+  process.exit(1);
+}
+console.log(`ALL PASS (${results.length})`);


### PR DESCRIPTION
## 背景

关闭 #56。webhook 是对外触发工作流的标准入口（外部调度器 / n8n 类集成），原协议面三处薄弱：

1. 仅 token 明文比较（非 timing-safe，Bearer 不校验 scheme，无签名与密钥轮换）
2. 无幂等保护：网络层超时重试、调度器重复触发都各自起新 run
3. 触发方拿不到完成事件，只能轮询 GET /runs/detail

## 方案

全部做成可选能力，未配置的存量 hook 行为零变化：

| 能力 | 配置 | 协议 |
|---|---|---|
| HMAC 签名 | `PATCH /hooks {id, signingSecret}`（≥16 字符，GET 只回 hasSigningSecret） | `X-WF1-Timestamp`（unix 秒，±5min）+ `X-WF1-Signature: sha256=<hex>`，签名覆盖**原始 body 字节**+时间戳 |
| 幂等键 | 无需配置，按请求携带 | `Idempotency-Key` 头或 body.inputs.idempotencyKey；24h 窗口同 key 复用首次 runId（`idempotent:true`） |
| 完成回调 | `PATCH /hooks {id, callbackUrl}` | run 终态 POST `workflow_run.finished` 负载（summary 脱敏+截断）；失败只记日志/内存元数据，不重试不碰运行状态 |

配套改动：

- `readBody` 加 `{raw:true}` 选项暴露原始 Buffer（HMAC 必须对原始字节验签，重新序列化的 JSON 键序不同即漂移）；其他调用方行为不变
- token 比较换 `crypto.timingSafeEqual`；Bearer 分支补 scheme 校验
- **触发起跑统一走 `startWorkflowRun`**（此前 webhook 直调 startRun 绕过图 lint 与输入 schema 校验，与 manual/assistant 路径不一致）；坏图/坏输入返回 422
- 新增 `PATCH /wf1/api/hooks`（signingSecret/callbackUrl 配置与清除、token 轮换）——补齐 #56 分诊记录的端点缺口
- `persistTriggers` 白名单同步扩展新字段（否则重启即丢）

## 验证

- 新增 `test/webhook-hooks.integration.test.mjs` 12 用例：纯函数（签名/时间窗/幂等窗口/回调脱敏）+ 路由级（token 对错、HMAC 缺失/错误/过期、幂等同 key 复用/异 key、回调送达与失败隔离、PATCH 落盘与 GET 脱敏、坏图 422、存量 hook 零变化、删除后 404）；假 req 扩展支持任意 raw Buffer body
- 全仓 `npm test` 通过；`build-web.sh` 双构建通过
- 实机（真 dsh web profile）：curl + openssl 验证 PATCH 配 secret、无签名 401、正确 HMAC 200、同 Idempotency-Key 重放返首次 runId、本地接收器收到 `workflow_run.finished` 终态负载、过期时间戳 401