### PR TITLE
feat(web+canvasui): 画布内轻量指令条（#109）

### DIFF
--- a/dsh-plugins/dsh-ccpg-canvasui/src/client.js
+++ b/dsh-plugins/dsh-ccpg-canvasui/src/client.js
@@ -244,6 +244,41 @@ window.__ModuleLoader__.load({
       return false;
     }
 
+    // ---- #109 指令注入官方聊天：能力探测 + 双层降级 ----
+    // 首选官方 conversation.send(text)（同一聊天会话的 AI 执行，无第二写者）；
+    // 服务不在场/scope 不命中/发送抛错 → fillComposer 填入宿主输入框（#107 同机制）。
+    // 回执 wf1-command-result 发回画布 toast。
+    var hostCtxRef = null;
+    var conversationSvcCache;
+    function deliverCommandToChat(text) {
+      var ack = function (ok, via) {
+        postToCanvas({ type: "wf1-command-result", ok: ok, via: via, text: text });
+      };
+      var fallbackFill = function () {
+        fillComposer(text);
+        ack(false, "filled");
+      };
+      if (!conversationSvcCache) {
+        // 不缓存阴性结果：conversation 服务可能晚于本插件注册，
+        // 每次重探（一次属性访问，代价可忽略），晚到也能命中
+        try {
+          // tracker 优先（属性访问重绑 scope），不存在再退 get（可能抛错）
+          conversationSvcCache = hostCtxRef && hostCtxRef.conversation || null;
+          if (!conversationSvcCache && hostCtxRef) {
+            try { conversationSvcCache = hostCtxRef.get("conversation") || null; } catch (e0) { /* 未声明依赖 */ }
+          }
+        } catch (e) { /* 宿主无该服务 */ }
+      }
+      if (conversationSvcCache && typeof conversationSvcCache.send === "function") {
+        Promise.resolve()
+          .then(function () { return conversationSvcCache.send(text); })
+          .then(function () { ack(true, "chat"); })
+          .catch(function () { fallbackFill(); });
+        return;
+      }
+      fallbackFill();
+    }
+
     function openWorkflowSidebar() {
       if (!betterSidebarRef.svc) return false;
       betterSidebarRef.svc.openTab({
@@ -2358,12 +2393,22 @@ window.__ModuleLoader__.load({
 
     function apply(ctx) {
       ensureStyle();
-      // 画布 iframe（App）推送的确认状态（#105）：pending/applied/discarded → 确认条
+      hostCtxRef = ctx;
+      // 画布 iframe（App）推送的确认状态（#105）与指令注入（#109）：pending/applied/discarded → 确认条
       window.addEventListener("message", function (ev) {
         if (ev.origin !== window.location.origin) return;
         var d = ev.data;
-        if (d && typeof d === "object" && d.type === "wf1-patch-confirm-state") {
+        if (!d || typeof d !== "object") return;
+        if (d.type === "wf1-patch-confirm-state") {
           setPatchConfirmState(d);
+        }
+        if (d.type === "wf1-command" && typeof d.text === "string" && d.text.trim()) {
+          // 只接受常驻画布 iframe 的指令：同源页面可能有其他 iframe，
+          // 不校验 source 会把任意同源帧的文本注入聊天
+          var cmdFrame = persistentHost ? persistentHost.querySelector("iframe") : null;
+          if (cmdFrame && ev.source === cmdFrame.contentWindow) {
+            deliverCommandToChat(String(d.text).trim());
+          }
         }
       });
 
@@ -2565,6 +2610,9 @@ window.__ModuleLoader__.load({
       setPatchConfirmState: setPatchConfirmState,
       cardSuggestRow: cardSuggestRow,
       fillComposer: fillComposer,
+      deliverCommandToChat: deliverCommandToChat,
+      setHostCtxForTest: function (v) { hostCtxRef = v; conversationSvcCache = undefined; },
+      setPersistentHostForTest: function (v) { persistentHost = v; },
       WorkflowBindCapsule: WorkflowBindCapsule,
       setWfBoundInfoForTest: function (v) { wfBoundInfo = v; },
       renderCardMarkdown: renderCardMarkdown,

--- a/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
+++ b/dsh-plugins/dsh-ccpg-canvasui/test/client.test.mjs
@@ -1371,4 +1371,103 @@ for (const [body, expected] of [
   assert.match(guideClaim.hint, /工作流标签页/);
 }
 
+// ---- 指令注入降级链（#109）：无 conversation 服务→填输入框+回执；有则直达聊天 ----
+{
+  const cmdCalls = [];
+  const cmdLog = [];
+  let cursor = 0;
+  const slots = [];
+  const reactShim = {
+    createElement(tag, props, ...children) { cmdCalls.push({ tag, props, children }); return { tag, props, children }; },
+    useState(initial) {
+      const i = cursor++;
+      if (!slots[i]) slots[i] = { value: typeof initial === "function" ? initial() : initial };
+      const slot = slots[i];
+      return [slot.value, (v) => { slot.value = typeof v === "function" ? v(slot.value) : v; }];
+    },
+    useEffect(fn) {},
+  };
+  const fakeComposer = { focus() {} };
+  const sentTexts = [];
+  let cmdClient;
+  const cmdContext = {
+    console,
+    fetch: () => Promise.resolve({ ok: true, json: () => Promise.resolve({}) }),
+    setInterval: () => 0,
+    clearInterval: () => {},
+    document: {
+      head: { appendChild() {} },
+      createElement: () => ({}),
+      getElementById: () => null,
+      body: {},
+      querySelector() { return fakeComposer; },
+      execCommand(cmd, show, text) { cmdLog.push({ cmd, text }); },
+    },
+    window: {
+      location: { origin: "https://dsh.local" },
+      localStorage: { getItem: () => null },
+      __ModuleLoader__: {
+        load({ factory }) { cmdClient = factory((name) => (name === "react" ? reactShim : (() => { throw new Error("unexpected require: " + name); })())); },
+      },
+    },
+  };
+  // 模拟常驻 iframe：postToCanvas 的回执落 cmdLog 之外单独记录
+  const acks = [];
+  const fakeFrame = {
+    contentWindow: {
+      postMessage(msg) { acks.push(msg); },
+    },
+  };
+  const fakeHost = { querySelector: () => fakeFrame };
+  vm.runInNewContext(bundle, cmdContext, { filename: "dsh-ccpg-canvasui/src/client.js" });
+  cmdClient.__test.setPersistentHostForTest?.(fakeHost);
+
+  // 场景 1：无 conversation 服务（默认）→ fillComposer 降级 + ack(false,filled)
+  cmdClient.__test.deliverCommandToChat("给工单整理加超时");
+  await new Promise((r) => setTimeout(r, 0));
+  {
+    assert.deepEqual(cmdLog.map((x) => x.cmd), ["selectAll", "insertText"], "降级应填入宿主输入框");
+    assert.equal(cmdLog[1].text, "给工单整理加超时");
+    assert.equal(acks.length, 1);
+    assert.equal(acks[0].type, "wf1-command-result");
+    assert.equal(acks[0].ok, false);
+    assert.equal(acks[0].via, "filled");
+  }
+
+  // 场景 2：conversation.send 可用 → 直达聊天 ack(true,chat)
+  cmdLog.length = 0;
+  acks.length = 0;
+  cmdClient.__test.setHostCtxForTest({
+    conversation: {
+      send(text) { sentTexts.push(text); return Promise.resolve(); },
+    },
+  });
+  cmdClient.__test.deliverCommandToChat("跑一次当前工作流");
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+  {
+    assert.deepEqual(sentTexts, ["跑一次当前工作流"]);
+    assert.equal(acks.length, 1);
+    assert.equal(acks[0].ok, true);
+    assert.equal(acks[0].via, "chat");
+    assert.equal(cmdLog.length, 0, "直达聊天不填输入框");
+  }
+
+  // 场景 3：send 拒绝（scope 不命中）→ 回退填入
+  cmdLog.length = 0;
+  acks.length = 0;
+  cmdClient.__test.setHostCtxForTest({
+    conversation: {
+      send() { return Promise.reject(new Error("scope")); },
+    },
+  });
+  cmdClient.__test.deliverCommandToChat("再试一次");
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+  {
+    assert.equal(cmdLog[1] && cmdLog[1].text, "再试一次", "send 失败回退填入");
+    assert.equal(acks[0].ok, false);
+  }
+}
+
 console.log("canvasui client tests: passed");

--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -1135,6 +1135,23 @@ export default function App() {
     }
   }, [startRunFlow]);
 
+  // #109 指令条：快捷钮纯 API，自由文本经宿主注入官方聊天
+  const sendCmdbarCommand = useCallback((raw) => {
+    const text = String(raw || '').trim();
+    if (!text) return;
+    try {
+      window.parent.postMessage({ type: 'wf1-command', text, canvasId: canvasIdRef.current }, window.location.origin);
+    } catch {
+      toast('发送失败：宿主通道不可用', 'error');
+    }
+  }, [toast]);
+  const showCmdbarStatus = useCallback(() => {
+    const latest = runList[0];
+    toast(latest
+      ? `最近运行：${latest.workflowName || '草稿'} · ${STATUS_CN[latest.status] || latest.status}`
+      : '还没有运行记录', latest?.status === 'error' ? 'error' : 'info');
+  }, [runList, toast]);
+
   const cancelRun = useCallback(async () => {
     const runId = inspectedRunIdRef.current;
     if (!runId) return;
@@ -1563,6 +1580,10 @@ export default function App() {
         if (pending && !pending.resolved && Number(d.version) === pending.version) {
           resolvePendingConfirmRef.current?.(Boolean(d.approve));
         }
+      }
+      if (d.type === 'wf1-command-result' && d.text != null) {
+        // 指令送达回执（#109）：直达聊天成功 / 降级填入宿主输入框
+        toast(d.ok ? `已发送到对话：${d.text}` : '官方会话通道不可用，指令已填入聊天输入框，请切到对话发送', d.ok ? 'success' : 'warn', 3200);
       }
       if (d.type === 'wf1-session' && d.sessionId) {
         hostSessionRef.current = d.sessionId;
@@ -2093,6 +2114,10 @@ export default function App() {
         <PromptModal title={modal.title} initial={modal.initial} placeholder={modal.placeholder} confirmText={modal.confirmText}
           onCancel={() => setModal(null)} onConfirm={modal.onConfirm} />
       )}
+      {/* #109 画布内轻量指令条：快捷钮走纯 API，自由文本经宿主注入官方聊天（能力探测+降级） */}
+      {view === 'canvas' && hostSession.id && (
+        <CanvasCommandBar onRun={run} onStatus={showCmdbarStatus} onSend={sendCmdbarCommand} />
+      )}
     </div>
   );
 
@@ -2183,4 +2208,32 @@ function findFreeSpot(nodes) {
     }
   }
   return { x: 120 + Math.random() * 480, y: 100 + Math.random() * 260 };
+}
+
+// #109 画布内轻量指令条：右下角悬浮；快捷钮走纯 API（运行/最近状态），
+// 自由文本经宿主 conversation 通道注入官方聊天（不可用时宿主会填入输入框降级）。
+function CanvasCommandBar({ onRun, onStatus, onSend }) {
+  const [text, setText] = useState('');
+  const submit = (e) => {
+    e.preventDefault();
+    if (!text.trim()) return;
+    onSend(text);
+    setText('');
+  };
+  return (
+    <div className="wf1-cmdbar" role="toolbar" aria-label="画布快捷指令">
+      <button type="button" className="wf1-cmdbar-btn" onClick={onRun} title="运行当前工作流">▶ 跑一次</button>
+      <button type="button" className="wf1-cmdbar-btn" onClick={onStatus} title="查看最近一次运行状态">⏱ 最近状态</button>
+      <form className="wf1-cmdbar-form" onSubmit={submit}>
+        <input
+          className="wf1-cmdbar-input"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="描述指令（复杂修改会由对话里的 AI 执行）"
+          aria-label="画布指令"
+        />
+        <button type="submit" className="wf1-cmdbar-btn wf1-cmdbar-send" disabled={!text.trim()}>发送</button>
+      </form>
+    </div>
+  );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1710,3 +1710,31 @@ body {
   .vc-list-pane { flex: 0 0 42vh; border-right: 0; border-bottom: 1px solid var(--border); }
   .vc-editor-pane { flex: 0 0 auto; min-height: 54vh; }
 }
+
+/* ============ #109 画布内轻量指令条 ============ */
+.wf1-cmdbar {
+  position: fixed; right: 18px; bottom: 18px; z-index: 400;
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap; justify-content: flex-end;
+  max-width: min(520px, calc(100vw - 36px));
+  padding: 8px 10px; border-radius: 14px;
+  background: var(--bg-panel); border: 1px solid var(--border-strong);
+  box-shadow: var(--shadow-2);
+}
+.wf1-cmdbar-btn {
+  border: 1px solid var(--border); border-radius: 999px; background: var(--bg-raised);
+  color: var(--fg-secondary, var(--fg)); font-size: 12px; padding: 5px 12px;
+  cursor: pointer; white-space: nowrap;
+}
+.wf1-cmdbar-btn:hover:not(:disabled) { border-color: var(--border-strong); }
+.wf1-cmdbar-btn:disabled { opacity: .5; cursor: default; }
+.wf1-cmdbar-send { color: var(--accent, var(--fg)); font-weight: 600; }
+.wf1-cmdbar-form { display: flex; gap: 6px; min-width: 220px; flex: 1; }
+.wf1-cmdbar-input {
+  flex: 1; min-width: 0; border: 1px solid var(--border); border-radius: 10px;
+  background: var(--bg-raised); color: var(--fg); font: inherit; font-size: 12.5px; padding: 5px 10px;
+}
+.wf1-cmdbar-input:focus { outline: none; border-color: var(--accent, var(--border-strong)); }
+@media (max-width: 640px) {
+  .wf1-cmdbar { left: 12px; right: 12px; bottom: 12px; justify-content: stretch; }
+  .wf1-cmdbar-form { min-width: 0; }
+}


### PR DESCRIPTION
## 背景（#109）

用户在画布/文稿视图里没有随手发起指令的入口，切回聊天打断工作流。

## Spike（结论已落 issue 评论）

1. **iframe 调 assistant 路由** ✅ 早已验证（App.jsx 的 bind 即实例）
2. **LLM 轮次通道**：官方 `conversation` 服务有公开 `send(text)`（*Send a prompt into the scoped session*）→ 指令经宿主注入官方聊天，由**同一个聊天会话的 AI 执行**——画布不是第二个写者，无并发写图冲突
3. **插件侧另起 agent 轮次**：违反单一写者模型，明确不做
4. `conversation.send` 插件侧 scope 命中无先例 → 能力探测 + 双层降级

## 实现

**画布侧**（`App.jsx` + styles）：canvas 视图右下角悬浮指令条——
- 快捷钮「▶ 跑一次」（复用 run()）「⏱ 最近状态」（runList toast）：纯 API，不依赖 LLM
- 自由文本：postMessage `wf1-command` 到宿主；回执 `wf1-command-result` → toast（直达/降级两种文案）
- <640px 悬浮条铺满底部

**宿主侧**（`canvasui`）：`deliverCommandToChat` 能力探测——
- `conversation.send(text)` 可用 → 直达聊天（ack ok:true via:chat）
- 服务不在场 / send 抛错（scope 不命中）→ `fillComposer` 填入宿主输入框（#107 同机制）+ ack ok:false via:filled
- 任何宿主形态不炸不丢指令

## 验证

- 单测三场景：无服务降级填入+ack / send 可用直达+不填输入框 / send 拒绝回退填入
- 全量单测 + 双构建 + bundle --check 一致
- conversation.send 真机 scope 命中留待实机点验（降级路径保证可用）

## 合并顺序

基于 #147（#108）栈顶：#144 → #145 → #146 → #147 → 本 PR。

Closes #109