### PR TITLE
feat(web+canvasui): 修改类补丁应用前摘要确认（#105）

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -191,8 +191,37 @@ window.__ModuleLoader__.load({
         ".wf1-example-chip{flex:none;padding:4px 12px;border-radius:999px;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-base);color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;cursor:pointer;transition:border-color 100ms ease,color 100ms ease;}",
         ".wf1-example-chip:hover{border-color:var(--dsw-alias-border-l2);color:var(--dsw-alias-label-primary);}",
         ".wf1-example-chip:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
+        // ---- 修改类补丁确认条（#105）：与示例条同 dock，挂起期间常驻 ----
+        ".wf1-confirm-bar{gap:10px;}",
+        ".wf1-confirm-summary{flex:1;min-width:0;color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}",
+        ".wf1-confirm-btn{flex:none;padding:4px 14px;border-radius:999px;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-base);color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;cursor:pointer;transition:border-color 100ms ease,color 100ms ease;}",
+        ".wf1-confirm-btn:hover{border-color:var(--dsw-alias-border-l2);color:var(--dsw-alias-label-primary);}",
+        ".wf1-confirm-btn:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
+        ".wf1-confirm-discard:hover{border-color:var(--dsw-alias-state-error-primary);color:var(--dsw-alias-state-error-primary);}",
+        ".wf1-confirm-countdown{flex:none;color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:18px;}",
       ].join("\n");
       document.head.appendChild(el);
+    }
+
+    // ---- #105 修改类补丁确认条：画布 iframe（App）↔ 宿主确认条双向桥 ----
+    // App 挂起修改类补丁后推送 {state,version,summary,deadline}；确认条回传
+    // {approve}。消息只在本源（同 origin）内传递，确认条无独立会话身份。
+    var patchConfirmState = null;
+    var patchConfirmListeners = new Set();
+    function setPatchConfirmState(next) {
+      patchConfirmState = next;
+      patchConfirmListeners.forEach(function (fn) { try { fn(next); } catch (e) { /* 单个监听异常不炸 */ } });
+    }
+    // 向常驻画布 iframe 发裁决消息；未挂载/未就绪返回 false（调用方自行降级）
+    function postToCanvas(msg) {
+      try {
+        var frame = persistentHost ? persistentHost.querySelector("iframe") : null;
+        if (frame && frame.contentWindow) {
+          frame.contentWindow.postMessage(msg, window.location.origin);
+          return true;
+        }
+      } catch (e) { /* 画布异常不炸确认条 */ }
+      return false;
     }
 
     function openWorkflowSidebar() {
@@ -951,6 +980,50 @@ window.__ModuleLoader__.load({
             p.name,
           );
         }),
+      );
+    }
+
+    // ---- #105 修改类补丁确认条（conversation.input.dock）：挂起期间输入框上方 ----
+    // 常驻展示「将删除 N 个节点（…）」摘要 + 应用/放弃 + 30s 倒计时；
+    // App 30s 自动应用，倒计时归零后本条自行收起等状态消息。onDecide 可注入（测试）。
+    function PatchConfirmBar(props) {
+      var onDecide = props && props.onDecide || postToCanvas;
+      var [state, setState] = react.useState(patchConfirmState);
+      var [, forceTick] = react.useState(0);
+      react.useEffect(function () {
+        var listener = function (next) { setState(next); };
+        patchConfirmListeners.add(listener);
+        return function () { patchConfirmListeners.delete(listener); };
+      }, []);
+      react.useEffect(function () {
+        if (!state || state.state !== "pending") return undefined;
+        var timer = window.setInterval(function () { forceTick(function (n) { return n + 1; }); }, 500);
+        return function () { window.clearInterval(timer); };
+      }, [state]);
+      if (!state || state.state !== "pending") return null;
+      var remaining = Math.max(0, Math.ceil(((state.deadline || 0) - Date.now()) / 1000));
+      var decide = function (approve) {
+        // 乐观收起：裁决已发出，后续状态消息不再展开
+        setPatchConfirmState({ ...state, state: approve ? "applied" : "discarded" });
+        onDecide({ type: "wf1-patch-confirm", canvasId: state.canvasId, version: state.version, approve: approve });
+      };
+      return react.createElement(
+        "div",
+        { className: "wf1-example-bar wf1-confirm-bar", role: "alert" },
+        react.createElement(
+          "span", { className: "wf1-confirm-summary" },
+          "AI 修改画布待确认：" + (state.summary || ""),
+        ),
+        react.createElement(
+          "button", { type: "button", className: "wf1-confirm-btn", onClick: function () { decide(true); } }, "应用",
+        ),
+        react.createElement(
+          "button", { type: "button", className: "wf1-confirm-btn wf1-confirm-discard", onClick: function () { decide(false); } }, "放弃",
+        ),
+        react.createElement(
+          "span", { className: "wf1-confirm-countdown", "aria-live": "off" },
+          remaining + "s 后自动应用",
+        ),
       );
     }
 
