### PR TITLE
fix(canvasui): 示例指令 chip 点击无反应（输入框查找依赖 DOM 父子关系落空）

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -821,6 +821,15 @@ window.__ModuleLoader__.load({
     // 官方 dock slot 在「已建会话的空白态（hero）」渲染于 hero 区与输入框之间，
     // props 带 {session, input}；input 是状态快照（无写 API），点击 chip 用
     // contenteditable 注入在用户手势内生效。草稿非空时隐藏，避免干扰输入。
+    // 输入框定位不能依赖 DOM 父子关系（dock 容器与编辑器不同子树），按官方
+    // 编辑器标记 data-composer-input 全文档找，找不到再退 contenteditable。
+    function findComposerInput() {
+      return (
+        document.querySelector("[data-composer-input='true']") ||
+        document.querySelector("textarea[placeholder]") ||
+        null
+      );
+    }
     function WorkflowExampleBar(props) {
       var visible =
         props.input && (props.input.draft === "" || props.input.draft == null) &&
@@ -829,17 +838,13 @@ window.__ModuleLoader__.load({
       var prompts = examplePromptsFor(wfBoundState === true);
       var fill = function (text, ev) {
         ev.preventDefault();
-        var host = ev.currentTarget.closest(".wf1-example-bar");
-        var editable = host && host.parentElement
-          ? host.parentElement.querySelector("[contenteditable='true'], textarea")
-          : null;
-        if (editable) {
-          editable.focus();
-          try {
-            document.execCommand("selectAll");
-            document.execCommand("insertText", false, text);
-          } catch (e) { /* 输入框形态变化时静默，用户仍可手动输入 */ }
-        }
+        var editable = findComposerInput();
+        if (!editable) return;
+        editable.focus();
+        try {
+          document.execCommand("selectAll");
+          document.execCommand("insertText", false, text);
+        } catch (e) { /* 输入框形态变化时静默，用户仍可手动输入 */ }
       };
       return react.createElement(
         "div",


### PR DESCRIPTION
## 背景

#139 上线后用户实测：「试试」示例条的所有 chip 点击无反应。

## 根因

`WorkflowExampleBar.fill()` 用 `bar.parentElement.querySelector('[contenteditable]')` 定位编辑器——dock slot 容器与官方编辑器不在同一 DOM 子树，查找恒为 null，点击后静默失败。

## 修法

不依赖 DOM 父子关系，按官方编辑器标记 `data-composer-input` 全文档定位（找不到再退 `textarea[placeholder]`）。

## 验证

- canvasui 单测全过；`build-canvasui.sh` 重建（--check 无漂移）
- 真机（dsh web profile，已建会话空白态）：点击「把当前画布的工作流跑一次」chip，草稿正确填入该示例文本