### PR TITLE
feat(canvasui+web): 工具卡受限 markdown 渲染与窄屏适配（#110）

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -185,8 +185,10 @@ window.__ModuleLoader__.load({
         ".wf1-card-suggest-btn:hover{border-color:var(--dsw-alias-border-l2);color:var(--dsw-alias-label-primary);}",
         ".wf1-card-suggest-btn:focus-visible{outline:none;box-shadow:0 0 0 2px var(--dsw-alias-border-l3);}",
         ".wf1-card-detail{display:flex;flex-direction:column;gap:2px;max-height:72px;overflow-y:auto;border-radius:8px;padding:6px 10px;background:color-mix(in srgb,var(--dsw-alias-border-l1) 18%,transparent);}",
-        ".wf1-card-detail-line{color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;white-space:pre-wrap;word-break:break-word;}",
-        ".wf1-card-detail[data-error] .wf1-card-detail-line{color:var(--dsw-alias-state-error-primary);}",
+        ".wf1-card-detail p{margin:0;color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;overflow-wrap:break-word;}",
+        ".wf1-card-detail ul{margin:0;padding-left:18px;color:var(--dsw-alias-label-secondary);font-size:12px;line-height:18px;overflow-wrap:break-word;}",
+        ".wf1-card-detail code{font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:11px;padding:0 4px;border-radius:4px;background:color-mix(in srgb,var(--dsw-alias-border-l1) 30%,transparent);}",
+        ".wf1-card-detail[data-error] p,.wf1-card-detail[data-error] ul{color:var(--dsw-alias-state-error-primary);}",
         ".wf1-card-open{flex:none;display:inline-flex;align-items:center;gap:3px;color:var(--dsw-alias-label-caption);font-size:12px;line-height:18px;opacity:0;transition:opacity 100ms ease;}",
         ".wf1-card:hover .wf1-card-open,.wf1-card:focus-visible .wf1-card-open{opacity:1;}",
         // ---- 空会话示例指令条（conversation.input.dock）----
@@ -215,6 +217,8 @@ window.__ModuleLoader__.load({
         ".wf1-bind-label{min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;}",
         ".wf1-bind-dot{width:6px;height:6px;border-radius:999px;flex:none;background:var(--dsw-alias-border-l2);}",
         ".wf1-bind-dot[data-s=on]{background:var(--dsw-alias-state-success-primary);}",
+        // ---- 窄屏（#110）：<520 收窄卡片内距，动作/建议按钮自然换行 ----
+        "@media (max-width:520px){.wf1-card{padding:8px 10px;gap:4px;}.wf1-card-title{max-width:52%;}.wf1-example-bar{padding:2px 2px 8px;}}",
       ].join("\n");
       document.head.appendChild(el);
     }
@@ -887,9 +891,7 @@ window.__ModuleLoader__.load({
       var detail = expanded && hasDetail ? react.createElement(
         "div",
         { className: "wf1-card-detail", "data-error": !ok || undefined },
-        detailLines.map(function (line, index) {
-          return react.createElement("div", { key: index, className: "wf1-card-detail-line" }, line);
-        }),
+        renderCardMarkdown(text),
       ) : null;
 
       return workflowCardShell({
@@ -1131,6 +1133,45 @@ window.__ModuleLoader__.load({
           remaining + "s 后自动应用",
         ),
       );
+    }
+
+    // ---- #110 受限 markdown：只放行 **加粗**、`代码`、- 列表、换行 ----
+    // 直接构造 React 元素（不经 innerHTML），文本节点由 React 转义，无 XSS 面。
+    var CARD_INLINE_RE = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+    function cardInlineNodes(text, keyPrefix) {
+      var out = [];
+      String(text).split(CARD_INLINE_RE).forEach(function (part, i) {
+        if (!part) return;
+        if (/^\*\*[^*]+\*\*$/.test(part)) {
+          out.push(react.createElement("strong", { key: keyPrefix + "b" + i }, part.slice(2, -2)));
+        } else if (/^`[^`]+`$/.test(part)) {
+          out.push(react.createElement("code", { key: keyPrefix + "c" + i }, part.slice(1, -1)));
+        } else {
+          out.push(part);
+        }
+      });
+      return out;
+    }
+    function renderCardMarkdown(text) {
+      var blocks = [];
+      var listItems = [];
+      var seq = 0;
+      var flushList = function () {
+        if (!listItems.length) return;
+        blocks.push(react.createElement("ul", { key: "ul" + seq++ }, listItems));
+        listItems = [];
+      };
+      String(text || "").split("\n").forEach(function (line) {
+        var item = line.match(/^\s*-\s+(.*)$/);
+        if (item) {
+          listItems.push(react.createElement("li", { key: "li" + seq++ }, cardInlineNodes(item[1], "li" + seq)));
+          return;
+        }
+        flushList();
+        if (line.trim()) blocks.push(react.createElement("p", { key: "p" + seq++ }, cardInlineNodes(line, "p" + seq)));
+      });
+      flushList();
+      return blocks;
     }
 
     // ---- 画布半：常驻 iframe（侧栏折叠或切换 tab 时不重载）----
@@ -2410,6 +2451,7 @@ window.__ModuleLoader__.load({
       fillComposer: fillComposer,
       WorkflowBindCapsule: WorkflowBindCapsule,
       setWfBoundInfoForTest: function (v) { wfBoundInfo = v; },
+      renderCardMarkdown: renderCardMarkdown,
       WorkflowExampleBar: WorkflowExampleBar,
       examplePromptsFor: examplePromptsFor,
       setWfBoundState: function (v) { wfBoundState = v; },

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -1019,10 +1019,10 @@ for (const [body, expected] of [
     const detail = find("wf1-card-detail", "div");
     assert.ok(detail, "展开后渲染完整错误列表");
     assert.equal(detail.props["data-error"], true, "被拒态错误行用错误色");
-    // createElement shim 单数组参数不展开，先展平再断言
-    const lines = Array.isArray(detail.children[0]) ? detail.children[0] : detail.children;
-    assert.equal(lines.length, 6, "全部错误行均展示（超 3 条靠滚动）");
-    assert.match(String(lines[2].children[0]), /构成环 —— 修复建议：删掉形成环的那条连线/);
+    // #110 后详情走受限 markdown 渲染：每行一个 <p>；shim 单数组参数不展开，先展平
+    const blocks = Array.isArray(detail.children[0]) ? detail.children[0] : detail.children;
+    assert.equal(blocks.length, 6, "全部错误行均展示（超 3 条靠滚动）");
+    assert.match(JSON.stringify(blocks[2]), /构成环 —— 修复建议：删掉形成环的那条连线/);
     const toggle = find("wf1-card-toggle", "span");
     assert.equal(toggle.children[0], "收起");
     assert.equal(toggle.props["aria-expanded"], true);
@@ -1263,6 +1263,43 @@ for (const [body, expected] of [
   await tick();
   render();
   assert.equal(pill(), undefined, "未绑定时胶囊不渲染");
+}
+
+// ---- 受限 markdown 渲染（#110）：加粗/代码/列表，纯元素构造无 XSS 面 ----
+{
+  const flat = (nodes) => {
+    const out = [];
+    const walk = (n) => {
+      if (Array.isArray(n)) { n.forEach(walk); return; }
+      if (n && typeof n === "object" && n.tag) { walk(n.children); out.push(n); return; }
+      if (n && typeof n === "object" && n.props) { walk(n.children); return; }
+      if (typeof n === "string") out.push(n);
+    };
+    walk(nodes);
+    return out;
+  };
+  const blocks = cardClient.__test.renderCardMarkdown("第一段 **加粗** 与 `code here`\n- 列表项 **强**\n- 第二项\n尾段");
+  {
+    const tags = flat(blocks).map((n) => n.tag);
+    assert.ok(tags.includes("p") && tags.includes("ul") && tags.includes("li"), "应有段落/列表结构");
+    const strongs = flat(blocks).filter((n) => n.tag === "strong");
+    assert.equal(strongs.length, 2);
+    assert.equal(strongs[0].children[0], "加粗");
+    const codes = flat(blocks).filter((n) => n.tag === "code");
+    assert.equal(codes.length, 1);
+    assert.equal(codes[0].children[0], "code here");
+  }
+  // XSS：恶意标签只是文本，不存在对应元素类型
+  {
+    const evil = cardClient.__test.renderCardMarkdown("<script>alert(1)</script> **<img onerror=x>** `- <b>`");
+    const tags = flat(evil).map((n) => n.tag);
+    assert.equal(tags.includes("script"), false, "script 不成为元素");
+    assert.equal(tags.includes("img"), false);
+    assert.ok(evil.some((b) => JSON.stringify(b).includes("<script>alert")), "原文保留为文本");
+  }
+  // 空文本/纯文本回退
+  assert.equal(cardClient.__test.renderCardMarkdown("").length, 0);
+  assert.equal(cardClient.__test.renderCardMarkdown("平平无奇").length, 1);
 }
 
 console.log("canvasui client tests: passed");

--- a/dsh-plugins/dsh-ccpg-orchestrator/lib/assistant.js
+++ b/dsh-plugins/dsh-ccpg-orchestrator/lib/assistant.js
@@ -240,6 +240,6 @@ export function canvasAssistantPersona() {
 6. 管理已保存工作流（新建/改名/复制/删除）用 workflow_create / workflow_patch(name) / workflow_delete；删除必须 confirm:true，有关联运行/定时/webhook 时工具会拒绝并列出关联。
 7. 让用户屏幕切到某工作流：workflow_open（需本会话绑定画布）。
 8. 修改已有节点用 updateNode 只传变化字段；改名用 renameNode（下游模板引用会自动同步）。
-9. 回复用户时简洁说明改了什么（节点名/连线/运行结果），不复述 JSON。
+9. 回复用户时简洁说明改了什么（节点名/连线/运行结果），不复述 JSON；需要多步说明时可用 **加粗**、- 列表、\`代码\` 三种受限语法（工具卡支持渲染，其余 markdown 语法不要用）。
 10. 涉及修改或运行前，先核对当前绑定的目标工作流（用户侧可见绑定状态胶囊）；操作非当前绑定工作流时先向用户确认目标。`;
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -292,11 +292,16 @@ body {
   .view-tab { padding: 5px 8px; }
   .tb-add-btn { width: 34px; height: 30px; padding: 0; justify-content: center; }
   .tb-add-label, .tb-add-btn .tb-caret { display: none; }
+  /* #110 窄屏：弹窗近全屏，历史列表不再横向滚动 */
+  .modal-box { min-width: 0; width: calc(100vw - 24px); max-width: none; max-height: calc(100dvh - 24px); }
+  .rh-list { min-width: 0; }
 }
 @media (max-width: 360px) {
   .view-tab { padding-inline: 6px; }
   .tb-run-btn { width: 34px; padding: 6px; justify-content: center; }
   .tb-run-label { display: none; }
+  /* #110 极窄：文稿墙卡片满宽，不横向滚动 */
+  .docwall-card, .docwall-card-image, .docwall-card-video { width: 100%; }
 }
 
 /* 双击/右键画布弹出的浮动加节点菜单 */


### PR DESCRIPTION
## 背景（#110）

1. WF1 工具卡纯文本，多步说明读起来费劲 → 受限 markdown 渲染
2. 工具卡与画布在 <520px 视口挤压严重 → 补断点

## 方案

**受限 markdown**（不引 md 库）：
- `renderCardMarkdown`（~50 行）只放行 `**加粗**`、`\`代码\``、`- 列表`、换行；直接构造 React 元素，不经 innerHTML，文本节点由 React 转义——**无 XSS 面**
- 建图卡详情区（#104 展开态）接入；persona 第 9 条追加语法许可（只用这三种）
- 单测：段落/列表/加粗/代码结构 + `<script>`/`<img onerror>` 注入只是文本

**窄屏**：
- canvasui `<520px`：卡片内距收窄（卡片本就 100% 宽）
- web `<520px`：弹窗近全屏（`modal-box`/`rh-list` 的 `min-width` 放开），历史抽屉不再横向滚动
- web `<360px`：文稿墙卡片满宽；文稿墙 `<720px` 侧栏 chip 条已存在（优于 spec 设想的抽屉）

## 验证

- markdown 渲染器纯函数单测（含 XSS 用例）+ #104 详情测试适配块结构
- 全量单测 + build-web 双构建 + bundle --check 一致
- 视觉断言（360px 不横向滚动）留待真机

## 合并顺序

基于 #145（#106）：先合 #144（107）→ #145（106）→ 本 PR。

Closes #110