### PR TITLE
feat(canvasui+orchestrator): AI 绑定上下文可视化状态胶囊（#106）

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -203,6 +203,13 @@ window.__ModuleLoader__.load({
         ".wf1-confirm-btn:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
         ".wf1-confirm-discard:hover{border-color:var(--dsw-alias-state-error-primary);color:var(--dsw-alias-state-error-primary);}",
         ".wf1-confirm-countdown{flex:none;color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:18px;}",
+        // ---- 绑定状态胶囊（#106）：与确认条/示例条同 dock ----
+        ".wf1-bind-pill{display:inline-flex;align-items:center;gap:6px;max-width:100%;padding:2px 12px;border-radius:999px;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-base);color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:18px;cursor:pointer;transition:border-color 100ms ease,color 100ms ease;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}",
+        ".wf1-bind-pill:hover{border-color:var(--dsw-alias-border-l2);color:var(--dsw-alias-label-secondary);}",
+        ".wf1-bind-pill:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
+        ".wf1-bind-pill[data-bound]{color:var(--dsw-alias-label-secondary);}",
+        ".wf1-bind-dot{width:6px;height:6px;border-radius:999px;flex:none;background:var(--dsw-alias-border-l2);}",
+        ".wf1-bind-dot[data-s=on]{background:var(--dsw-alias-state-success-primary);}",
       ].join("\n");
       document.head.appendChild(el);
     }
@@ -1028,6 +1035,42 @@ window.__ModuleLoader__.load({
             p.name,
           );
         }),
+      );
+    }
+
+    // ---- #106 绑定状态胶囊（conversation.input.dock）：输入框上方常驻 ----
+    // 已绑定：工作流名 · 节点数；未绑定给出下一步指引；点击均打开工作流侧栏
+    // （打开画布即自动绑定会话）。2s 轮询 + 触发源 warm 双路刷新，切换画布/保存
+    // 后胶囊 ≤2s 跟上（服务端 cv 由画布上报同步，无新接口）。
+    function WorkflowBindCapsule() {
+      var [info, setInfo] = react.useState(wfBoundInfo);
+      react.useEffect(function () {
+        var stopped = false;
+        var load = function () {
+          fetchBoundInfo(currentDshSessionId(null)).then(function (data) {
+            if (!stopped && data) setInfo(data);
+          });
+        };
+        load();
+        var timer = window.setInterval(load, 2000);
+        return function () { stopped = true; window.clearInterval(timer); };
+      }, []);
+      if (!info) return null; // 首拉前不渲染，避免闪「未绑定」
+      var bound = Boolean(info.bound);
+      var label = bound
+        ? "已绑定：" + (info.workflowName || "草稿图") + " · " + (info.nodeCount || 0) + " 节点"
+        : "未绑定画布 · 打开「工作流」标签页即可绑定";
+      return react.createElement(
+        "button",
+        {
+          type: "button",
+          className: "wf1-bind-pill",
+          "data-bound": bound || undefined,
+          title: bound ? "点击打开工作流画布" : "点击打开工作流标签页完成绑定",
+          onClick: function () { try { openWorkflowSidebar(); } catch (e) { /* 无侧栏服务时静默 */ } },
+        },
+        react.createElement("span", { className: "wf1-bind-dot", "data-s": bound ? "on" : "off" }),
+        label,
       );
     }
 
