### PR TITLE
feat(canvasui): 结果卡片可点击后续动作 suggestion（#107）

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -180,6 +180,10 @@ window.__ModuleLoader__.load({
         ".wf1-card-toggle{flex:none;display:inline-flex;align-items:center;padding:2px 10px;border-radius:999px;border:1px solid var(--dsw-alias-border-l2);color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;cursor:pointer;transition:background-color 100ms ease;}",
         ".wf1-card-toggle:hover{background:var(--dsw-alias-interactive-bg-hover-solid);}",
         ".wf1-card-toggle:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
+        ".wf1-card-suggest{display:flex;flex-wrap:wrap;gap:6px;}",
+        ".wf1-card-suggest-btn{padding:2px 10px;border-radius:999px;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-base);color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;cursor:pointer;transition:border-color 100ms ease,color 100ms ease;}",
+        ".wf1-card-suggest-btn:hover{border-color:var(--dsw-alias-border-l2);color:var(--dsw-alias-label-primary);}",
+        ".wf1-card-suggest-btn:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
         ".wf1-card-detail{display:flex;flex-direction:column;gap:2px;max-height:72px;overflow-y:auto;border-radius:8px;padding:6px 10px;background:color-mix(in srgb,var(--dsw-alias-border-l1) 18%,transparent);}",
         ".wf1-card-detail-line{color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;white-space:pre-wrap;word-break:break-word;}",
         ".wf1-card-detail[data-error] .wf1-card-detail-line{color:var(--dsw-alias-state-error-primary);}",
@@ -584,6 +588,7 @@ window.__ModuleLoader__.load({
           props.action || null,
           react.createElement("span", { className: "wf1-card-open" }, "打开画布 ↗"),
         ),
+        props.footer || null,
       );
     }
 
@@ -800,6 +805,13 @@ window.__ModuleLoader__.load({
         action: stopAction,
         // 点击定位到卡片正在跟踪的 run（续跑换 run 后也指向最新）
         target: { runId: trackedRunId },
+        // #107 suggestion：成功/失败终态给下一步指令（≤3 个，点击只填入）；
+        // 「导出 ZIP」无后端能力支撑不做
+        footer: dot === "success"
+          ? cardSuggestRow(["查看上次运行的文稿", "再跑一次", "把运行结果存到工作目录"])
+          : dot === "error" && run.status !== "waiting"
+            ? cardSuggestRow(["再跑一次", "基于这次结果继续改"])
+            : null,
       });
     }
 
@@ -877,6 +889,10 @@ window.__ModuleLoader__.load({
         thumbnail: null,
         action: toggle,
         detail: detail,
+        // #107 suggestion：已应用（含告警）态的下一步指令；运行中/被拒不显示
+        footer: settled && ok
+          ? cardSuggestRow(["撤销刚才那批修改", "运行这个工作流", "保存为工作流"])
+          : null,
       });
     }
 
@@ -944,6 +960,38 @@ window.__ModuleLoader__.load({
         null
       );
     }
