### PR TITLE
feat(canvasui): 运行卡运行中状态提供一键停止（#103）

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -79,6 +79,13 @@ window.__ModuleLoader__.load({
       }
     }
 
+    // 会话作用域 URL：/wf1/api 路由靠 ?sessionId= 定位宿主会话工作区（跨会话互不串）
+    function scopedApiUrl(path) {
+      var sessionId = currentDshSessionId(null);
+      if (!sessionId) return path;
+      return path + (path.indexOf("?") >= 0 ? "&" : "?") + "sessionId=" + encodeURIComponent(sessionId);
+    }
+
     var RUN_EVENT_NAMES = ["snapshot", "run-start", "node-status", "agent-progress", "run-end", "run-error"];
     var runEventHub = { sessionId: null, source: null, listeners: new Set(), timer: null };
     function ensureRunEventHub() {
@@ -167,6 +174,9 @@ window.__ModuleLoader__.load({
         ".wf1-card-foot{display:flex;align-items:center;gap:8px;min-width:0;}",
         ".wf1-card-meta{color:var(--dsw-alias-label-tertiary);font-size:13px;line-height:18px;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;flex:1;}",
         ".wf1-card-meta[data-error]{color:var(--dsw-alias-state-error-primary);}",
+        ".wf1-card-action{flex:none;display:inline-flex;align-items:center;padding:2px 10px;border-radius:999px;border:1px solid var(--dsw-alias-state-error-primary);color:var(--dsw-alias-state-error-primary);font-size:12px;line-height:18px;cursor:pointer;transition:background-color 100ms ease;}",
+        ".wf1-card-action:hover{background:color-mix(in srgb,var(--dsw-alias-state-error-primary) 12%,transparent);}",
+        ".wf1-card-action:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
         ".wf1-card-open{flex:none;display:inline-flex;align-items:center;gap:3px;color:var(--dsw-alias-label-caption);font-size:12px;line-height:18px;opacity:0;transition:opacity 100ms ease;}",
         ".wf1-card:hover .wf1-card-open,.wf1-card:focus-visible .wf1-card-open{opacity:1;}",
         // ---- 空会话示例指令条（conversation.input.dock）----
@@ -505,8 +515,10 @@ window.__ModuleLoader__.load({
       window.open(CANVAS_URL, "_blank");
     }
 
-    // 卡片骨架：头（图标+标题+状态章）+ 缩略图 + 底（meta+打开按钮）。整卡可点。
+    // 卡片骨架：头（图标+标题+状态章）+ 缩略图 + 底（meta+动作+打开按钮）。整卡可点。
     // hostRef：骨架是卡片根元素，缩略图宽度自适应从这里实测（缺省时 ref 不挂）。
+    // action：可选行内动作（如运行卡「停止」）。卡片根是 <button> 不能嵌套交互元素，
+    // 用 span[role=button] + stopPropagation 承载。
     function workflowCardShell(props) {
       return react.createElement(
         "button",
@@ -533,6 +545,7 @@ window.__ModuleLoader__.load({
             "span", { className: "wf1-card-meta", "data-error": props.metaError || undefined },
             props.meta,
           ),
+          props.action || null,
           react.createElement("span", { className: "wf1-card-open" }, "打开画布 ↗"),
         ),
       );
@@ -577,6 +590,8 @@ window.__ModuleLoader__.load({
       var [trackedRunId, setTrackedRunId] = react.useState(runId);
       var [run, setRun] = react.useState(null);
       var [missing, setMissing] = react.useState(false);
+      // 停止按钮状态：点击后乐观置位，SSE/轮询到终态自动出清；取消失败则回退可重试
+      var [canceling, setCanceling] = react.useState(false);
 
       react.useEffect(function () {
         setTrackedRunId(runId);
@@ -587,11 +602,7 @@ window.__ModuleLoader__.load({
         var stopped = false;
         var latestRun = null;
         var timer = null;
-        var scopedUrl = function (path) {
-          var sessionId = currentDshSessionId(null);
-          if (!sessionId) return path;
-          return path + (path.indexOf("?") >= 0 ? "&" : "?") + "sessionId=" + encodeURIComponent(sessionId);
-        };
+        var scopedUrl = scopedApiUrl;
         var followCurrentRun = function (current) {
           if (!current || ["interrupted", "error", "canceled"].indexOf(current.status) < 0) return;
           fetch(scopedUrl("/wf1/api/runs"))
@@ -639,6 +650,7 @@ window.__ModuleLoader__.load({
         });
         setRun(null);
         setMissing(false);
+        setCanceling(false);
         fetchRun();
         timer = window.setInterval(fetchRun, 2000);
         return function () {
@@ -687,6 +699,22 @@ window.__ModuleLoader__.load({
         });
       }
 
+      var stopRun = function () {
+        if (canceling || !trackedRunId) return;
+        setCanceling(true);
+        fetch(scopedApiUrl("/wf1/api/run/cancel"), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ runId: trackedRunId }),
+        })
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (d) {
+            // 取消失败（运行已结束/跨工作区）：回退按钮，卡片仍由轮询驱动真实状态
+            if (!d || !d.ok) setCanceling(false);
+          })
+          .catch(function () { setCanceling(false); });
+      };
+
       var dot = runDotState(run);
       var progress = runCardProgress(run);
       var nodeTotal = progress.total, nodeDone = progress.done;
@@ -698,7 +726,9 @@ window.__ModuleLoader__.load({
       var secs = run && run.durationMs ? Math.round(run.durationMs / 1000) + "s" : "";
       var meta;
       if (dot === "running") {
-        meta = (currentLabel ? "「" + currentLabel + "」执行中" : "执行中") + (secs ? " · " + secs : "");
+        meta = canceling
+          ? "停止中，等待节点中断…"
+          : (currentLabel ? "「" + currentLabel + "」执行中" : "执行中") + (secs ? " · " + secs : "");
       } else if (dot === "error") {
         meta = errText || run.status && (RUN_STATUS_CN[run.status] || run.status) || "运行失败";
       } else if (dot === "success") {
@@ -706,6 +736,21 @@ window.__ModuleLoader__.load({
       } else {
         meta = RUN_STATUS_CN[run.status] || run.status || "";
       }
+      var stopAction = dot === "running" ? react.createElement(
+        "span",
+        {
+          className: "wf1-card-action",
+          role: "button",
+          tabIndex: 0,
+          "aria-label": "停止该运行",
+          onClick: function (e) { e.stopPropagation(); stopRun(); },
+          onKeyDown: function (e) {
+            if (e.key !== "Enter" && e.key !== " ") return;
+            e.stopPropagation(); e.preventDefault(); stopRun();
+          },
+        },
+        canceling ? "停止中…" : "停止",
+      ) : null;
       return workflowCardShell({
         title: "工作流 · " + (run && run.workflowName ? run.workflowName : "草稿图"),
         dotState: dot,
@@ -716,6 +761,7 @@ window.__ModuleLoader__.load({
           width: thumbW, capacity: capacity,
         }),
         hostRef: attachHost,
+        action: stopAction,
         // 点击定位到卡片正在跟踪的 run（续跑换 run 后也指向最新）
         target: { runId: trackedRunId },
       });

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -780,4 +780,138 @@ for (const [body, expected] of [
   assert.equal(client.__test.WorkflowExampleBar({}), null);
 }
 
+// ---- 运行卡停止按钮（#103）：有状态 react shim 驱动 运行中→停止中→已取消 流转 ----
+{
+  const stopCalls = [];
+  const fetchLog = [];
+  const intervals = [];
+  const runningRun = {
+    runId: "run_stop_case", status: "running", workflowName: "停止测试",
+    graph: { nodes: [{ id: "n1", type: "agent", data: { label: "步骤1" } }], edges: [] },
+    nodeStates: { n1: { status: "running" } },
+  };
+  const canceledRun = { ...runningRun, status: "canceled", nodeStates: { n1: { status: "canceled" } } };
+  const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  // 有状态 hooks：slot 按 hook 序号复用，组件重调即「重渲染」；effect 仅首渲染后跑
+  let cursor = 0;
+  const slots = [];
+  const effects = [];
+  const reactShim = {
+    createElement(tag, props, ...children) { stopCalls.push({ tag, props, children }); return { tag, props, children }; },
+    useRef() { const i = cursor++; if (!slots[i]) slots[i] = { ref: true, value: { current: null } }; return slots[i].value; },
+    useState(initial) {
+      const i = cursor++;
+      if (!slots[i]) slots[i] = { value: typeof initial === "function" ? initial() : initial };
+      const slot = slots[i];
+      return [slot.value, (v) => { slot.value = typeof v === "function" ? v(slot.value) : v; }];
+    },
+    useEffect(fn) { effects.push(fn); },
+    useMemo(fn) { return fn(); },
+  };
+
+  let stopClient;
+  let cancelOk = true;
+  let detailRun = runningRun;
+  const fetchStub = (url, opts) => {
+    const u = String(url);
+    fetchLog.push({ url: u, opts });
+    if (u.includes("/wf1/api/run/cancel")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ ok: cancelOk, runId: "run_stop_case" }) });
+    }
+    if (u.includes("/wf1/api/runs/detail")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(detailRun) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({ runs: [] }) });
+  };
+  const setIntervalStub = (fn) => { intervals.push(fn); return intervals.length; };
+  const clearIntervalStub = () => {};
+  const stopContext = {
+    console,
+    // 裸 fetch/interval（vm realm 全局）与 window.* 两种引用路径都要有
+    fetch: fetchStub,
+    setInterval: setIntervalStub,
+    clearInterval: clearIntervalStub,
+    document: {
+      head: { appendChild() {} },
+      createElement: () => ({}),
+      getElementById: () => null,
+      body: {},
+    },
+    window: {
+      localStorage: { getItem: (k) => (k === "dsh.sessions.current" ? JSON.stringify({ sessionId: "sess_stop" }) : null) },
+      fetch: fetchStub,
+      setInterval: setIntervalStub,
+      clearInterval: clearIntervalStub,
+    },
+  };
+  stopContext.window.__ModuleLoader__ = {
+    load({ factory }) { stopClient = factory((name) => (name === "react" ? reactShim : (() => { throw new Error("unexpected require: " + name); })())); },
+  };
+  vm.runInNewContext(bundle, stopContext, { filename: "dsh-ccpg-canvasui/src/client.js" });
+
+  const render = () => {
+    cursor = 0;
+    stopCalls.length = 0;
+    return stopClient.__test.WorkflowRunCard({
+      block: {
+        kind: "tool-result",
+        isError: false,
+        content: [{ type: "text", text: JSON.stringify({ started: true, runId: "run_stop_case" }) }],
+      },
+    });
+  };
+  const find = (className, tag) => stopCalls.findLast((c) => c.tag === tag && c.props?.className === className);
+
+  render();
+  effects.splice(0).forEach((fn) => fn());
+  await tick(); // 首次详情拉回 running
+  render();
+  {
+    const action = find("wf1-card-action", "span");
+    assert.ok(action, "运行中应渲染停止按钮");
+    assert.equal(action.props.role, "button");
+    assert.equal(action.children[0], "停止");
+    const meta = find("wf1-card-meta", "span");
+    assert.match(String(meta.children[0]), /步骤1」执行中/);
+  }
+
+  // 先验证取消失败回退：点停止但服务端回 ok:false → 按钮回到「停止」可重试
+  cancelOk = false;
+  find("wf1-card-action", "span").props.onClick({ stopPropagation() {} });
+  await tick();
+  render();
+  assert.equal(find("wf1-card-action", "span").children[0], "停止", "取消失败应回退到可重试态");
+
+  // 成功路径：stopPropagation + POST cancel（带 sessionId 作用域与 runId）
+  cancelOk = true;
+  let propagationStopped = false;
+  find("wf1-card-action", "span").props.onClick({ stopPropagation() { propagationStopped = true; } });
+  assert.equal(propagationStopped, true, "停止点击不得触发整卡打开画布");
+  await tick();
+  const cancelCall = fetchLog.findLast((f) => f.url.includes("/wf1/api/run/cancel"));
+  assert.ok(cancelCall, "应发 POST /wf1/api/run/cancel");
+  assert.match(cancelCall.url, /[?&]sessionId=sess_stop/, "cancel 请求须带 sessionId 作用域");
+  assert.equal(cancelCall.opts?.method, "POST");
+  assert.deepEqual(JSON.parse(cancelCall.opts.body), { runId: "run_stop_case" });
+
+  render();
+  {
+    assert.equal(find("wf1-card-action", "span").children[0], "停止中…");
+    assert.match(String(find("wf1-card-meta", "span").children[0]), /停止中/);
+  }
+
+  // 轮询到已取消：停止按钮消失，卡片转取消态
+  detailRun = canceledRun;
+  intervals.splice(0).forEach((fn) => fn());
+  await tick();
+  render();
+  {
+    assert.equal(find("wf1-card-action", "span"), undefined, "终态后不再渲染停止按钮");
+    const dot = find("wf1-card-dot", "span");
+    assert.equal(dot.props["data-s"], "error");
+    assert.equal(String(find("wf1-card-meta", "span").children[0]), "已取消");
+  }
+}
+
 console.log("canvasui client tests: passed");


### PR DESCRIPTION
## 背景（#103）

AI 起工作流运行后用户只能干等，取消只能靠自然语言叫停 workflow_run_cancel。等待是高频场景，一次点击的停止按钮是刚需。

## 方案

- 运行卡（WorkflowRunCard，canvas_run_workflow / canvas_run_status / workflow_run(_status) 共用）在运行中状态渲染「停止」动作：点击 POST `/wf1/api/run/cancel`（sessionId 作用域），乐观进入「停止中」态，SSE run-end / 2s 轮询到终态后转已取消；取消失败（运行已结束/跨工作区）回退可重试
- 卡片骨架 foot 增加 action 槽位；卡片根是 `<button>` 不能嵌套交互元素，用 span[role=button] + stopPropagation 承载
- `scopedApiUrl` 提为模块级（轮询与停止共用）

## 不需要改的面

- **web 画布侧**：工具栏取消按钮随 inspected run 的 running 态展示（#121 已落地），cancelRun 用 inspectedRunIdRef
- **orchestrator**：cancel 路由按 workspaceRoot 守卫，source='trigger'/'catch-up' 运行天然覆盖，无代码改动

## 验证

- 单测：有状态 react shim 驱动 运行中→停止(失败回退)→停止中→已取消 全链路（cancel 请求带 sessionId 作用域与 runId、stopPropagation 不触发整卡打开）
- 实测：真 dsh 起长运行（script 节点忙等 9.5s），trigger 源起跑 → POST cancel → **52ms 到 canceled 终态**（验收 ≤2s）
- 全量单测通过 + build-web.sh 双构建通过 + canvasui bundle --check 一致
- 已知缺口：卡片在官方 UI 消息流中的真浏览器点按未做（需 LLM 对话产生工具卡），留日常使用时人工确认