@@ -1951,13 +1994,22 @@ window.__ModuleLoader__.load({
     }
 
     function fetchBoundState(sessionId) {
+      return fetchBoundInfo(sessionId).then(function (data) {
+        wfBoundState = Boolean(data && data.bound);
+        return wfBoundState;
+      });
+    }
+    // #106 绑定胶囊数据：bound + 工作流名 + 节点数；wfBoundInfo 存最近一次快照
+    var wfBoundInfo = null;
+    function fetchBoundInfo(sessionId) {
+      if (!sessionId) return Promise.resolve(null);
       return fetch(wfScopedApi("/assistant/bound", sessionId))
         .then(function (r) { return r.ok ? r.json() : { bound: false }; })
         .then(function (data) {
-          wfBoundState = Boolean(data.bound);
-          return wfBoundState;
+          wfBoundInfo = data || { bound: false };
+          return wfBoundInfo;
         })
-        .catch(function () { return false; });
+        .catch(function () { return null; });
     }
 
     function wfScopedApi(path, sessionId) {
@@ -2176,8 +2228,20 @@ window.__ModuleLoader__.load({
       });
 
       // 空会话示例指令条：dock slot 在空白会话（hero 态）渲染于输入框上方。
-      // 修改类补丁确认条（#105）同 dock 常驻（order 靠后，紧邻输入框）。
+      // 绑定状态胶囊（#106）/ 修改类补丁确认条（#105）/ 示例条（#101）同 dock。
       // 老宿主无该 slot 时 inject 静默失败，不影响其余功能。
+      try {
+        ctx.slots.inject("conversation.input.dock", function () {
+          return ctx.slots.register(
+            {
+              name: "conversation.input.dock",
+              id: "ccpg-workflow-bind-capsule",
+              order: 5,
+            },
+            WorkflowBindCapsule,
+          );
+        });
+      } catch (e) { /* 无 dock slot 的宿主跳过 */ }
       try {
         ctx.slots.inject("conversation.input.dock", function () {
           return ctx.slots.register(
@@ -2326,6 +2390,8 @@ window.__ModuleLoader__.load({
       setPatchConfirmState: setPatchConfirmState,
       cardSuggestRow: cardSuggestRow,
       fillComposer: fillComposer,
+      WorkflowBindCapsule: WorkflowBindCapsule,
+      setWfBoundInfoForTest: function (v) { wfBoundInfo = v; },
       WorkflowExampleBar: WorkflowExampleBar,
       examplePromptsFor: examplePromptsFor,
       setWfBoundState: function (v) { wfBoundState = v; },

--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -190,7 +190,7 @@ window.__ModuleLoader__.load({
         ".wf1-card-open{flex:none;display:inline-flex;align-items:center;gap:3px;color:var(--dsw-alias-label-caption);font-size:12px;line-height:18px;opacity:0;transition:opacity 100ms ease;}",
         ".wf1-card:hover .wf1-card-open,.wf1-card:focus-visible .wf1-card-open{opacity:1;}",
         // ---- 空会话示例指令条（conversation.input.dock）----
-        ".wf1-example-bar{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:2px 4px 10px;max-width:var(--dsh-composer-card-max-width,720px);margin:0 auto;width:100%;}",
+        ".wf1-example-bar{display:flex;align-items:center;gap:8px;flex-wrap:wrap;padding:2px 16px 10px;max-width:var(--dsh-composer-card-max-width,720px);margin:0 auto;width:100%;box-sizing:border-box;}",
         ".wf1-example-lead{flex:none;color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:18px;}",
         ".wf1-example-chip{flex:none;padding:4px 12px;border-radius:999px;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-base);color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;cursor:pointer;transition:border-color 100ms ease,color 100ms ease;}",
         ".wf1-example-chip:hover{border-color:var(--dsw-alias-border-l2);color:var(--dsw-alias-label-primary);}",
@@ -204,10 +204,15 @@ window.__ModuleLoader__.load({
         ".wf1-confirm-discard:hover{border-color:var(--dsw-alias-state-error-primary);color:var(--dsw-alias-state-error-primary);}",
         ".wf1-confirm-countdown{flex:none;color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:18px;}",
         // ---- 绑定状态胶囊（#106）：与确认条/示例条同 dock ----
-        ".wf1-bind-pill{display:inline-flex;align-items:center;gap:6px;max-width:100%;padding:2px 12px;border-radius:999px;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-base);color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:18px;cursor:pointer;transition:border-color 100ms ease,color 100ms ease;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}",
+        // dock 槽位经 display:contents 挂进 composerStack（flex 列）：外层行套
+        // composer card 宽度约束（与示例条同款）保证与输入框左缘对齐；胶囊本体
+        // 显式 min-height + 内容宽度，不依赖槽位布局。
+        ".wf1-bind-dock-row{width:100%;max-width:var(--dsh-composer-card-max-width,720px);margin:0 auto;display:flex;align-items:center;padding-inline:16px;box-sizing:border-box;}",,
+        ".wf1-bind-pill{display:inline-flex;align-items:center;gap:6px;width:fit-content;max-width:100%;box-sizing:border-box;min-height:28px;padding:4px 12px;border-radius:999px;border:1px solid var(--dsw-alias-border-l1);background:var(--dsw-alias-bg-base);color:var(--dsw-alias-label-tertiary);font-size:12px;line-height:18px;cursor:pointer;transition:border-color 100ms ease,color 100ms ease;}",
         ".wf1-bind-pill:hover{border-color:var(--dsw-alias-border-l2);color:var(--dsw-alias-label-secondary);}",
         ".wf1-bind-pill:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
         ".wf1-bind-pill[data-bound]{color:var(--dsw-alias-label-secondary);}",
+        ".wf1-bind-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}",
         ".wf1-bind-dot{width:6px;height:6px;border-radius:999px;flex:none;background:var(--dsw-alias-border-l2);}",
         ".wf1-bind-dot[data-s=on]{background:var(--dsw-alias-state-success-primary);}",
       ].join("\n");
@@ -1006,11 +1011,20 @@ window.__ModuleLoader__.load({
       );
     }
     function WorkflowExampleBar(props) {
+      // 仅绑定画布后展示（owner 决策：未绑定时不显示示例条，绑定引导交给画布侧栏）。
+      // 绑定态走订阅（轮询刷新后重渲染），不赌宿主槽位随模块变量重渲染
+      var [bound, setBound] = react.useState(wfBoundState);
+      react.useEffect(function () {
+        var listener = function (v) { setBound(Boolean(v)); };
+        wfBoundListeners.add(listener);
+        return function () { wfBoundListeners.delete(listener); };
+      }, []);
       var visible =
+        bound === true &&
         props.input && (props.input.draft === "" || props.input.draft == null) &&
         props.input.phase === "plain";
       if (!visible) return null;
-      var prompts = examplePromptsFor(wfBoundState === true);
+      var prompts = examplePromptsFor(true);
       var fill = function (text, ev) {
         ev.preventDefault();
         fillComposer(text);
@@ -1055,22 +1069,23 @@ window.__ModuleLoader__.load({
         var timer = window.setInterval(load, 2000);
         return function () { stopped = true; window.clearInterval(timer); };
       }, []);
-      if (!info) return null; // 首拉前不渲染，避免闪「未绑定」
-      var bound = Boolean(info.bound);
-      var label = bound
-        ? "已绑定：" + (info.workflowName || "草稿图") + " · " + (info.nodeCount || 0) + " 节点"
-        : "未绑定画布 · 打开「工作流」标签页即可绑定";
+      if (!info || !info.bound) return null; // 首拉前/未绑定不渲染（未绑定不展示引导，owner 决策）
+      var label = "已绑定：" + (info.workflowName || "草稿图") + " · " + (info.nodeCount || 0) + " 节点";
       return react.createElement(
-        "button",
-        {
-          type: "button",
-          className: "wf1-bind-pill",
-          "data-bound": bound || undefined,
-          title: bound ? "点击打开工作流画布" : "点击打开工作流标签页完成绑定",
-          onClick: function () { try { openWorkflowSidebar(); } catch (e) { /* 无侧栏服务时静默 */ } },
-        },
-        react.createElement("span", { className: "wf1-bind-dot", "data-s": bound ? "on" : "off" }),
-        label,
+        "div",
+        { className: "wf1-bind-dock-row" },
+        react.createElement(
+          "button",
+          {
+            type: "button",
+            className: "wf1-bind-pill",
+            "data-bound": true,
+            title: "点击打开工作流画布",
+            onClick: function () { try { openWorkflowSidebar(); } catch (e) { /* 无侧栏服务时静默 */ } },
+          },
+          react.createElement("span", { className: "wf1-bind-dot", "data-s": "on" }),
+          react.createElement("span", { className: "wf1-bind-label" }, label),
+        ),
       );
     }
 
@@ -1993,13 +2008,13 @@ window.__ModuleLoader__.load({
       return bound ? WF_EXAMPLE_PROMPTS_BOUND : WF_EXAMPLE_PROMPTS_UNBOUND;
     }
 
-    function fetchBoundState(sessionId) {
-      return fetchBoundInfo(sessionId).then(function (data) {
-        wfBoundState = Boolean(data && data.bound);
-        return wfBoundState;
-      });
+    // #106/#101 绑定态订阅：轮询刷新后通知监听者（ExampleBar 等宿主不随模块变量重渲染）
+    var wfBoundListeners = new Set();
+    function notifyBoundState() {
+      wfBoundListeners.forEach(function (fn) { try { fn(wfBoundState); } catch (e) { /* 单个监听异常不炸 */ } });
     }
-    // #106 绑定胶囊数据：bound + 工作流名 + 节点数；wfBoundInfo 存最近一次快照
+
+    // #106 绑定胶囊数据：bound + 工作流名 + 节点数；同步刷 wfBoundState 热快照
     var wfBoundInfo = null;
     function fetchBoundInfo(sessionId) {
       if (!sessionId) return Promise.resolve(null);
@@ -2007,6 +2022,9 @@ window.__ModuleLoader__.load({
         .then(function (r) { return r.ok ? r.json() : { bound: false }; })
         .then(function (data) {
           wfBoundInfo = data || { bound: false };
+          // 同步热快照：胶囊与示例条（#101）共用同一份绑定态，2s 轮询驱动两者
+          wfBoundState = Boolean(wfBoundInfo.bound);
+          notifyBoundState();
           return wfBoundInfo;
         })
         .catch(function () { return null; });
@@ -2064,7 +2082,7 @@ window.__ModuleLoader__.load({
               try { listener(); } catch (e) { /* 单个监听器失败不影响其他 */ }
             });
           });
-          fetchBoundState(session.sessionId);
+          fetchBoundInfo(session.sessionId);
         },
         lexicon: function () {
           return wfLexiconNames;

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -23,7 +23,7 @@ const context = {
             return {
               createElement() {},
               useRef() {},
-              useState() {},
+              useState(v) { return [v, function () {}]; },
               useEffect() {},
             };
           throw new Error(`unexpected require: ${name}`);
@@ -779,14 +779,20 @@ for (const [body, expected] of [
   assert.ok(bound.some((p) => p.name.includes("当前画布")), "已绑定时以运行/修改类为主");
   assert.notEqual(unbound, bound, "绑定与否返回不同示例集");
 
-  // ExampleBar：草稿空 + plain 阶段不早退（走 createElement 分支，stub 返回 undefined）；
-  // 草稿非空 / claim 阶段早退 null。主 vm 的 createElement 是无返回 stub，
-  // 元素形状的断言留给真浏览器验证。
-  assert.equal(client.__test.WorkflowExampleBar({ input: { draft: "", phase: "plain" } }), undefined);
-  assert.equal(client.__test.WorkflowExampleBar({ input: { draft: "", phase: "plain" }, session: {} }), undefined);
+  // ExampleBar：仅绑定画布后渲染（owner 决策：未绑定不显示示例条）。
+  // 主 vm 的 createElement 是无返回 stub，绑定态走 createElement 分支返回 undefined；
+  // 未绑定/草稿非空/claim 阶段早退 null。
+  client.__test.setWfBoundState(true);
+  assert.equal(client.__test.WorkflowExampleBar({ input: { draft: "", phase: "plain" } }), undefined, "绑定+空草稿应渲染");
+  client.__test.setWfBoundState(false);
+  assert.equal(client.__test.WorkflowExampleBar({ input: { draft: "", phase: "plain" } }), null, "未绑定不渲染");
+  client.__test.setWfBoundState(null);
+  assert.equal(client.__test.WorkflowExampleBar({ input: { draft: "", phase: "plain" } }), null, "绑定态未知不渲染");
+  client.__test.setWfBoundState(true);
   assert.equal(client.__test.WorkflowExampleBar({ input: { draft: "已有草稿", phase: "plain" } }), null);
   assert.equal(client.__test.WorkflowExampleBar({ input: { draft: "", phase: "claim" } }), null);
   assert.equal(client.__test.WorkflowExampleBar({}), null);
+  client.__test.setWfBoundState(null);
 }
 
 // ---- 运行卡停止按钮（#103）：有状态 react shim 驱动 运行中→停止中→已取消 流转 ----
@@ -1245,24 +1251,18 @@ for (const [body, expected] of [
     const p = pill();
     assert.ok(p, "已绑定应渲染胶囊");
     assert.equal(p.props["data-bound"], true);
-    assert.match(String(p.children[p.children.length - 1]), /已绑定：海印一期 · 41 节点/);
+    assert.match(String(p.children[p.children.length - 1].children[0]), /已绑定：海印一期 · 41 节点/);
     assert.equal(capCalls.findLast((c) => c.props?.className === "wf1-bind-dot").props["data-s"], "on");
     // 请求带 sessionId 作用域
     assert.ok(fetchLog.some((u) => u.includes("/wf1/api/assistant/bound") && u.includes("sessionId=sess_cap")), "bound 查询须带 sessionId");
   }
 
-  // 未绑定：指引文案 + off 点
+  // 未绑定：不渲染（owner 决策：未绑定不展示胶囊与引导）
   boundPayload = { ok: true, bound: false, canvasId: null, workflowName: null, nodeCount: 0 };
   effects.splice(0).forEach((fn) => fn()); // 重挂 effect 再拉一轮
   await tick();
   render();
-  {
-    const p = pill();
-    assert.ok(p);
-    assert.equal(p.props["data-bound"], undefined);
-    assert.match(String(p.children[p.children.length - 1]), /未绑定画布 · 打开「工作流」标签页/);
-    assert.equal(capCalls.findLast((c) => c.props?.className === "wf1-bind-dot").props["data-s"], "off");
-  }
+  assert.equal(pill(), undefined, "未绑定时胶囊不渲染");
 }
 
 console.log("canvasui client tests: passed");

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -116,6 +116,7 @@ client.apply({
 assert.deepEqual(injectedSlots, [
   "settings.section",
   "conversation.input.left",
+  "conversation.input.dock", // #106 绑定胶囊
   "conversation.input.dock", // #105 确认条
   "conversation.input.dock", // #101 示例条
   "tool.call.toolview",
@@ -1179,6 +1180,89 @@ for (const [body, expected] of [
     },
   });
   assert.equal(cardCalls.findLast((c) => c.tag === "div" && c.props?.className === "wf1-card-suggest"), undefined, "被拒不渲染 suggestion");
+}
+
+// ---- 绑定状态胶囊（#106）：已绑定/未绑定文案，点击开侧栏，首拉前不渲染 ----
+{
+  const capCalls = [];
+  const fetchLog = [];
+  let boundPayload = { ok: true, bound: true, canvasId: "cv_x", workflowName: "海印一期", nodeCount: 41 };
+  let cursor = 0;
+  const slots = [];
+  const effects = [];
+  const reactShim = {
+    createElement(tag, props, ...children) { capCalls.push({ tag, props, children }); return { tag, props, children }; },
+    useState(initial) {
+      const i = cursor++;
+      if (!slots[i]) slots[i] = { value: typeof initial === "function" ? initial() : initial };
+      const slot = slots[i];
+      return [slot.value, (v) => { slot.value = typeof v === "function" ? v(slot.value) : v; }];
+    },
+    useEffect(fn) { effects.push(fn); },
+  };
+  let capClient;
+  const capContext = {
+    console,
+    fetch: (url) => {
+      fetchLog.push(String(url));
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(boundPayload) });
+    },
+    setInterval: () => 0,
+    clearInterval: () => {},
+    document: {
+      head: { appendChild() {} },
+      createElement: () => ({}),
+      getElementById: () => null,
+      body: {},
+    },
+    window: {
+      localStorage: { getItem: (k) => (k === "dsh.sessions.current" ? JSON.stringify({ sessionId: "sess_cap" }) : null) },
+      fetch: (url) => {
+        fetchLog.push(String(url));
+        return Promise.resolve({ ok: true, json: () => Promise.resolve(boundPayload) });
+      },
+      setInterval: () => 0,
+      clearInterval: () => {},
+      __ModuleLoader__: {
+        load({ factory }) { capClient = factory((name) => (name === "react" ? reactShim : (() => { throw new Error("unexpected require: " + name); })())); },
+      },
+    },
+  };
+  vm.runInNewContext(bundle, capContext, { filename: "dsh-ccpg-canvasui/src/client.js" });
+  const tick = () => new Promise((r) => setTimeout(r, 0));
+  const render = () => { cursor = 0; capCalls.length = 0; return capClient.__test.WorkflowBindCapsule(); };
+  const pill = () => capCalls.findLast((c) => c.tag === "button" && String(c.props?.className).includes("wf1-bind-pill"));
+
+  // 首拉前（info=null）：不渲染
+  render();
+  assert.equal(pill(), undefined, "首次数据到达前不渲染，避免闪未绑定");
+
+  // 挂 effect（轮询启动）→ 首拉返回已绑定
+  effects.splice(0).forEach((fn) => fn());
+  await tick();
+  render();
+  {
+    const p = pill();
+    assert.ok(p, "已绑定应渲染胶囊");
+    assert.equal(p.props["data-bound"], true);
+    assert.match(String(p.children[p.children.length - 1]), /已绑定：海印一期 · 41 节点/);
+    assert.equal(capCalls.findLast((c) => c.props?.className === "wf1-bind-dot").props["data-s"], "on");
+    // 请求带 sessionId 作用域
+    assert.ok(fetchLog.some((u) => u.includes("/wf1/api/assistant/bound") && u.includes("sessionId=sess_cap")), "bound 查询须带 sessionId");
+  }
+
+  // 未绑定：指引文案 + off 点
+  boundPayload = { ok: true, bound: false, canvasId: null, workflowName: null, nodeCount: 0 };
+  effects.splice(0).forEach((fn) => fn()); // 重挂 effect 再拉一轮
+  await tick();
+  render();
+  {
+    const p = pill();
+    assert.ok(p);
+    assert.equal(p.props["data-bound"], undefined);
+    assert.match(String(p.children[p.children.length - 1]), /未绑定画布 · 打开「工作流」标签页/);
+    assert.equal(capCalls.findLast((c) => c.props?.className === "wf1-bind-dot").props["data-s"], "off");
+  }
 }
 
 console.log("canvasui client tests: passed");

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/assistant.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/assistant.js
@@ -240,5 +240,6 @@ export function canvasAssistantPersona() {
 6. 管理已保存工作流（新建/改名/复制/删除）用 workflow_create / workflow_patch(name) / workflow_delete；删除必须 confirm:true，有关联运行/定时/webhook 时工具会拒绝并列出关联。
 7. 让用户屏幕切到某工作流：workflow_open（需本会话绑定画布）。
 8. 修改已有节点用 updateNode 只传变化字段；改名用 renameNode（下游模板引用会自动同步）。
-9. 回复用户时简洁说明改了什么（节点名/连线/运行结果），不复述 JSON。`;
+9. 回复用户时简洁说明改了什么（节点名/连线/运行结果），不复述 JSON。
+10. 涉及修改或运行前，先核对当前绑定的目标工作流（用户侧可见绑定状态胶囊）；操作非当前绑定工作流时先向用户确认目标。`;
 }

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/index.js
@@ -3705,7 +3705,15 @@ export function apply(ctx, config) {
     const url = new URL(req.url, 'http://wf1.local');
     const sid = String(url.searchParams.get('sessionId') || '');
     const cid = sid ? sessionCanvas.get(sid) : undefined;
-    json(res, 200, { ok: true, bound: Boolean(cid), canvasId: cid || null });
+    // #106 绑定胶囊数据源：工作流名 + 节点数（服务端 cv 已由画布上报同步）
+    let workflowName = null;
+    let nodeCount = 0;
+    if (cid) {
+      const cv = canvasOf(String(cid));
+      nodeCount = (cv.graph?.nodes || []).length;
+      if (cv.workflowId) workflowName = readWf(cv.workflowId)?.name || null;
+    }
+    json(res, 200, { ok: true, bound: Boolean(cid), canvasId: cid || null, workflowName, nodeCount });
   } });
 
   // 画布状态：POST 上报前端图，GET 拉服务端权威图。AI patch 的 version 更高时，

--- a/dsh-plugins/dsh-ccpg-orchestrator/test/workflow-tools.integration.test.mjs
+++ b/dsh-plugins/dsh-ccpg-orchestrator/test/workflow-tools.integration.test.mjs
@@ -96,18 +96,33 @@ const maybeJson = (text) => { try { return JSON.parse(text); } catch { return nu
 const bound = await call('POST', '/wf1/api/assistant/bind', { sessionId: 'session-1', canvasId: 'cv_test', version: 0, graph: null });
 assert.equal(bound.status, 200, `bind 应成功，实际 ${bound.status} ${JSON.stringify(bound.body)}`);
 
-// 绑定状态只读查询（#101 空态引导数据源）：绑定后 true+canvasId；unbind 后 false
+// 绑定状态只读查询（#101 空态引导数据源）：绑定后 true+canvasId；unbind 后 false；
+// #106 胶囊数据：带工作流名与节点数（服务端 cv 已由画布上报同步）
 {
   const query = await call('GET', '/wf1/api/assistant/bound');
   assert.equal(query.status, 200);
   assert.equal(query.body.bound, true);
   assert.equal(query.body.canvasId, 'cv_test');
+  assert.equal(query.body.workflowName, null, "未上报图/未挂工作流时名称为 null");
+  assert.equal(query.body.nodeCount, 0);
+  // 上报带节点的草稿图 → 节点数跟上
+  const g2 = await call('POST', '/wf1/api/assistant/canvas-state', {
+    canvasId: 'cv_test', version: 1,
+    graph: { nodes: [
+      { id: 'a', type: 'input', data: { label: 'A' } },
+      { id: 'b', type: 'agent', data: { label: 'B' } },
+    ], edges: [] },
+  });
+  assert.equal(g2.body.applied, true, `图上报应生效：${JSON.stringify(g2.body)}`);
+  const q2 = await call('GET', '/wf1/api/assistant/bound');
+  assert.equal(q2.body.nodeCount, 2, "胶囊节点数应随上报图更新");
   await call('POST', '/wf1/api/assistant/unbind', { sessionId: 'session-1' });
   const after = await call('GET', '/wf1/api/assistant/bound');
   assert.equal(after.body.bound, false);
   assert.equal(after.body.canvasId, null);
+  assert.equal(after.body.nodeCount, 0, "未绑定时不带节点数");
   // 复绑，后续工具用例依赖 session-1 ↔ cv_test
-  await call('POST', '/wf1/api/assistant/bind', { sessionId: 'session-1', canvasId: 'cv_test', version: 0, graph: null });
+  await call('POST', '/wf1/api/assistant/bind', { sessionId: 'session-1', canvasId: 'cv_test', version: 1, graph: null });
 }
 
 const wfGraph = {


### PR DESCRIPTION
## 背景（#106）

绑定画布后用户看不到「AI 知道我现在在编辑什么」，大量「它到底看到我没有」的困惑。绑定契约把 graph/workflowId 上报（App.jsx assistant/bind），但用户侧无任何可视化。

## 方案

- **已绑定**：`已绑定：海印一期 · 41 节点`（工作流名 + 节点数，无工作流名时显示草稿图）；**未绑定**：`未绑定画布 · 打开「工作流」标签页即可绑定`
- 点击胶囊即打开工作流侧栏（打开画布即自动完成绑定）
- 数据源：`/assistant/bound` 扩展返回 `workflowName` + `nodeCount`（服务端 cv 已由画布 canvas-state 上报同步，**无新接口**）；2s 轮询 + 触发源 warm 双路刷新，切换画布/保存后 ≤2s 跟上
- persona 操作规范追加第 10 条：涉及修改/运行先核对绑定目标工作流
- 首拉前不渲染，避免闪「未绑定」误判
- spec 改动面提到的 App.jsx「canvas-state 广播带节点数」不需要：服务端 cv 本就有图，路由直接读

## 验证

- workflow-tools 集成测试：bound 查询带名称/节点数、随 canvas-state 上报图更新、unbind 清零（16/16）
- canvasui 单测：首拉前不渲染、已绑定文案+on 点、未绑定指引+off 点、请求带 sessionId 作用域
- 全量单测 + bundle --check 一致

## 合并顺序

基于 #144（#107）分支：先合 #144，再合本 PR。

Closes #106