+    // 填入输入框不发送（#107 suggestion 按钮 / #101 示例条共用）：
+    // 按钮文案即可直接发送的指令，用户确认后 Enter
+    function fillComposer(text) {
+      var editable = findComposerInput();
+      if (!editable) return false;
+      editable.focus();
+      try {
+        document.execCommand("selectAll");
+        document.execCommand("insertText", false, text);
+        return true;
+      } catch (e) { /* 输入框形态变化时静默，用户仍可手动输入 */ }
+      return false;
+    }
+    // 卡片尾部 suggestion 按钮组（#107）：点击只填入不发送；文案=可直接发送的指令
+    function cardSuggestRow(labels) {
+      return react.createElement(
+        "div",
+        { className: "wf1-card-suggest" },
+        labels.map(function (label) {
+          return react.createElement(
+            "button",
+            {
+              key: label,
+              type: "button",
+              className: "wf1-card-suggest-btn",
+              onClick: function (e) { e.stopPropagation(); fillComposer(label); },
+            },
+            label,
+          );
+        }),
+      );
+    }
     function WorkflowExampleBar(props) {
       var visible =
         props.input && (props.input.draft === "" || props.input.draft == null) &&
@@ -952,13 +1000,7 @@ window.__ModuleLoader__.load({
       var prompts = examplePromptsFor(wfBoundState === true);
       var fill = function (text, ev) {
         ev.preventDefault();
-        var editable = findComposerInput();
-        if (!editable) return;
-        editable.focus();
-        try {
-          document.execCommand("selectAll");
-          document.execCommand("insertText", false, text);
-        } catch (e) { /* 输入框形态变化时静默，用户仍可手动输入 */ }
+        fillComposer(text);
       };
       return react.createElement(
         "div",
@@ -2276,6 +2318,8 @@ window.__ModuleLoader__.load({
       GraphPatchCard: GraphPatchCard,
       PatchConfirmBar: PatchConfirmBar,
       setPatchConfirmState: setPatchConfirmState,
+      cardSuggestRow: cardSuggestRow,
+      fillComposer: fillComposer,
       WorkflowExampleBar: WorkflowExampleBar,
       examplePromptsFor: examplePromptsFor,
       setWfBoundState: function (v) { wfBoundState = v; },

--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -973,19 +973,25 @@ window.__ModuleLoader__.load({
       } catch (e) { /* 输入框形态变化时静默，用户仍可手动输入 */ }
       return false;
     }
-    // 卡片尾部 suggestion 按钮组（#107）：点击只填入不发送；文案=可直接发送的指令
+    // 卡片尾部 suggestion 按钮组（#107）：点击只填入不发送；文案=可直接发送的指令。
+    // 卡片根是 <button> 不能嵌套交互元素，与停止动作同款 span[role=button] 承载
     function cardSuggestRow(labels) {
       return react.createElement(
         "div",
         { className: "wf1-card-suggest" },
         labels.map(function (label) {
           return react.createElement(
-            "button",
+            "span",
             {
               key: label,
-              type: "button",
               className: "wf1-card-suggest-btn",
+              role: "button",
+              tabIndex: 0,
               onClick: function (e) { e.stopPropagation(); fillComposer(label); },
+              onKeyDown: function (e) {
+                if (e.key !== "Enter" && e.key !== " ") return;
+                e.stopPropagation(); e.preventDefault(); fillComposer(label);
+              },
             },
             label,
           );

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -921,7 +921,7 @@ for (const [body, expected] of [
     assert.equal(String(find("wf1-card-meta", "span").children[0]), "已取消");
     const row = find("wf1-card-suggest", "div");
     assert.ok(row, "失败终态应渲染 suggestion");
-    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "button");
+    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "span");
     assert.deepEqual(Array.from(btns, (b) => String(b.children[0])), ["再跑一次", "基于这次结果继续改"]);
   }
 
@@ -932,7 +932,7 @@ for (const [body, expected] of [
   render();
   {
     const row = find("wf1-card-suggest", "div");
-    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "button");
+    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "span");
     assert.deepEqual(Array.from(btns, (b) => String(b.children[0])), ["查看上次运行的文稿", "再跑一次", "把运行结果存到工作目录"]);
   }
 }
@@ -1134,7 +1134,7 @@ for (const [body, expected] of [
   {
     const row = cardCalls.findLast((c) => c.tag === "div" && c.props?.className === "wf1-card-suggest");
     assert.ok(row, "应渲染 suggestion 行");
-    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "button");
+    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "span");
     assert.equal(btns.length, 2);
     assert.equal(btns[0].children[0], "查看上次运行的文稿");
     assert.equal(btns[1].children[0], "再跑一次");
@@ -1145,7 +1145,7 @@ for (const [body, expected] of [
   {
     cardCalls.length = 0;
     cardClient.__test.cardSuggestRow(["再跑一次"]);
-    const btn = cardCalls.findLast((c) => c.tag === "button" && c.children[0] === "再跑一次");
+    const btn = cardCalls.findLast((c) => c.tag === "span" && c.children[0] === "再跑一次");
     let stopped = false;
     btn.props.onClick({ stopPropagation() { stopped = true; } });
     assert.equal(stopped, true, "点击不触发整卡打开");
@@ -1166,7 +1166,7 @@ for (const [body, expected] of [
   {
     const row = cardCalls.findLast((c) => c.tag === "div" && c.props?.className === "wf1-card-suggest");
     assert.ok(row, "已应用态应渲染 suggestion");
-    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "button");
+    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "span");
     assert.deepEqual(Array.from(btns, (b) => String(b.children[0])), ["撤销刚才那批修改", "运行这个工作流", "保存为工作流"]);
   }
   cardCalls.length = 0;

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -386,9 +386,14 @@ const cardContext = {
     head: { appendChild() {} },
     createElement() { return {}; },
     getElementById() { return null; },
+    // #107 suggestion 点击填入：模拟宿主 composer 输入框
+    querySelector() { return composerFake; },
+    execCommand(cmd, show, text) { composerLog.push({ cmd, text }); },
   },
   console,
 };
+const composerFake = { focus() {} };
+const composerLog = [];
 vm.runInNewContext(bundle, cardContext, {
   filename: "dsh-ccpg-canvasui/src/client.js",
 });
@@ -904,9 +909,9 @@ for (const [body, expected] of [
     assert.match(String(find("wf1-card-meta", "span").children[0]), /停止中/);
   }
 
-  // 轮询到已取消：停止按钮消失，卡片转取消态
+  // 轮询到已取消：停止按钮消失，卡片转取消态；失败终态给下一步 suggestion
   detailRun = canceledRun;
-  intervals.splice(0).forEach((fn) => fn());
+  intervals.forEach((fn) => fn());
   await tick();
   render();
   {
@@ -914,6 +919,21 @@ for (const [body, expected] of [
     const dot = find("wf1-card-dot", "span");
     assert.equal(dot.props["data-s"], "error");
     assert.equal(String(find("wf1-card-meta", "span").children[0]), "已取消");
+    const row = find("wf1-card-suggest", "div");
+    assert.ok(row, "失败终态应渲染 suggestion");
+    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "button");
+    assert.deepEqual(Array.from(btns, (b) => String(b.children[0])), ["再跑一次", "基于这次结果继续改"]);
+  }
+
+  // 成功终态：3 个下一步指令（查看文稿/再跑一次/存到工作目录）
+  detailRun = { ...runningRun, status: "success", nodeStates: { n1: { status: "success" } } };
+  intervals.forEach((fn) => fn());
+  await tick();
+  render();
+  {
+    const row = find("wf1-card-suggest", "div");
+    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "button");
+    assert.deepEqual(Array.from(btns, (b) => String(b.children[0])), ["查看上次运行的文稿", "再跑一次", "把运行结果存到工作目录"]);
   }
 }
 
@@ -1104,6 +1124,61 @@ for (const [body, expected] of [
   confirmClient.__test.setPatchConfirmState({ state: "discarded", version: 8 });
   render();
   assert.equal(find("wf1-confirm-bar", "div"), undefined);
+}
+
+// ---- suggestion 按钮组（#107）：卡片尾部指令按钮，点击填入输入框不发送 ----
+{
+  // 纯渲染：cardSuggestRow 生成按钮组，文案保留原文
+  cardCalls.length = 0;
+  cardClient.__test.cardSuggestRow(["查看上次运行的文稿", "再跑一次"]);
+  {
+    const row = cardCalls.findLast((c) => c.tag === "div" && c.props?.className === "wf1-card-suggest");
+    assert.ok(row, "应渲染 suggestion 行");
+    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "button");
+    assert.equal(btns.length, 2);
+    assert.equal(btns[0].children[0], "查看上次运行的文稿");
+    assert.equal(btns[1].children[0], "再跑一次");
+  }
+
+  // 点击：selectAll + insertText 填入，不自动发送
+  composerLog.length = 0;
+  {
+    cardCalls.length = 0;
+    cardClient.__test.cardSuggestRow(["再跑一次"]);
+    const btn = cardCalls.findLast((c) => c.tag === "button" && c.children[0] === "再跑一次");
+    let stopped = false;
+    btn.props.onClick({ stopPropagation() { stopped = true; } });
+    assert.equal(stopped, true, "点击不触发整卡打开");
+    assert.deepEqual(composerLog.map((x) => x.cmd), ["selectAll", "insertText"], "填入应 selectAll+insertText");
+    assert.equal(composerLog[1].text, "再跑一次");
+  }
+
+  // GraphPatchCard 已应用态：尾部 3 按钮；被拒不渲染
+  cardCalls.length = 0;
+  cardClient.__test.GraphPatchCard({
+    block: {
+      kind: "tool-result",
+      isError: false,
+      call: { name: "canvas_graph_patch", argsRaw: JSON.stringify({ ops: [{ op: "addNode" }] }) },
+      content: [{ type: "text", text: "已应用 1 个操作到画布。\nlint: 通过" }],
+    },
+  });
+  {
+    const row = cardCalls.findLast((c) => c.tag === "div" && c.props?.className === "wf1-card-suggest");
+    assert.ok(row, "已应用态应渲染 suggestion");
+    const btns = (Array.isArray(row.children[0]) ? row.children[0] : row.children).filter((c) => c.tag === "button");
+    assert.deepEqual(Array.from(btns, (b) => String(b.children[0])), ["撤销刚才那批修改", "运行这个工作流", "保存为工作流"]);
+  }
+  cardCalls.length = 0;
+  cardClient.__test.GraphPatchCard({
+    block: {
+      kind: "tool-result",
+      isError: true,
+      call: { name: "canvas_graph_patch", argsRaw: JSON.stringify({ ops: [{ op: "bogus" }] }) },
+      content: [{ type: "text", text: "整批拒绝（未做任何修改）" }],
+    },
+  });
+  assert.equal(cardCalls.findLast((c) => c.tag === "div" && c.props?.className === "wf1-card-suggest"), undefined, "被拒不渲染 suggestion");
 }
 
 console.log("canvasui client tests: passed");


### PR DESCRIPTION
## 背景（#107）

运行完成/改图完成后，常见下一步（看文稿、再跑一次、存结果）都要用户重新组织一句话。

## 方案

卡片尾部（骨架新增 footer 槽位）追加 suggestion 按钮，点击即填入输入框不自动发送，按钮文案=可直接发送的指令：

- **运行卡成功态**：查看上次运行的文稿 / 再跑一次 / 把运行结果存到工作目录（保存有 artifact-save 能力支撑）
- **运行卡失败/取消终态**：再跑一次 / 基于这次结果继续改
- **建图卡已应用态**：撤销刚才那批修改 / 运行这个工作流 / 保存为工作流
- 运行中/被拒不显示；每卡 ≤3 个
- 「导出 ZIP」spec 列了但无后端能力支撑，不做（按钮文案必须是真的可发送指令）
- fillComposer 提为共用（#101 示例条复用同机制）

## 验证

- cardSuggestRow 渲染 + 点击 selectAll/insertText 填入 + stopPropagation 断言
- GraphPatchCard 已应用/被拒两态 wiring；RunCard 成功/取消终态 wiring（复用 #103 状态流测试链）
- 全量单测 + bundle --check 一致

Closes #107