@@ -2019,6 +2092,14 @@ window.__ModuleLoader__.load({
 
     function apply(ctx) {
       ensureStyle();
+      // 画布 iframe（App）推送的确认状态（#105）：pending/applied/discarded → 确认条
+      window.addEventListener("message", function (ev) {
+        if (ev.origin !== window.location.origin) return;
+        var d = ev.data;
+        if (d && typeof d === "object" && d.type === "wf1-patch-confirm-state") {
+          setPatchConfirmState(d);
+        }
+      });
 
       ctx.slots.inject("settings.section", function () {
         return ctx.slots.register(
@@ -2047,7 +2128,20 @@ window.__ModuleLoader__.load({
       });
 
       // 空会话示例指令条：dock slot 在空白会话（hero 态）渲染于输入框上方。
+      // 修改类补丁确认条（#105）同 dock 常驻（order 靠后，紧邻输入框）。
       // 老宿主无该 slot 时 inject 静默失败，不影响其余功能。
+      try {
+        ctx.slots.inject("conversation.input.dock", function () {
+          return ctx.slots.register(
+            {
+              name: "conversation.input.dock",
+              id: "ccpg-workflow-patch-confirm",
+              order: 20,
+            },
+            PatchConfirmBar,
+          );
+        });
+      } catch (e) { /* 无 dock slot 的宿主跳过 */ }
       try {
         ctx.slots.inject("conversation.input.dock", function () {
           return ctx.slots.register(
@@ -2180,6 +2274,8 @@ window.__ModuleLoader__.load({
       graphThumbnail: graphThumbnail,
       WorkflowRunCard: WorkflowRunCard,
       GraphPatchCard: GraphPatchCard,
+      PatchConfirmBar: PatchConfirmBar,
+      setPatchConfirmState: setPatchConfirmState,
       WorkflowExampleBar: WorkflowExampleBar,
       examplePromptsFor: examplePromptsFor,
       setWfBoundState: function (v) { wfBoundState = v; },

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -15,6 +15,7 @@ const context = {
         return storage.get(key) ?? null;
       },
     },
+    addEventListener() {},
     __ModuleLoader__: {
       load({ factory }) {
         client = factory((name) => {
@@ -115,7 +116,8 @@ client.apply({
 assert.deepEqual(injectedSlots, [
   "settings.section",
   "conversation.input.left",
-  "conversation.input.dock",
+  "conversation.input.dock", // #105 确认条
+  "conversation.input.dock", // #101 示例条
   "tool.call.toolview",
   "tool.call.toolview",
   "tool.call.toolview",
@@ -522,6 +524,7 @@ function loadClientInContext(overrides) {
     window: {
       location: { origin: "https://dsh.local" },
       localStorage: { getItem: () => null },
+      addEventListener() {},
       __ModuleLoader__: {
         load({ factory }) {
           scoped = factory(() => ({ createElement() {}, useRef() {}, useState() {}, useEffect() {} }));
@@ -1014,6 +1017,93 @@ for (const [body, expected] of [
     },
   });
   assert.equal(find("wf1-card-toggle", "span"), undefined, "lint 通过不渲染展开");
+}
+
+// ---- 修改类补丁确认条（#105）：挂起渲染摘要/倒计时/按钮，裁决回传后收起 ----
+{
+  const confirmCalls = [];
+  const decisions = [];
+  let cursor = 0;
+  const slots = [];
+  const effects = [];
+  const reactShim = {
+    createElement(tag, props, ...children) { confirmCalls.push({ tag, props, children }); return { tag, props, children }; },
+    useState(initial) {
+      const i = cursor++;
+      if (!slots[i]) slots[i] = { value: typeof initial === "function" ? initial() : initial };
+      const slot = slots[i];
+      return [slot.value, (v) => { slot.value = typeof v === "function" ? v(slot.value) : v; }];
+    },
+    useEffect(fn) { effects.push(fn); },
+  };
+  let confirmClient;
+  const confirmContext = {
+    console,
+    document: {
+      head: { appendChild() {} },
+      createElement: () => ({}),
+      getElementById: () => null,
+      body: {},
+    },
+    window: {
+      localStorage: { getItem: () => null },
+      setInterval: () => 0,
+      clearInterval: () => {},
+      __ModuleLoader__: {
+        load({ factory }) { confirmClient = factory((name) => (name === "react" ? reactShim : (() => { throw new Error("unexpected require: " + name); })())); },
+      },
+    },
+  };
+  vm.runInNewContext(bundle, confirmContext, { filename: "dsh-ccpg-canvasui/src/client.js" });
+  const render = () => {
+    cursor = 0;
+    confirmCalls.length = 0;
+    return confirmClient.__test.PatchConfirmBar({ onDecide: (msg) => decisions.push(msg) });
+  };
+  const find = (className, tag) => confirmCalls.findLast((c) => c.tag === tag && c.props?.className && c.props.className.indexOf(className) >= 0);
+  // 无状态时：不渲染（首渲染后跑 effect：订阅监听）
+  render();
+  effects.splice(0).forEach((fn) => fn());
+  assert.equal(find("wf1-confirm-bar", "div"), undefined, "无挂起状态不渲染确认条");
+  // 挂起：摘要 + 双按钮 + 倒计时（deadline 未来 30s）；监听已在，推送即达
+  confirmClient.__test.setPatchConfirmState({
+    state: "pending", canvasId: "cv_1", version: 7, summary: "删除 1 个节点（工单输出）、修改 2 个节点",
+    deadline: Date.now() + 30000,
+  });
+  render();
+  {
+    const bar = find("wf1-confirm-bar", "div");
+    assert.ok(bar, "挂起时渲染确认条");
+    assert.equal(bar.props.role, "alert");
+    assert.match(String(find("wf1-confirm-summary", "span").children[0]), /删除 1 个节点（工单输出）、修改 2 个节点/);
+    const btns = confirmCalls.filter((c) => c.tag === "button");
+    assert.equal(btns.length, 2);
+    assert.equal(btns[0].children[0], "应用");
+    assert.equal(btns[1].children[0], "放弃");
+    assert.match(String(find("wf1-confirm-countdown", "span").children[0]), /^\d+s 后自动应用$/);
+  }
+  // 点「应用」：乐观收起 + 回传 approve 与版本/canvasId（vm realm 对象不 deepEqual，逐字段）
+  confirmCalls.findLast((c) => c.tag === "button" && c.children[0] === "应用").props.onClick();
+  assert.equal(decisions.length, 1);
+  assert.equal(decisions[0].type, "wf1-patch-confirm");
+  assert.equal(decisions[0].canvasId, "cv_1");
+  assert.equal(decisions[0].version, 7);
+  assert.equal(decisions[0].approve, true);
+  render();
+  assert.equal(find("wf1-confirm-bar", "div"), undefined, "裁决后确认条收起");
+  // 再挂起一批，点「放弃」
+  confirmClient.__test.setPatchConfirmState({
+    state: "pending", canvasId: "cv_1", version: 8, summary: "删除 1 个节点",
+    deadline: Date.now() + 30000,
+  });
+  render();
+  confirmCalls.findLast((c) => c.tag === "button" && c.children[0] === "放弃").props.onClick();
+  assert.equal(decisions[1].version, 8);
+  assert.equal(decisions[1].approve, false);
+  // App 推送 applied/applied 之外的终态：同样不渲染
+  confirmClient.__test.setPatchConfirmState({ state: "discarded", version: 8 });
+  render();
+  assert.equal(find("wf1-confirm-bar", "div"), undefined);
 }
 
 console.log("canvasui client tests: passed");

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
     "test:variables": "node src/variables.test.mjs && node src/global-variables.test.mjs && node src/json-response.test.mjs && node src/api-base.test.mjs && node src/trial-request.test.mjs && node src/variable-scope.test.mjs && node src/run-event-routing.test.mjs && node src/workflow-serialization.test.mjs && node src/doc-wall-data.test.mjs && node src/live-run-adopt.test.mjs",
     "test:results": "node src/result-adapter.test.mjs && node src/markdown-compat.test.mjs",
     "test:scripts": "node src/script-parameters.test.mjs",
-    "test:ui": "node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs && node src/notify-node.test.mjs && node src/agent-default-label.test.mjs && node src/workflow-transfer-ui.test.mjs && node src/run-switcher.test.mjs && node src/schedule-center.test.mjs && node src/node-detail-polling.test.mjs"
+    "test:ui": "node src/patch-confirm.test.mjs && node src/toolbar-responsive.test.mjs && node src/resume-workflow.test.mjs && node src/notify-node.test.mjs && node src/agent-default-label.test.mjs && node src/workflow-transfer-ui.test.mjs && node src/run-switcher.test.mjs && node src/schedule-center.test.mjs && node src/node-detail-polling.test.mjs"
   },
   "dependencies": {
     "@codemirror/autocomplete": "^6.20.3",

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -11,6 +11,7 @@ import {
   useReactFlow,
 } from '@xyflow/react';
 import { apiUrl, setApiSessionId } from './api.js';
+import { isModifyClassPatch, summarizePendingOps, PATCH_CONFIRM_TIMEOUT_MS } from './patch-confirm.js';
 import {
   normalizeWorkflowDocument,
   serializeGraph,
@@ -122,6 +123,9 @@ export default function App() {
   nodesRef.current = nodes;
   const assistantOpsRef = useRef(null); // SSE assistant-patch → applyAssistantOps 桥（定义在后段）
   const assistantGraphRef = useRef(null); // 漏失 patch 时用服务端权威完整图恢复
+  const pendingConfirmRef = useRef(null); // #105 修改类补丁挂起确认（定义在后段 resolve）
+  const resolvePendingConfirmRef = useRef(null);
+  const notifyPatchConfirmRef = useRef(null);
   const assistantVersionRef = useRef(0);
   const openWorkflowRef = useRef(null); // SSE assistant-open-workflow → openWorkflow 桥（定义在后段）
   const dirtyRef = useRef(dirty); // 脏草稿守卫：AI 请求切换前先静默保存，避免丢未存改动
@@ -538,10 +542,36 @@ export default function App() {
       const version = Number(p.version) || 0;
       if (version && version <= assistantVersionRef.current) return;
       if (version && version !== assistantVersionRef.current + 1 && p.graph) {
+        // 版本跳变：服务端权威整图恢复（含挂起批次，确认作废——已随整图落地），
+        // 确认条同步收起
+        if (pendingConfirmRef.current) {
+          const superseded = pendingConfirmRef.current;
+          clearTimeout(superseded.timer);
+          pendingConfirmRef.current = null;
+          notifyPatchConfirmRef.current?.('applied', superseded.version, 'superseded');
+        }
         assistantGraphRef.current?.(p.graph, version, true);
         return;
       }
-      assistantOpsRef.current?.(p.patch || [], version);
+      const ops = p.patch || [];
+      // #105 修改类补丁（删节点/改已有节点）先挂起确认再落图；服务端状态已先行，
+      // 挂起只挡前端落图，放弃时以旧图回写覆盖。搭建类直接落图不变。
+      if (version && isModifyClassPatch(ops)) {
+        clearTimeout(pendingConfirmRef.current?.timer);
+        const deadline = Date.now() + PATCH_CONFIRM_TIMEOUT_MS;
+        pendingConfirmRef.current = {
+          ops, version, deadline, resolved: false, workflowId: currentWfIdRef.current || null,
+          timer: setTimeout(() => resolvePendingConfirmRef.current?.(true, 'auto'), PATCH_CONFIRM_TIMEOUT_MS),
+        };
+        try {
+          window.parent.postMessage({
+            type: 'wf1-patch-confirm-state', state: 'pending', canvasId: canvasIdRef.current,
+            version, deadline, summary: summarizePendingOps(ops, nodesRef.current),
+          }, window.location.origin);
+        } catch { /* 宿主无确认条（独立窗口画布）→ 30s 自动应用 */ }
+        return;
+      }
+      assistantOpsRef.current?.(ops, version);
     });
     es.addEventListener('assistant-open-workflow', (e) => {
       // AI 请求把本画布切到指定工作流（workflow_open）：复用 openWorkflow 既有加载路径。
@@ -1406,6 +1436,14 @@ export default function App() {
   // 让对话侧 canvas_* 工具同步指向最新工作流。此前依赖 reportCanvasState 身份变化触发
   // 嵌入 effect 重跑——是隐式耦合，调整任意一侧 hook 依赖都会无声断掉。
   useEffect(() => {
+    // 挂起期间切到别的工作流：旧批次不落到新图上，作废收尾（服务端已先行，
+    // 重开该工作流时随整图恢复落地；确认条同步收起）
+    const pending = pendingConfirmRef.current;
+    if (pending && !pending.resolved && (pending.workflowId || null) !== (currentWfIdRef.current || null)) {
+      clearTimeout(pending.timer);
+      pendingConfirmRef.current = null;
+      notifyPatchConfirmRef.current?.('applied', pending.version, 'superseded');
+    }
     reportCanvasStateRef.current?.(true);
   }, [currentWf?.id]);
 
@@ -1458,6 +1496,39 @@ export default function App() {
   }, [setNodes, setEdges, snapshot, markDirty, toast, fitView, reportCanvasState]);
   assistantOpsRef.current = applyAssistantOps;
 
+  // #105 挂起批次裁决：approve → 正常落图；放弃 → 前端不落图，认领版本后把旧图
+  // 回写画布状态并立即静默保存（覆盖服务端已持久化的补丁图，Cmd+Z 基线也回到旧图）
+  const notifyPatchConfirm = (state, version, via) => {
+    try {
+      window.parent.postMessage({ type: 'wf1-patch-confirm-state', state, version, via, canvasId: canvasIdRef.current }, window.location.origin);
+    } catch { /* 独立窗口画布无确认条 */ }
+  };
+  const resolvePendingConfirm = useCallback((approve, via = 'user') => {
+    const pending = pendingConfirmRef.current;
+    if (!pending || pending.resolved) return;
+    pending.resolved = true;
+    clearTimeout(pending.timer);
+    pendingConfirmRef.current = null;
+    if (approve) {
+      applyAssistantOps(pending.ops, pending.version);
+      notifyPatchConfirm('applied', pending.version, via);
+      return;
+    }
+    assistantVersionRef.current = Math.max(assistantVersionRef.current, pending.version);
+    markDirty();
+    Promise.resolve(saveRef.current?.({ silent: true })).catch(() => {});
+    reportCanvasState(true);
+    toast('已放弃 AI 本批修改', 'warn', 3000);
+    notifyPatchConfirm('discarded', pending.version, via);
+  }, [applyAssistantOps, markDirty, reportCanvasState, toast]);
+  resolvePendingConfirmRef.current = resolvePendingConfirm;
+  notifyPatchConfirmRef.current = notifyPatchConfirm;
+  // 卸载：只停掉计时器。服务端状态已先行，重开后经 bind/整图恢复自然落地，
+  // 无需（也无法）在已卸载组件上落图。
+  useEffect(() => () => {
+    clearTimeout(pendingConfirmRef.current?.timer);
+  }, []);
+
   // 宿主 postMessage：wf1-session（官方 UI 会话绑定）→ 绑定 + 拿 persona；
   // wf1-theme（官方 UI 主题切换）→ 画布跟随切换 data-theme
   useEffect(() => {
@@ -1485,6 +1556,13 @@ export default function App() {
             setView('canvas');
           } catch { toast('打开画布：定位运行失败', 'error'); }
         })();
+      }
+      if (d.type === 'wf1-patch-confirm' && d.canvasId === canvasIdRef.current) {
+        // 确认条（宿主 canvasui）回传裁决：只认严格匹配的挂起版本
+        const pending = pendingConfirmRef.current;
+        if (pending && !pending.resolved && Number(d.version) === pending.version) {
+          resolvePendingConfirmRef.current?.(Boolean(d.approve));
+        }
       }
       if (d.type === 'wf1-session' && d.sessionId) {
         hostSessionRef.current = d.sessionId;

--- a/web/src/patch-confirm.js
+++ b/web/src/patch-confirm.js
@@ -1,0 +1,33 @@
+// #105 修改类补丁应用前确认：性质判定与摘要（纯函数，App.jsx 与单测共用）。
+// 「修改类」= 批内含 deleteNode 或 updateNode（renameNode 服务端归一为 updateNode）；
+// 搭建类（新增为主）保持直接落图。
+export const isModifyClassPatch = (ops) => (ops || []).some(
+  (op) => op?.op === 'deleteNode' || op?.op === 'updateNode',
+);
+
+// 摘要文案：删除带节点名（点名最危险的操作），其余计类别数。
+// nodes 是落图前的画布节点（React Flow 形状），用于 id→label。
+export const summarizePendingOps = (ops, nodes) => {
+  const labels = new Map((nodes || []).map((n) => [n.id, n.data?.label || n.id]));
+  const deleted = [];
+  const updated = new Set();
+  let added = 0;
+  let connected = 0;
+  let deletedEdges = 0;
+  for (const op of ops || []) {
+    if (op?.op === 'deleteNode') deleted.push(labels.get(op.id) || op.id);
+    else if (op?.op === 'updateNode') updated.add(labels.get(op.id) || op.id);
+    else if (op?.op === 'addNode') added += 1;
+    else if (op?.op === 'connect') connected += 1;
+    else if (op?.op === 'deleteEdge') deletedEdges += 1;
+  }
+  const parts = [];
+  if (deleted.length) parts.push(`删除 ${deleted.length} 个节点（${deleted.join('、')}）`);
+  if (updated.size) parts.push(`修改 ${updated.size} 个节点`);
+  if (added) parts.push(`新增 ${added} 个节点`);
+  if (connected) parts.push(`新增 ${connected} 条连线`);
+  if (deletedEdges) parts.push(`删除 ${deletedEdges} 条连线`);
+  return parts.join('、') || '无变更';
+};
+
+export const PATCH_CONFIRM_TIMEOUT_MS = 30000;

--- a/web/src/patch-confirm.test.mjs
+++ b/web/src/patch-confirm.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import { isModifyClassPatch, summarizePendingOps, PATCH_CONFIRM_TIMEOUT_MS } from './patch-confirm.js';
+
+// 判定：deleteNode/updateNode → 修改类；纯新增/连线 → 搭建类
+assert.equal(isModifyClassPatch([{ op: 'addNode' }, { op: 'connect' }]), false);
+assert.equal(isModifyClassPatch([{ op: 'addNode' }, { op: 'updateNode', id: 'a', data: {} }]), true);
+assert.equal(isModifyClassPatch([{ op: 'deleteNode', id: 'a' }]), true);
+assert.equal(isModifyClassPatch(null), false);
+assert.equal(isModifyClassPatch([]), false);
+
+// 摘要：删除带节点名、各类别计数、连本文案
+const nodes = [
+  { id: 'n1', data: { label: '工单输出' } },
+  { id: 'n2', data: {} }, // 无 label 回退 id
+  { id: 'n3', data: { label: '分类智能体' } },
+];
+const summary = summarizePendingOps(
+  [
+    { op: 'deleteNode', id: 'n1' },
+    { op: 'updateNode', id: 'n3', data: { prompt: 'x' } },
+    { op: 'updateNode', id: 'n3', data: { model: 'y' } }, // 同节点两次修改计 1
+    { op: 'addNode', id: 'n9' },
+    { op: 'connect', id: 'e1' },
+  ],
+  nodes,
+);
+assert.equal(summary, '删除 1 个节点（工单输出）、修改 1 个节点、新增 1 个节点、新增 1 条连线');
+
+assert.equal(summarizePendingOps([], nodes), '无变更');
+assert.equal(summarizePendingOps([{ op: 'deleteNode', id: 'ghost' }], nodes), '删除 1 个节点（ghost）');
+assert.equal(summarizePendingOps([{ op: 'deleteEdge', id: 'e2' }], nodes), '删除 1 条连线');
+
+assert.equal(PATCH_CONFIRM_TIMEOUT_MS, 30000);
+console.log('patch-confirm tests: passed');


### PR DESCRIPTION
## 背景（#105）

现在 AI 的 ops 经服务端校验后直接落图（SSE assistant-patch），好在有 Cmd+Z 整批撤销。但「修改现有图」类操作直接生效缺乏安全感，删节点/改连线这类动作错了要靠用户自己发现。

## 方案

**判定与摘要**（`web/src/patch-confirm.js` 纯函数，新增单测）：
- 修改类 = 批内含 `deleteNode` 或 `updateNode`（renameNode 服务端归一为 updateNode）；搭建类（新增为主）不弹确认，行为与现状一致
- 摘要：「删除 1 个节点（工单输出）、修改 2 个节点、新增 1 条连线」，删除类点名节点 label

**画布侧**（`App.jsx`，确认权威）：
- assistant-patch 命中修改类 → 挂起不落图，30s 无操作自动应用（计时器权威在此）
- postMessage 推送 pending/applied/discarded 给宿主确认条；`wf1-patch-confirm` 回传裁决，只认严格匹配的挂起版本
- **放弃**：前端不落图，认领版本后把旧图回写 canvas-state 并立即静默保存——服务端 cv 与持久化工作流都回到旧图，Cmd+Z 基线一致
- 版本跳变整图恢复/切换工作流：挂起批次作废收尾（superseded），绝不落到别的工作流图上
- 卸载只停计时器（服务端状态已先行，重开经 bind 整图恢复自然落地）

**宿主侧**（`canvasui PatchConfirmBar`，`conversation.input.dock`）：
- 输入框上方常驻确认条：摘要 + 应用/放弃 + 可见倒计时；裁决乐观收起
- 无 dock slot 的老宿主静默跳过；独立窗口画布无确认条 → 30s 自动应用兜底

SSE 协议与服务端零改动，确认逻辑全部在前端。

## 验证

- `patch-confirm.test.mjs`：判定矩阵 + 摘要文案（同名合并计数、无 label 回退 id、空批次）
- canvasui 单测（有状态 shim）：无挂起不渲染 → 挂起渲染摘要/双按钮/倒计时 → 点应用回传 approve+version+canvasId → 收起 → 放弃路径 → 终态不渲染
- 全量单测（web 15 套）+ build-web 双构建 + canvasui bundle --check 全过
- 真实浏览器点验（官方 UI 聊天里让 AI 删节点）留待人工：需 LLM 产生修改类补丁

## 合并顺序

栈式分支：#141（103）→ #142（104）→ 本 PR。**先合 #141，再合 #142，最后本 PR**（rebase 已对齐，本 PR diff 已只含本主题）。

Closes #105