### PR TITLE
feat(orchestrator+canvasui): 被拒补丁展示完整错误与修复建议（#104）

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -177,6 +177,12 @@ window.__ModuleLoader__.load({
         ".wf1-card-action{flex:none;display:inline-flex;align-items:center;padding:2px 10px;border-radius:999px;border:1px solid var(--dsw-alias-state-error-primary);color:var(--dsw-alias-state-error-primary);font-size:12px;line-height:18px;cursor:pointer;transition:background-color 100ms ease;}",
         ".wf1-card-action:hover{background:color-mix(in srgb,var(--dsw-alias-state-error-primary) 12%,transparent);}",
         ".wf1-card-action:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
+        ".wf1-card-toggle{flex:none;display:inline-flex;align-items:center;padding:2px 10px;border-radius:999px;border:1px solid var(--dsw-alias-border-l2);color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;cursor:pointer;transition:background-color 100ms ease;}",
+        ".wf1-card-toggle:hover{background:var(--dsw-alias-interactive-bg-hover-solid);}",
+        ".wf1-card-toggle:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
+        ".wf1-card-detail{display:flex;flex-direction:column;gap:2px;max-height:72px;overflow-y:auto;border-radius:8px;padding:6px 10px;background:color-mix(in srgb,var(--dsw-alias-border-l1) 18%,transparent);}",
+        ".wf1-card-detail-line{color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;white-space:pre-wrap;word-break:break-word;}",
+        ".wf1-card-detail[data-error] .wf1-card-detail-line{color:var(--dsw-alias-state-error-primary);}",
         ".wf1-card-open{flex:none;display:inline-flex;align-items:center;gap:3px;color:var(--dsw-alias-label-caption);font-size:12px;line-height:18px;opacity:0;transition:opacity 100ms ease;}",
         ".wf1-card:hover .wf1-card-open,.wf1-card:focus-visible .wf1-card-open{opacity:1;}",
         // ---- 空会话示例指令条（conversation.input.dock）----
@@ -539,6 +545,7 @@ window.__ModuleLoader__.load({
           ),
         ),
         props.thumbnail || null,
+        props.detail || null,
         react.createElement(
           "div", { className: "wf1-card-foot" },
           react.createElement(
@@ -797,10 +804,40 @@ window.__ModuleLoader__.load({
       var lintOk = ok && text ? text.indexOf("lint: 通过") >= 0 : false;
       var dotState = !settled ? "running" : ok ? (lintOk ? "success" : "pending") : "error";
       var stateText = !settled ? "应用中" : ok ? (lintOk ? "已应用" : "已应用·有告警") : "被拒绝";
+      // 完整详情（#104）：被拒的全部错误行 / 已应用时的 lint 告警行，默认收起，
+      // 点击展开（超 3 条区域内滚动）；服务端已在行尾附「修复建议」
+      var [expanded, setExpanded] = react.useState(false);
+      var detailLines = settled && text
+        ? text.split("\n").map(function (l) { return l.trim(); }).filter(Boolean)
+        : [];
+      var hasDetail = settled && detailLines.length > 1 && (!ok || !lintOk);
       var meta;
       if (!settled) meta = opSummary;
-      else if (!ok) meta = (text || "整批被拒绝").split("\n")[0].slice(0, 60);
+      else if (!ok) meta = detailLines[0] ? detailLines[0].slice(0, 60) : "整批被拒绝";
       else meta = opSummary + (lintOk ? "" : " · lint 有告警");
+
+      var toggle = hasDetail ? react.createElement(
+        "span",
+        {
+          className: "wf1-card-toggle",
+          role: "button",
+          tabIndex: 0,
+          "aria-expanded": expanded,
+          onClick: function (e) { e.stopPropagation(); setExpanded(!expanded); },
+          onKeyDown: function (e) {
+            if (e.key !== "Enter" && e.key !== " ") return;
+            e.stopPropagation(); e.preventDefault(); setExpanded(!expanded);
+          },
+        },
+        expanded ? "收起" : "展开 " + (detailLines.length - 1) + " 条",
+      ) : null;
+      var detail = expanded && hasDetail ? react.createElement(
+        "div",
+        { className: "wf1-card-detail", "data-error": !ok || undefined },
+        detailLines.map(function (line, index) {
+          return react.createElement("div", { key: index, className: "wf1-card-detail-line" }, line);
+        }),
+      ) : null;
 
       return workflowCardShell({
         title: "建图 · " + opSummary.slice(0, 40),
@@ -809,6 +846,8 @@ window.__ModuleLoader__.load({
         meta: meta,
         metaError: settled && !ok,
         thumbnail: null,
+        action: toggle,
+        detail: detail,
       });
     }
 

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -914,4 +914,106 @@ for (const [body, expected] of [
   }
 }
 
+// ---- 建图卡错误展开（#104）：默认收起，点击展开完整错误行（含服务端修复建议）----
+{
+  const expandCalls = [];
+  let cursor = 0;
+  const slots = [];
+  const reactShim = {
+    createElement(tag, props, ...children) { expandCalls.push({ tag, props, children }); return { tag, props, children }; },
+    useState(initial) {
+      const i = cursor++;
+      if (!slots[i]) slots[i] = { value: typeof initial === "function" ? initial() : initial };
+      const slot = slots[i];
+      return [slot.value, (v) => { slot.value = typeof v === "function" ? v(slot.value) : v; }];
+    },
+  };
+  let expandClient;
+  const expandContext = {
+    console,
+    document: {
+      head: { appendChild() {} },
+      createElement: () => ({}),
+      getElementById: () => null,
+      body: {},
+    },
+    window: {
+      localStorage: { getItem: () => null },
+      __ModuleLoader__: {
+        load({ factory }) { expandClient = factory((name) => (name === "react" ? reactShim : (() => { throw new Error("unexpected require: " + name); })())); },
+      },
+    },
+  };
+  vm.runInNewContext(bundle, expandContext, { filename: "dsh-ccpg-canvasui/src/client.js" });
+
+  // 5 行错误（含服务端修复建议）：成环 + 引用不存在 + 缺字段等
+  const rejectedText = [
+    "整批拒绝（未做任何修改）：",
+    'ops[1]: connect from 节点 "ghost" 不存在 —— 修复建议：先在同批 addNode 创建该节点，或改用画布摘要里已有的节点 id',
+    "ops[2]: 这条边会构成环 —— 修复建议：删掉形成环的那条连线（回边），或改连到环外节点",
+    "ops[3]: data 必须是对象 —— 修复建议：updateNode 的 data 传 {字段: 值} 对象",
+    "ops[4]: label 不能为空 —— 修复建议：renameNode 需要非空 label",
+    "请修正后重发整批 ops。",
+  ].join("\n");
+  const render = () => {
+    cursor = 0;
+    expandCalls.length = 0;
+    return expandClient.__test.GraphPatchCard({
+      block: {
+        kind: "tool-result",
+        isError: true,
+        call: { name: "canvas_graph_patch", argsRaw: JSON.stringify({ ops: [{ op: "connect" }] }) },
+        content: [{ type: "text", text: rejectedText }],
+      },
+    });
+  };
+  const find = (className, tag) => expandCalls.findLast((c) => c.tag === tag && c.props?.className === className);
+
+  render();
+  {
+    const toggle = find("wf1-card-toggle", "span");
+    assert.ok(toggle, "被拒多行错误应渲染展开入口");
+    assert.match(String(toggle.children[0]), /^展开 \d+ 条$/);
+    assert.equal(toggle.props["aria-expanded"], false);
+    assert.equal(find("wf1-card-detail", "div"), undefined, "默认收起");
+    // meta 仍是首行摘要，不撑爆卡片
+    assert.match(String(find("wf1-card-meta", "span").children[0]), /^整批拒绝/);
+
+    // 点击展开（stopPropagation 不触发整卡打开）
+    let stopped = false;
+    toggle.props.onClick({ stopPropagation() { stopped = true; } });
+    assert.equal(stopped, true);
+  }
+  render();
+  {
+    const detail = find("wf1-card-detail", "div");
+    assert.ok(detail, "展开后渲染完整错误列表");
+    assert.equal(detail.props["data-error"], true, "被拒态错误行用错误色");
+    // createElement shim 单数组参数不展开，先展平再断言
+    const lines = Array.isArray(detail.children[0]) ? detail.children[0] : detail.children;
+    assert.equal(lines.length, 6, "全部错误行均展示（超 3 条靠滚动）");
+    assert.match(String(lines[2].children[0]), /构成环 —— 修复建议：删掉形成环的那条连线/);
+    const toggle = find("wf1-card-toggle", "span");
+    assert.equal(toggle.children[0], "收起");
+    assert.equal(toggle.props["aria-expanded"], true);
+
+    // 再点收起
+    toggle.props.onClick({ stopPropagation() {} });
+  }
+  render();
+  assert.equal(find("wf1-card-detail", "div"), undefined, "点击收起后详情隐藏");
+
+  // lint 通过的成功卡：不渲染展开入口
+  expandCalls.length = 0;
+  expandClient.__test.GraphPatchCard({
+    block: {
+      kind: "tool-result",
+      isError: false,
+      call: { name: "canvas_graph_patch", argsRaw: JSON.stringify({ ops: [{ op: "addNode" }] }) },
+      content: [{ type: "text", text: "已应用 1 个操作到画布。\nlint: 通过" }],
+    },
+  });
+  assert.equal(find("wf1-card-toggle", "span"), undefined, "lint 通过不渲染展开");
+}
+
 console.log("canvasui client tests: passed");

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/assistant.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/assistant.js
@@ -20,6 +20,34 @@ export function newCanvasEdgeId() {
 
 const isPlainObject = (v) => v !== null && typeof v === 'object' && !Array.isArray(v);
 
+// ---- 常见校验错误的修复提示（#104）：命中即在错误行尾追加「修复建议」----
+// 单点维护在服务端，前端工具卡直接展示完整行，不做第二套映射。
+// 规则按实际错误文案匹配（validateGraphOps 的 ops 错误 + lintGraph 的 issue 文案）。
+const PATCH_HINTS = [
+  [/构成环|存在环/, '删掉形成环的那条连线（回边），或改连到环外节点'],
+  [/不能自连/, '节点不能连自己，需要中转时中间加一个节点'],
+  [/引用的节点 ".+?" 不存在/, '先在同批 addNode 创建该节点，或改用画布摘要里已有的节点 id'],
+  [/节点 ".+?" 不存在/, 'id 必须来自画布摘要；新节点先 addNode 再引用'],
+  [/变量引用没有该节点/, '模板只能引用存在的节点：先 addNode 或改引用别的节点'],
+  [/变量只能引用直接上游节点/, '把该节点连成上游，或改引用已连通的上游节点'],
+  [/边已存在/, '这条连线已存在，无需重复 connect'],
+  [/边不存在/, '用画布摘要里已有的边 id，或改用 from/to 定位'],
+  [/未知节点类型/, 'type 用注册类型之一：input/agent/script/condition/http/output/notify/note/subworkflow'],
+  [/未知操作/, 'op 用 addNode/updateNode/renameNode/deleteNode/connect/deleteEdge/updateEdge'],
+  [/缺少 op 字段/, '每个操作必须带 op 字段'],
+  [/label 不能为空/, 'renameNode 需要非空 label'],
+  [/data 必须是对象/, 'updateNode 的 data 传 {字段: 值} 对象'],
+  [/没有上游连线/, '从上游节点 connect 一条边到该输出节点'],
+  [/多个名为「.+?」的节点/, '用 renameNode 消除同名，避免模板引用歧义'],
+  [/单批 ops 上限/, '一批最多 60 个操作，拆成多批'],
+];
+export const withPatchHint = (line) => {
+  for (const [re, hint] of PATCH_HINTS) {
+    if (re.test(line)) return `${line} —— 修复建议：${hint}`;
+  }
+  return line;
+};
+
 // 成环检测：在图上加 from→to 后是否出现环（DFS）
 export function wouldCreateCycle(nodes, edges, from, to) {
   const adj = new Map();
@@ -47,10 +75,10 @@ export function wouldCreateCycle(nodes, edges, from, to) {
 export function validateGraphOps(graph, ops) {
   const errors = [];
   if (!isPlainObject(graph) || !Array.isArray(graph.nodes) || !Array.isArray(graph.edges)) {
-    return { ok: false, errors: ['缺少有效画布图（先让用户打开工作流画布）'] };
+    return { ok: false, errors: [withPatchHint('缺少有效画布图（先让用户打开工作流画布）')] };
   }
-  if (!Array.isArray(ops) || ops.length === 0) return { ok: false, errors: ['ops 必须是非空数组'] };
-  if (ops.length > 60) return { ok: false, errors: [`单批 ops 上限 60，收到 ${ops.length}`] };
+  if (!Array.isArray(ops) || ops.length === 0) return { ok: false, errors: [withPatchHint('ops 必须是非空数组')] };
+  if (ops.length > 60) return { ok: false, errors: [withPatchHint(`单批 ops 上限 60，收到 ${ops.length}`)] };
 
   // 工作副本：逐 op 应用到副本，全部成功才对外可见
   const nodes = graph.nodes.map((n) => ({ ...n, data: { ...n.data } }));
@@ -58,7 +86,7 @@ export function validateGraphOps(graph, ops) {
   const byId = new Map(nodes.map((n) => [n.id, n]));
   const patch = [];
 
-  const fail = (i, msg) => errors.push(`ops[${i}]: ${msg}`);
+  const fail = (i, msg) => errors.push(withPatchHint(`ops[${i}]: ${msg}`));
 
   ops.forEach((op, i) => {
     if (!isPlainObject(op) || typeof op.op !== 'string') { fail(i, '缺少 op 字段'); return; }
@@ -182,7 +210,7 @@ export function checkPatchResult(nextGraph) {
   const lint = lintGraph(nextGraph);
   return {
     lintOk: lint.ok,
-    issues: lint.issues.map((x) => `[${x.level}]${x.nodeId ? `(${x.nodeId})` : ''} ${x.message}`),
+    issues: lint.issues.map((x) => withPatchHint(`[${x.level}]${x.nodeId ? `(${x.nodeId})` : ''} ${x.message}`)),
   };
 }
 

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/assistant.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/assistant.test.mjs
@@ -132,3 +132,47 @@ test('full scenario: build leak-repair chain via ops', () => {
   assert.equal(r3.ok, true);
   assert.equal(r3.graph.edges.some((e) => e.branch === 'true'), true);
 });
+
+// ---- #104：错误行尾附「修复建议」hint ----
+test('reject errors carry fix hints (#104)', () => {
+  const g = baseGraph();
+  // 成环：反向连一条边
+  const cycle = validateGraphOps(g, [
+    { op: 'addNode', type: 'output', label: '输出' },
+    { op: "connect", from: "n_agent_1", to: "n_input_1" },
+  ]);
+  assert.equal(cycle.ok, false);
+  assert.ok(cycle.errors.some((e) => /构成环/.test(e) && e.includes('修复建议')), '成环错误应带修复建议');
+
+  // 引用不存在节点
+  const missing = validateGraphOps(g, [{ op: 'updateNode', id: 'ghost', data: { x: 1 } }]);
+  assert.equal(missing.ok, false);
+  assert.ok(missing.errors.some((e) => /节点 "ghost" 不存在/.test(e) && e.includes('先 addNode')), '引用不存在节点应带建议');
+
+  // 缺必填字段
+  const badData = validateGraphOps(g, [{ op: 'updateNode', id: 'n_agent_1', data: 'oops' }]);
+  assert.equal(badData.ok, false);
+  assert.ok(badData.errors.some((e) => /data 必须是对象/.test(e) && e.includes('修复建议')), '缺字段错误应带建议');
+});
+
+test('checkPatchResult issues carry hints (#104)', () => {
+  // 成环图：A→B→A
+  const g = {
+    nodes: [
+      { id: 'a', type: 'input', position: { x: 0, y: 0 }, data: { label: 'A', text: 'x' } },
+      { id: 'b', type: 'agent', position: { x: 1, y: 0 }, data: { label: 'B', prompt: 'p' } },
+    ],
+    edges: [
+      { id: 'e1', source: 'a', target: 'b' },
+      { id: 'e2', source: 'b', target: 'a' },
+    ],
+  };
+  const r = checkPatchResult(g);
+  assert.ok(r.issues.some((x) => /存在环/.test(x) && x.includes('修复建议')), 'lint 环错误应带修复建议');
+});
+
+test('withPatchHint leaves unmatched lines untouched', async () => {
+  const { withPatchHint } = await import('../lib/assistant.js');
+  assert.equal(withPatchHint('普通错误消息'), '普通错误消息');
+  assert.match(withPatchHint('ops[2]: 这条边会构成环'), /—— 修复建议：删掉形成环的那条连线/);
+});


### PR DESCRIPTION
## 背景（#104）

AI 补丁被服务端拒绝（lint/成环/校验）时，工具卡只显示错误首行 60 字符，用户不知道为什么被拒、更不知道怎么改。

## 方案

**服务端**（`assistant.js` 单点，`index.js` 零改动）：
- `PATCH_HINTS` 映射 16 条常见错误（成环/引用不存在节点/缺必填字段/边不存在/未知类型与操作/同名节点等，全部按实际错误文案匹配），命中即在错误行尾追加「—— 修复建议：…」
- `validateGraphOps` 的 fail 与前置校验、`checkPatchResult` 的 lint issue 行统一过 `withPatchHint`

**前端**（`GraphPatchCard`）：
- 被拒/有告警且结果多于 1 行 → 渲染「展开 N 条」入口（默认收起，aria-expanded）
- 展开后完整错误行列表（含服务端修复建议），超 3 条区域内滚动
- 卡片骨架新增 detail 槽位；lint 通过/运行中不渲染入口

## 验证

- assistant 单测：成环/引用不存在/缺字段错误带建议、checkPatchResult 环 issue 带建议、未匹配行不动
- canvasui 单测（有状态 shim）：默认收起→展开见全部 6 行（含建议文案、错误色）→收起；lint 通过卡无入口；stopPropagation 不触发整卡打开
- 全量单测通过 + canvasui bundle --check 一致
- 基于 #141 分支（同文件不同函数），#141 合并后本 PR diff 自动只剩本主题

Closes #104